### PR TITLE
refactor: align codex adapter with shared A2A extension contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,14 +46,14 @@ Additional notes:
   closes with `TaskStatusUpdateEvent(final=true)`. For detailed streaming
   contract and event semantics, see `docs/guide.md`.
 - Token usage passthrough: normalized usage/cost stats are exposed at
-  `metadata.codex.usage` (stream final status and non-streaming task metadata).
+  `metadata.shared.usage` (stream final status and non-streaming task metadata).
 - Interrupt callback passthrough: when Codex emits `permission.asked` /
-  `question.asked`, stream status events include `metadata.codex.interrupt`
-  so downstream can reply via JSON-RPC extension methods.
+  `question.asked`, stream status events include `metadata.shared.interrupt`
+  while provider-private raw details remain under `metadata.codex.interrupt`.
 - Re-subscribe after disconnect: `GET /v1/tasks/{task_id}:subscribe`
   (available while the task is not in a terminal state).
 - Session continuation contract: clients can explicitly bind to an existing
-  Codex session via `metadata.codex_session_id`.
+  Codex session via `metadata.shared.session.id`.
 - Codex session query extension (JSON-RPC):
   `codex.sessions.list` / `codex.sessions.messages.list`.
 
@@ -112,8 +112,9 @@ For full configuration, see `docs/guide.md`. Most commonly used options:
 - `CODEX_APP_SERVER_LISTEN`: Codex app-server transport (default: `stdio://`)
 - `CODEX_MODEL`: default model for `thread/start` (default: `gpt-5.1-codex`)
 - `CODEX_MODEL_ID`: optional per-turn model override for `turn/start`
-- `CODEX_DIRECTORY`: default `cwd` (optional). Clients may pass `metadata.directory`
-  only when `A2A_ALLOW_DIRECTORY_OVERRIDE=true` and the path stays inside the allowed workspace.
+- `CODEX_DIRECTORY`: default `cwd` (optional). Clients may pass
+  `metadata.codex.directory` only when `A2A_ALLOW_DIRECTORY_OVERRIDE=true`
+  and the path stays inside the allowed workspace.
 - `CODEX_TIMEOUT_STREAM`: optional timeout for streaming send path.
   Unset means no explicit stream timeout (the turn waits until completion).
 - `A2A_BEARER_TOKEN`: required bearer token for authentication
@@ -130,7 +131,7 @@ Compatibility note:
 
 To continue an existing Codex conversation, pass this metadata key on every invoke request:
 
-- `metadata.codex_session_id`: target Codex session ID (for example
+- `metadata.shared.session.id`: target Codex session ID (for example
   `ses_xxx`)
 
 Server behavior:
@@ -152,7 +153,11 @@ curl -sS http://127.0.0.1:8000/v1/message:send \
       "content": [{"text": "Continue our previous conversation and summarize the last conclusion."}]
     },
     "metadata": {
-      "codex_session_id": "<session_id>"
+      "shared": {
+        "session": {
+          "id": "<session_id>"
+        }
+      }
     }
   }'
 ```
@@ -164,11 +169,12 @@ The service exposes Codex session list/history queries through A2A extension met
 - Auth: same `Authorization: Bearer <token>`
 - Result: `result.items` always contains A2A standard objects
   (Task for session list, Message for history)
+- Shared session metadata is exposed at `metadata.shared.session`
 - Codex raw records are preserved in `metadata.codex.raw`
 - Interrupt callback methods:
-  - `codex.permission.reply`
-  - `codex.question.reply`
-  - `codex.question.reject`
+  - `a2a.interrupt.permission.reply`
+  - `a2a.interrupt.question.reply`
+  - `a2a.interrupt.question.reject`
 
 List sessions (`codex.sessions.list`):
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -63,27 +63,29 @@ Compatibility note:
 - Streaming (`/v1/message:stream`) emits incremental
   `TaskArtifactUpdateEvent` and then
   `TaskStatusUpdateEvent(final=true)`. Stream artifacts carry
-  `artifact.metadata.codex.block_type` with values
+  `artifact.metadata.shared.stream.block_type` with values
   `text` / `reasoning` / `tool_call`. All chunks share one stream
   artifact ID and preserve original timeline via
-  `artifact.metadata.codex.sequence`. Events without
-  `message_id` are dropped. A final snapshot is only emitted when stream
-  chunks did not already produce the same final text.
+  `artifact.metadata.shared.stream.sequence`. Timeline identity fields such as
+  `message_id`, `event_id`, and `source` are emitted under
+  `metadata.shared.stream`. A final snapshot is only emitted when stream chunks
+  did not already produce the same final text.
   Stream routing is schema-first: the service classifies chunks primarily by
   Codex `part.type` (plus `part_id` state) rather than inline text markers.
   `message.part.delta` and `message.part.updated` are merged per `part_id`;
   out-of-order deltas are buffered and replayed when the corresponding
   `part.updated` arrives. Structured `tool` parts are emitted as `tool_call`
   blocks with normalized state payload. Final status event metadata may include
-  normalized token usage at `metadata.codex.usage` with fields like
+  normalized token usage at `metadata.shared.usage` with fields like
   `input_tokens`, `output_tokens`, `total_tokens`, and optional `cost`.
   Interrupt events (`permission.asked` / `question.asked`) are mapped to
   `TaskStatusUpdateEvent(final=false, state=input-required)` with details at
-  `metadata.codex.interrupt` (including `request_id`, event type, and
-  structured payload for downstream callback handling).
+  `metadata.shared.interrupt` (including `request_id`, interrupt type, and
+  shared payload for downstream callback handling). Provider-private raw
+  interrupt payload is preserved under `metadata.codex.interrupt`.
   Non-streaming requests return a `Task` directly.
 - Non-streaming `message:send` responses may include normalized token usage at
-  `Task.metadata.codex.usage` with the same field schema.
+  `Task.metadata.shared.usage` with the same field schema.
 - Requests require `Authorization: Bearer <token>`; otherwise `401` is
   returned. Agent Card endpoints are public.
 - Within one `codex-a2a-serve` instance, all consumers share the same
@@ -95,7 +97,7 @@ Compatibility note:
     via `event_queue`.
   - Failure events include concrete error details with `failed` state.
 - Directory validation and normalization:
-  - Clients can pass `metadata.directory`, but it must stay inside
+  - Clients can pass `metadata.codex.directory`, but it must stay inside
     `${CODEX_DIRECTORY}` (or service runtime root if not configured).
   - All paths are normalized with `realpath` to prevent `..` or symlink
     boundary bypass.
@@ -110,7 +112,7 @@ Compatibility note:
 
 To continue a historical Codex session, include this metadata key in each invoke request:
 
-- `metadata.codex_session_id`: target Codex session ID
+- `metadata.shared.session.id`: target Codex session ID
 
 Server behavior:
 
@@ -131,7 +133,11 @@ curl -sS http://127.0.0.1:8000/v1/message:send \
       "content": [{"text": "Continue the previous session and restate the key conclusion."}]
     },
     "metadata": {
-      "codex_session_id": "<session_id>"
+      "shared": {
+        "session": {
+          "id": "<session_id>"
+        }
+      }
     }
   }'
 ```
@@ -150,8 +156,9 @@ This service exposes Codex session list and message-history queries via A2A JSON
   - `result.items` is always an array of A2A standard objects
   - session list => `Task` with `status.state=completed`
   - message history => `Message`
+  - canonical session metadata is exposed at `metadata.shared.session`
   - raw upstream payload is preserved at `metadata.codex.raw`
-  - session title is available at `metadata.codex.title`
+  - session title is available at `metadata.shared.session.title`
 
 ### Session List (`codex.sessions.list`)
 
@@ -186,17 +193,17 @@ curl -sS http://127.0.0.1:8000/ \
 
 ## Codex Interrupt Callback (A2A Extension)
 
-When stream metadata reports an interrupt request at `metadata.codex.interrupt`,
+When stream metadata reports an interrupt request at `metadata.shared.interrupt`,
 clients can reply through JSON-RPC extension methods:
 
-- `codex.permission.reply`
+- `a2a.interrupt.permission.reply`
   - required: `request_id`
   - required: `reply` (`once` / `always` / `reject`)
   - optional: `message`
-- `codex.question.reply`
+- `a2a.interrupt.question.reply`
   - required: `request_id`
   - required: `answers` (`Array<Array<string>>`)
-- `codex.question.reject`
+- `a2a.interrupt.question.reject`
   - required: `request_id`
 
 Permission reply example:
@@ -208,7 +215,7 @@ curl -sS http://127.0.0.1:8000/ \
   -d '{
     "jsonrpc": "2.0",
     "id": 3,
-    "method": "codex.permission.reply",
+    "method": "a2a.interrupt.permission.reply",
     "params": {
       "request_id": "<request_id>",
       "reply": "once"

--- a/src/codex_a2a_serve/agent.py
+++ b/src/codex_a2a_serve/agent.py
@@ -29,6 +29,7 @@ from a2a.types import (
 )
 
 from .codex_client import OpencodeClient
+from .extension_contracts import SHARED_METADATA_NAMESPACE
 
 logger = logging.getLogger(__name__)
 
@@ -309,10 +310,9 @@ class OpencodeAgentExecutor(AgentExecutor):
 
         streaming_request = self._should_stream(context)
         user_text = context.get_user_input().strip()
-        bound_session_id = _extract_codex_session_id(context)
+        bound_session_id = _extract_shared_session_id(context)
 
         # Directory validation
-        requested_dir = None
         metadata = context.metadata
         if metadata is not None and not isinstance(metadata, Mapping):
             await self._emit_error(
@@ -323,8 +323,7 @@ class OpencodeAgentExecutor(AgentExecutor):
                 streaming_request=streaming_request,
             )
             return
-        if isinstance(metadata, Mapping):
-            requested_dir = metadata.get("directory")
+        requested_dir = _extract_codex_directory(context)
 
         try:
             directory = self._resolve_and_validate_directory(requested_dir)
@@ -467,18 +466,15 @@ class OpencodeAgentExecutor(AgentExecutor):
                             state=TaskState.input_required,
                         ),
                         final=True,
-                        metadata={
-                            "codex": {
-                                "session_id": response.session_id,
+                        metadata=_build_output_metadata(
+                            session_id=response.session_id,
+                            usage=resolved_token_usage,
+                            stream={
                                 "message_id": resolved_message_id,
                                 "event_id": f"{stream_state.event_id_namespace}:status",
-                                **(
-                                    {"usage": resolved_token_usage}
-                                    if resolved_token_usage is not None
-                                    else {}
-                                ),
-                            }
-                        },
+                                "source": "status",
+                            },
+                        ),
                     )
                 )
             else:
@@ -501,17 +497,10 @@ class OpencodeAgentExecutor(AgentExecutor):
                     status=TaskStatus(state=TaskState.input_required),
                     history=history,
                     artifacts=[artifact],
-                    metadata={
-                        "codex": {
-                            "session_id": response.session_id,
-                            "message_id": resolved_message_id,
-                            **(
-                                {"usage": resolved_token_usage}
-                                if resolved_token_usage is not None
-                                else {}
-                            ),
-                        }
-                    },
+                    metadata=_build_output_metadata(
+                        session_id=response.session_id,
+                        usage=resolved_token_usage,
+                    ),
                 )
                 # Attach the assistant message as the current status message.
                 task.status.message = assistant_message
@@ -862,8 +851,8 @@ class OpencodeAgentExecutor(AgentExecutor):
             state: TaskState,
             request_id: str,
             interrupt_type: str,
-            event_type: str,
             details: Mapping[str, Any],
+            codex_private: Mapping[str, Any] | None = None,
         ) -> None:
             sequence = stream_state.next_sequence()
             await event_queue.enqueue_event(
@@ -872,19 +861,23 @@ class OpencodeAgentExecutor(AgentExecutor):
                     context_id=context_id,
                     status=TaskStatus(state=state),
                     final=False,
-                    metadata={
-                        "codex": {
-                            "session_id": session_id,
+                    metadata=_build_output_metadata(
+                        session_id=session_id,
+                        stream={
                             "message_id": stream_state.resolve_message_id(None),
                             "event_id": stream_state.build_event_id(sequence),
-                            "interrupt": {
-                                "request_id": request_id,
-                                "type": interrupt_type,
-                                "event_type": event_type,
-                                "details": dict(details),
-                            },
-                        }
-                    },
+                            "source": "interrupt",
+                            "sequence": sequence,
+                        },
+                        interrupt={
+                            "request_id": request_id,
+                            "type": interrupt_type,
+                            "details": dict(details),
+                        },
+                        codex_private=(
+                            {"interrupt": dict(codex_private)} if codex_private else None
+                        ),
+                    ),
                 )
             )
 
@@ -1050,8 +1043,8 @@ class OpencodeAgentExecutor(AgentExecutor):
                                         state=TaskState.input_required,
                                         request_id=request_id,
                                         interrupt_type=asked["interrupt_type"],
-                                        event_type=event_type,
                                         details=asked["details"],
+                                        codex_private=asked.get("codex_private"),
                                     )
                             resolved = _extract_interrupt_resolved_event(event)
                             if resolved is not None:
@@ -1221,19 +1214,49 @@ def _build_stream_artifact_metadata(
     sequence: int | None = None,
     event_id: str | None = None,
 ) -> dict[str, Any]:
-    codex_meta: dict[str, Any] = {
-        "block_type": block_type,
+    stream_meta: dict[str, Any] = {
+        "block_type": block_type.value,
         "source": source,
     }
     if message_id:
-        codex_meta["message_id"] = message_id
+        stream_meta["message_id"] = message_id
     if role:
-        codex_meta["role"] = role
+        stream_meta["role"] = role
     if sequence is not None:
-        codex_meta["sequence"] = sequence
+        stream_meta["sequence"] = sequence
     if event_id:
-        codex_meta["event_id"] = event_id
-    return {"codex": codex_meta}
+        stream_meta["event_id"] = event_id
+    return {"shared": {"stream": stream_meta}}
+
+
+def _build_output_metadata(
+    *,
+    session_id: str | None = None,
+    session_title: str | None = None,
+    usage: Mapping[str, Any] | None = None,
+    stream: Mapping[str, Any] | None = None,
+    interrupt: Mapping[str, Any] | None = None,
+    codex_private: Mapping[str, Any] | None = None,
+) -> dict[str, Any] | None:
+    metadata: dict[str, Any] = {}
+    shared_meta: dict[str, Any] = {}
+
+    if session_id:
+        session_meta: dict[str, Any] = {"id": session_id}
+        if session_title is not None:
+            session_meta["title"] = session_title
+        shared_meta["session"] = session_meta
+    if usage is not None:
+        shared_meta["usage"] = dict(usage)
+    if stream is not None:
+        shared_meta["stream"] = dict(stream)
+    if interrupt is not None:
+        shared_meta["interrupt"] = dict(interrupt)
+    if shared_meta:
+        metadata[SHARED_METADATA_NAMESPACE] = shared_meta
+    if codex_private:
+        metadata["codex"] = dict(codex_private)
+    return metadata or None
 
 
 def _coerce_number(value: Any) -> int | float | None:
@@ -1467,27 +1490,30 @@ def _extract_interrupt_asked_event(event: Mapping[str, Any]) -> dict[str, Any] |
             "permission": props.get("permission"),
             "patterns": _extract_string_list(props.get("patterns")),
             "always": _extract_string_list(props.get("always")),
-            "metadata": dict(props.get("metadata"))
-            if isinstance(props.get("metadata"), Mapping)
-            else {},
         }
+        codex_private: dict[str, Any] = {}
+        if isinstance(props.get("metadata"), Mapping):
+            codex_private["metadata"] = dict(props.get("metadata"))
         tool = props.get("tool")
         if isinstance(tool, Mapping):
-            details["tool"] = dict(tool)
+            codex_private["tool"] = dict(tool)
         return {
             "request_id": request_id,
             "interrupt_type": "permission",
             "details": details,
+            "codex_private": codex_private,
         }
     questions = props.get("questions")
     details = {"questions": questions if isinstance(questions, list) else []}
+    codex_private = {}
     tool = props.get("tool")
     if isinstance(tool, Mapping):
-        details["tool"] = dict(tool)
+        codex_private["tool"] = dict(tool)
     return {
         "request_id": request_id,
         "interrupt_type": "question",
         "details": details,
+        "codex_private": codex_private,
     }
 
 
@@ -1650,23 +1676,53 @@ def _build_history(context: RequestContext) -> list[Message]:
     return history
 
 
-def _extract_codex_session_id(context: RequestContext) -> str | None:
-    # Contract: clients may pass the binding at either request-level metadata
-    # (MessageSendParams.metadata) or message-level metadata (Message.metadata).
-    candidate = None
+def _extract_namespaced_string_metadata(
+    context: RequestContext,
+    *,
+    namespace: str,
+    path: tuple[str, ...],
+) -> str | None:
+    candidates: list[Mapping[str, Any]] = []
     try:
         meta = context.metadata
         if isinstance(meta, Mapping):
-            candidate = meta.get("codex_session_id")
+            candidates.append(meta)
     except Exception:
-        candidate = None
+        pass
 
-    if not candidate and context.message is not None:
+    if context.message is not None:
         msg_meta = getattr(context.message, "metadata", None) or {}
         if isinstance(msg_meta, Mapping):
-            candidate = msg_meta.get("codex_session_id")
+            candidates.append(msg_meta)
 
-    if isinstance(candidate, str):
-        value = candidate.strip()
-        return value or None
+    for candidate in candidates:
+        current = candidate.get(namespace)
+        for part in path[:-1]:
+            if not isinstance(current, Mapping):
+                current = None
+                break
+            current = current.get(part)
+        if not isinstance(current, Mapping):
+            continue
+        value = current.get(path[-1])
+        if isinstance(value, str):
+            normalized = value.strip()
+            if normalized:
+                return normalized
     return None
+
+
+def _extract_shared_session_id(context: RequestContext) -> str | None:
+    return _extract_namespaced_string_metadata(
+        context,
+        namespace=SHARED_METADATA_NAMESPACE,
+        path=("session", "id"),
+    )
+
+
+def _extract_codex_directory(context: RequestContext) -> str | None:
+    return _extract_namespaced_string_metadata(
+        context,
+        namespace="codex",
+        path=("directory",),
+    )

--- a/src/codex_a2a_serve/app.py
+++ b/src/codex_a2a_serve/app.py
@@ -36,11 +36,11 @@ from .extension_contracts import (
     SESSION_CONTROL_METHODS,
     SESSION_QUERY_METHODS,
     build_interrupt_callback_extension_params,
+    build_session_binding_extension_params,
     build_session_query_extension_params,
+    build_streaming_extension_params,
 )
-from .jsonrpc_ext import (
-    OpencodeSessionQueryJSONRPCApplication,
-)
+from .jsonrpc_ext import OpencodeSessionQueryJSONRPCApplication
 from .request_handler import OpencodeRequestHandler
 
 logger = logging.getLogger(__name__)
@@ -48,9 +48,10 @@ logger = logging.getLogger(__name__)
 if TYPE_CHECKING:
     from a2a.server.context import ServerCallContext
 
-SESSION_BINDING_EXTENSION_URI = "urn:codex-a2a:codex-session-binding/v1"
+SESSION_BINDING_EXTENSION_URI = "urn:a2a:session-binding/v1"
+STREAMING_EXTENSION_URI = "urn:a2a:stream-hints/v1"
 SESSION_QUERY_EXTENSION_URI = "urn:codex-a2a:codex-session-query/v1"
-INTERRUPT_CALLBACK_EXTENSION_URI = "urn:codex-a2a:codex-interrupt-callback/v1"
+INTERRUPT_CALLBACK_EXTENSION_URI = "urn:a2a:interactive-interrupt/v1"
 
 
 class IdentityAwareCallContextBuilder(DefaultCallContextBuilder):
@@ -105,8 +106,8 @@ def _build_agent_card_description(
         "Supports HTTP+JSON and JSON-RPC transports, standard A2A messaging "
         "(message/send, message/stream), task APIs (tasks/get, tasks/cancel, "
         "tasks/resubscribe; REST mapping: GET /v1/tasks/{id}:subscribe), "
-        "Codex session-query extensions, and interrupt callback extensions "
-        "(permission/question reply)."
+        "shared session-binding and streaming contracts, Codex session-query "
+        "extensions, and shared interrupt callback extensions."
     )
     parts: list[str] = [base, summary]
     parts.append(
@@ -140,6 +141,17 @@ def build_agent_card(settings: Settings) -> AgentCard:
     public_url = settings.a2a_public_url.rstrip("/")
     base_url = public_url
     deployment_context = _build_deployment_context(settings)
+    session_binding_extension_params = build_session_binding_extension_params(
+        deployment_context=deployment_context,
+        directory_override_enabled=settings.a2a_allow_directory_override,
+    )
+    streaming_extension_params = build_streaming_extension_params()
+    session_query_extension_params = build_session_query_extension_params(
+        deployment_context=deployment_context
+    )
+    interrupt_callback_extension_params = build_interrupt_callback_extension_params(
+        deployment_context=deployment_context
+    )
     security_schemes: dict[str, SecurityScheme] = {
         "bearerAuth": SecurityScheme(
             root=HTTPAuthSecurityScheme(
@@ -184,31 +196,22 @@ def build_agent_card(settings: Settings) -> AgentCard:
                     uri=SESSION_BINDING_EXTENSION_URI,
                     required=False,
                     description=(
-                        "Contract to bind A2A messages to an existing Codex session "
+                        "Shared contract to bind A2A messages to an existing Codex session "
                         "when continuing a previous chat. Clients should pass "
-                        "metadata.codex_session_id. The metadata.directory field is also "
-                        "supported under server-side directory boundary validation."
+                        "metadata.shared.session.id. The metadata.codex.directory field "
+                        "remains available as a Codex-private override under "
+                        "server-side directory boundary validation."
                     ),
-                    params={
-                        "metadata_key": "codex_session_id",
-                        "behavior": "prefer_metadata_binding_else_create_session",
-                        "supported_metadata": ["codex_session_id", "directory"],
-                        "directory_override_enabled": settings.a2a_allow_directory_override,
-                        "shared_workspace_across_consumers": True,
-                        "tenant_isolation": "none",
-                        "deployment_context": deployment_context,
-                        "notes": [
-                            (
-                                "If metadata.codex_session_id is provided, the server will "
-                                "send the message to that Codex session_id."
-                            ),
-                            (
-                                "Otherwise, the server will create a new Codex session and "
-                                "cache the (identity, contextId)->session_id mapping in memory "
-                                "with TTL."
-                            ),
-                        ],
-                    },
+                    params=session_binding_extension_params,
+                ),
+                AgentExtension(
+                    uri=STREAMING_EXTENSION_URI,
+                    required=False,
+                    description=(
+                        "Shared streaming metadata contract for canonical block hints, "
+                        "timeline identity, usage, and interactive interrupt metadata."
+                    ),
+                    params=streaming_extension_params,
                 ),
                 AgentExtension(
                     uri=SESSION_QUERY_EXTENSION_URI,
@@ -217,20 +220,16 @@ def build_agent_card(settings: Settings) -> AgentCard:
                         "Support Codex session list/history queries via custom JSON-RPC methods "
                         "on the agent's A2A JSON-RPC interface."
                     ),
-                    params=build_session_query_extension_params(
-                        deployment_context=deployment_context
-                    ),
+                    params=session_query_extension_params,
                 ),
                 AgentExtension(
                     uri=INTERRUPT_CALLBACK_EXTENSION_URI,
                     required=False,
                     description=(
-                        "Handle interactive interrupt callbacks generated by Codex "
-                        "(permission/question asked events) through JSON-RPC methods."
+                        "Handle interactive interrupt callbacks generated during "
+                        "streaming through shared JSON-RPC methods."
                     ),
-                    params=build_interrupt_callback_extension_params(
-                        deployment_context=deployment_context
-                    ),
+                    params=interrupt_callback_extension_params,
                 ),
             ],
         ),
@@ -263,10 +262,10 @@ def build_agent_card(settings: Settings) -> AgentCard:
                 name="Codex Interrupt Callback",
                 description=(
                     "Reply permission/question interrupts emitted during streaming via "
-                    "JSON-RPC methods codex.permission.reply, "
-                    "codex.question.reply, and codex.question.reject."
+                    "JSON-RPC methods a2a.interrupt.permission.reply, "
+                    "a2a.interrupt.question.reply, and a2a.interrupt.question.reject."
                 ),
-                tags=["codex", "interrupt", "permission", "question"],
+                tags=["codex", "interrupt", "permission", "question", "shared"],
                 examples=[
                     "Reply once/always/reject to a permission request by request_id.",
                     "Submit answers for a question request by request_id.",

--- a/src/codex_a2a_serve/extension_contracts.py
+++ b/src/codex_a2a_serve/extension_contracts.py
@@ -1,44 +1,312 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any
 
-SESSION_QUERY_METHODS: dict[str, str] = {
-    "list_sessions": "codex.sessions.list",
-    "get_session_messages": "codex.sessions.messages.list",
-    "prompt_async": "codex.sessions.prompt_async",
-    "command": "codex.sessions.command",
-    "shell": "codex.sessions.shell",
-}
+SHARED_METADATA_NAMESPACE = "shared"
+SHARED_SESSION_BINDING_FIELD = "metadata.shared.session.id"
+SHARED_SESSION_METADATA_FIELD = "metadata.shared.session"
+SHARED_STREAM_METADATA_FIELD = "metadata.shared.stream"
+SHARED_INTERRUPT_METADATA_FIELD = "metadata.shared.interrupt"
+SHARED_USAGE_METADATA_FIELD = "metadata.shared.usage"
+CODEX_DIRECTORY_METADATA_FIELD = "metadata.codex.directory"
 
-SESSION_CONTROL_METHODS: dict[str, str] = {
-    key: SESSION_QUERY_METHODS[key] for key in ("prompt_async", "command", "shell")
-}
 
-INTERRUPT_CALLBACK_METHODS: dict[str, str] = {
-    "reply_permission": "codex.permission.reply",
-    "reply_question": "codex.question.reply",
-    "reject_question": "codex.question.reject",
-}
+@dataclass(frozen=True)
+class SessionQueryMethodContract:
+    method: str
+    required_params: tuple[str, ...] = ()
+    optional_params: tuple[str, ...] = ()
+    unsupported_params: tuple[str, ...] = ()
+    result_fields: tuple[str, ...] = ()
+    items_type: str | None = None
+    items_field: str | None = None
+    notification_response_status: int | None = None
+    pagination_mode: str | None = None
 
-PROMPT_ASYNC_ALLOWED_FIELDS: tuple[str, ...] = (
-    "parts",
+
+@dataclass(frozen=True)
+class InterruptMethodContract:
+    method: str
+    required_params: tuple[str, ...] = ()
+    optional_params: tuple[str, ...] = ()
+    notification_response_status: int | None = None
+
+
+PROMPT_ASYNC_REQUEST_REQUIRED_FIELDS: tuple[str, ...] = ("parts",)
+PROMPT_ASYNC_REQUEST_OPTIONAL_FIELDS: tuple[str, ...] = (
     "messageID",
     "agent",
     "system",
     "variant",
 )
-COMMAND_ALLOWED_FIELDS: tuple[str, ...] = (
-    "command",
+PROMPT_ASYNC_ALLOWED_FIELDS: tuple[str, ...] = (
+    *PROMPT_ASYNC_REQUEST_REQUIRED_FIELDS,
+    *PROMPT_ASYNC_REQUEST_OPTIONAL_FIELDS,
+)
+COMMAND_REQUEST_REQUIRED_FIELDS: tuple[str, ...] = ("command",)
+COMMAND_REQUEST_OPTIONAL_FIELDS: tuple[str, ...] = (
     "arguments",
     "messageID",
 )
-SHELL_ALLOWED_FIELDS: tuple[str, ...] = ("command",)
+COMMAND_ALLOWED_FIELDS: tuple[str, ...] = (
+    *COMMAND_REQUEST_REQUIRED_FIELDS,
+    *COMMAND_REQUEST_OPTIONAL_FIELDS,
+)
+SHELL_REQUEST_REQUIRED_FIELDS: tuple[str, ...] = ("command",)
+SHELL_REQUEST_OPTIONAL_FIELDS: tuple[str, ...] = ()
+SHELL_ALLOWED_FIELDS: tuple[str, ...] = (
+    *SHELL_REQUEST_REQUIRED_FIELDS,
+    *SHELL_REQUEST_OPTIONAL_FIELDS,
+)
+
+SESSION_QUERY_PAGINATION_MODE = "limit"
+SESSION_QUERY_PAGINATION_BEHAVIOR = "passthrough"
+SESSION_QUERY_PAGINATION_PARAMS: tuple[str, ...] = ("limit",)
+SESSION_QUERY_PAGINATION_UNSUPPORTED: tuple[str, ...] = ("cursor", "page", "size")
+
+SESSION_QUERY_METHOD_CONTRACTS: dict[str, SessionQueryMethodContract] = {
+    "list_sessions": SessionQueryMethodContract(
+        method="codex.sessions.list",
+        optional_params=("limit", "query.limit"),
+        unsupported_params=SESSION_QUERY_PAGINATION_UNSUPPORTED,
+        result_fields=("items",),
+        items_type="Task[]",
+        items_field="items",
+        notification_response_status=204,
+        pagination_mode=SESSION_QUERY_PAGINATION_MODE,
+    ),
+    "get_session_messages": SessionQueryMethodContract(
+        method="codex.sessions.messages.list",
+        required_params=("session_id",),
+        optional_params=("limit", "query.limit"),
+        unsupported_params=SESSION_QUERY_PAGINATION_UNSUPPORTED,
+        result_fields=("items",),
+        items_type="Message[]",
+        items_field="items",
+        notification_response_status=204,
+        pagination_mode=SESSION_QUERY_PAGINATION_MODE,
+    ),
+    "prompt_async": SessionQueryMethodContract(
+        method="codex.sessions.prompt_async",
+        required_params=("session_id", "request.parts"),
+        optional_params=(
+            "request.messageID",
+            "request.agent",
+            "request.system",
+            "request.variant",
+            CODEX_DIRECTORY_METADATA_FIELD,
+        ),
+        result_fields=("ok", "session_id", "turn_id"),
+        notification_response_status=204,
+    ),
+    "command": SessionQueryMethodContract(
+        method="codex.sessions.command",
+        required_params=("session_id", "request.command"),
+        optional_params=(
+            "request.arguments",
+            "request.messageID",
+            CODEX_DIRECTORY_METADATA_FIELD,
+        ),
+        result_fields=("item",),
+        notification_response_status=204,
+    ),
+    "shell": SessionQueryMethodContract(
+        method="codex.sessions.shell",
+        required_params=("session_id", "request.command"),
+        optional_params=(CODEX_DIRECTORY_METADATA_FIELD,),
+        result_fields=("item",),
+        notification_response_status=204,
+    ),
+}
+
+SESSION_QUERY_METHODS: dict[str, str] = {
+    key: contract.method for key, contract in SESSION_QUERY_METHOD_CONTRACTS.items()
+}
+SESSION_CONTROL_METHOD_KEYS: tuple[str, ...] = ("prompt_async", "command", "shell")
+SESSION_CONTROL_METHODS: dict[str, str] = {
+    key: SESSION_QUERY_METHODS[key] for key in SESSION_CONTROL_METHOD_KEYS
+}
+
+SESSION_QUERY_ERROR_BUSINESS_CODES: dict[str, int] = {
+    "SESSION_NOT_FOUND": -32001,
+    "SESSION_FORBIDDEN": -32006,
+    "UPSTREAM_UNREACHABLE": -32002,
+    "UPSTREAM_HTTP_ERROR": -32003,
+    "UPSTREAM_PAYLOAD_ERROR": -32005,
+}
+SESSION_QUERY_ERROR_DATA_FIELDS: tuple[str, ...] = (
+    "type",
+    "method",
+    "session_id",
+    "upstream_status",
+    "detail",
+)
+SESSION_QUERY_INVALID_PARAMS_DATA_FIELDS: tuple[str, ...] = (
+    "type",
+    "field",
+    "fields",
+    "supported",
+    "unsupported",
+)
+
+INTERRUPT_CALLBACK_METHOD_CONTRACTS: dict[str, InterruptMethodContract] = {
+    "reply_permission": InterruptMethodContract(
+        method="a2a.interrupt.permission.reply",
+        required_params=("request_id", "reply"),
+        optional_params=("message", "metadata"),
+        notification_response_status=204,
+    ),
+    "reply_question": InterruptMethodContract(
+        method="a2a.interrupt.question.reply",
+        required_params=("request_id", "answers"),
+        optional_params=("metadata",),
+        notification_response_status=204,
+    ),
+    "reject_question": InterruptMethodContract(
+        method="a2a.interrupt.question.reject",
+        required_params=("request_id",),
+        optional_params=("metadata",),
+        notification_response_status=204,
+    ),
+}
+
+INTERRUPT_CALLBACK_METHODS: dict[str, str] = {
+    key: contract.method for key, contract in INTERRUPT_CALLBACK_METHOD_CONTRACTS.items()
+}
+
+INTERRUPT_SUCCESS_RESULT_FIELDS: tuple[str, ...] = ("ok", "request_id")
+INTERRUPT_ERROR_BUSINESS_CODES: dict[str, int] = {
+    "INTERRUPT_REQUEST_NOT_FOUND": -32004,
+    "UPSTREAM_UNREACHABLE": -32002,
+    "UPSTREAM_HTTP_ERROR": -32003,
+}
+INTERRUPT_ERROR_TYPES: tuple[str, ...] = (
+    "INTERRUPT_REQUEST_NOT_FOUND",
+    "UPSTREAM_UNREACHABLE",
+    "UPSTREAM_HTTP_ERROR",
+)
+INTERRUPT_ERROR_DATA_FIELDS: tuple[str, ...] = ("type", "request_id", "upstream_status")
+INTERRUPT_INVALID_PARAMS_DATA_FIELDS: tuple[str, ...] = (
+    "type",
+    "field",
+    "fields",
+    "request_id",
+)
+
+
+def _build_method_contract_params(
+    *,
+    required: tuple[str, ...],
+    optional: tuple[str, ...],
+    unsupported: tuple[str, ...],
+) -> dict[str, list[str]]:
+    params: dict[str, list[str]] = {}
+    if required:
+        params["required"] = list(required)
+    if optional:
+        params["optional"] = list(optional)
+    if unsupported:
+        params["unsupported"] = list(unsupported)
+    return params
+
+
+def build_session_binding_extension_params(
+    *,
+    deployment_context: dict[str, str | bool],
+    directory_override_enabled: bool,
+) -> dict[str, Any]:
+    return {
+        "metadata_field": SHARED_SESSION_BINDING_FIELD,
+        "behavior": "prefer_metadata_binding_else_create_session",
+        "supported_metadata": [
+            "shared.session.id",
+            "codex.directory",
+        ],
+        "provider_private_metadata": ["codex.directory"],
+        "directory_override_enabled": directory_override_enabled,
+        "shared_workspace_across_consumers": True,
+        "tenant_isolation": "none",
+        "deployment_context": deployment_context,
+        "notes": [
+            (
+                "If metadata.shared.session.id is provided, the server will send the "
+                "message to that upstream session."
+            ),
+            (
+                "Otherwise, the server will create a new upstream session and cache "
+                "the (identity, contextId)->session_id mapping in memory with TTL."
+            ),
+        ],
+    }
+
+
+def build_streaming_extension_params() -> dict[str, Any]:
+    return {
+        "artifact_metadata_field": SHARED_STREAM_METADATA_FIELD,
+        "status_metadata_field": SHARED_STREAM_METADATA_FIELD,
+        "interrupt_metadata_field": SHARED_INTERRUPT_METADATA_FIELD,
+        "session_metadata_field": SHARED_SESSION_METADATA_FIELD,
+        "usage_metadata_field": SHARED_USAGE_METADATA_FIELD,
+        "block_types": ["text", "reasoning", "tool_call"],
+        "stream_fields": {
+            "block_type": f"{SHARED_STREAM_METADATA_FIELD}.block_type",
+            "source": f"{SHARED_STREAM_METADATA_FIELD}.source",
+            "message_id": f"{SHARED_STREAM_METADATA_FIELD}.message_id",
+            "event_id": f"{SHARED_STREAM_METADATA_FIELD}.event_id",
+            "sequence": f"{SHARED_STREAM_METADATA_FIELD}.sequence",
+            "role": f"{SHARED_STREAM_METADATA_FIELD}.role",
+        },
+        "interrupt_fields": {
+            "request_id": f"{SHARED_INTERRUPT_METADATA_FIELD}.request_id",
+            "type": f"{SHARED_INTERRUPT_METADATA_FIELD}.type",
+            "details": f"{SHARED_INTERRUPT_METADATA_FIELD}.details",
+        },
+        "usage_fields": {
+            "input_tokens": f"{SHARED_USAGE_METADATA_FIELD}.input_tokens",
+            "output_tokens": f"{SHARED_USAGE_METADATA_FIELD}.output_tokens",
+            "total_tokens": f"{SHARED_USAGE_METADATA_FIELD}.total_tokens",
+            "cost": f"{SHARED_USAGE_METADATA_FIELD}.cost",
+        },
+    }
 
 
 def build_session_query_extension_params(
     *,
     deployment_context: dict[str, str | bool],
 ) -> dict[str, Any]:
+    method_contracts: dict[str, Any] = {}
+    result_envelope_by_method: dict[str, Any] = {}
+    pagination_applies_to: list[str] = []
+
+    for method_contract in SESSION_QUERY_METHOD_CONTRACTS.values():
+        params_contract = _build_method_contract_params(
+            required=method_contract.required_params,
+            optional=method_contract.optional_params,
+            unsupported=method_contract.unsupported_params,
+        )
+        result_contract: dict[str, Any] = {"fields": list(method_contract.result_fields)}
+        if method_contract.items_type:
+            result_contract["items_type"] = method_contract.items_type
+
+        contract_doc: dict[str, Any] = {
+            "params": params_contract,
+            "result": result_contract,
+        }
+        if method_contract.notification_response_status is not None:
+            contract_doc["notification_response_status"] = (
+                method_contract.notification_response_status
+            )
+        method_contracts[method_contract.method] = contract_doc
+
+        envelope_doc: dict[str, Any] = {"fields": list(method_contract.result_fields)}
+        if method_contract.items_field:
+            envelope_doc["items_field"] = method_contract.items_field
+        result_envelope_by_method[method_contract.method] = envelope_doc
+
+        if method_contract.pagination_mode == SESSION_QUERY_PAGINATION_MODE:
+            pagination_applies_to.append(method_contract.method)
+
     return {
         "methods": dict(SESSION_QUERY_METHODS),
         "control_methods": dict(SESSION_CONTROL_METHODS),
@@ -46,14 +314,25 @@ def build_session_query_extension_params(
         "tenant_isolation": "none",
         "deployment_context": deployment_context,
         "supported_metadata": ["codex.directory"],
+        "provider_private_metadata": ["codex.directory"],
+        "pagination": {
+            "mode": SESSION_QUERY_PAGINATION_MODE,
+            "behavior": SESSION_QUERY_PAGINATION_BEHAVIOR,
+            "params": list(SESSION_QUERY_PAGINATION_PARAMS),
+            "applies_to": pagination_applies_to,
+        },
+        "method_contracts": method_contracts,
+        "errors": {
+            "business_codes": dict(SESSION_QUERY_ERROR_BUSINESS_CODES),
+            "error_data_fields": list(SESSION_QUERY_ERROR_DATA_FIELDS),
+            "invalid_params_data_fields": list(SESSION_QUERY_INVALID_PARAMS_DATA_FIELDS),
+        },
         "result_envelope": {
-            "by_method": {
-                SESSION_QUERY_METHODS["list_sessions"]: {"fields": ["items"]},
-                SESSION_QUERY_METHODS["get_session_messages"]: {"fields": ["items"]},
-                SESSION_QUERY_METHODS["prompt_async"]: {"fields": ["ok", "session_id", "turn_id"]},
-                SESSION_QUERY_METHODS["command"]: {"fields": ["item"]},
-                SESSION_QUERY_METHODS["shell"]: {"fields": ["item"]},
-            }
+            "by_method": result_envelope_by_method,
+        },
+        "context_semantics": {
+            "a2a_context_id_field": "contextId",
+            "upstream_session_id_field": SHARED_SESSION_BINDING_FIELD,
         },
     }
 
@@ -62,8 +341,46 @@ def build_interrupt_callback_extension_params(
     *,
     deployment_context: dict[str, str | bool],
 ) -> dict[str, Any]:
+    method_contracts: dict[str, Any] = {}
+    for contract in INTERRUPT_CALLBACK_METHOD_CONTRACTS.values():
+        method_contract_doc: dict[str, Any] = {
+            "params": _build_method_contract_params(
+                required=contract.required_params,
+                optional=contract.optional_params,
+                unsupported=(),
+            ),
+            "result": {"fields": list(INTERRUPT_SUCCESS_RESULT_FIELDS)},
+        }
+        if contract.notification_response_status is not None:
+            method_contract_doc["notification_response_status"] = (
+                contract.notification_response_status
+            )
+        method_contracts[contract.method] = method_contract_doc
+
     return {
         "methods": dict(INTERRUPT_CALLBACK_METHODS),
+        "method_contracts": method_contracts,
+        "supported_interrupt_events": [
+            "permission.asked",
+            "question.asked",
+        ],
+        "permission_reply_values": ["once", "always", "reject"],
+        "question_reply_contract": {
+            "answers": "array of answer arrays (same order as asked questions)"
+        },
+        "request_id_field": f"{SHARED_INTERRUPT_METADATA_FIELD}.request_id",
+        "supported_metadata": ["codex.directory"],
+        "provider_private_metadata": ["codex.directory"],
+        "context_fields": {
+            "directory": CODEX_DIRECTORY_METADATA_FIELD,
+        },
+        "success_result_fields": list(INTERRUPT_SUCCESS_RESULT_FIELDS),
+        "errors": {
+            "business_codes": dict(INTERRUPT_ERROR_BUSINESS_CODES),
+            "error_types": list(INTERRUPT_ERROR_TYPES),
+            "error_data_fields": list(INTERRUPT_ERROR_DATA_FIELDS),
+            "invalid_params_data_fields": list(INTERRUPT_INVALID_PARAMS_DATA_FIELDS),
+        },
         "shared_workspace_across_consumers": True,
         "tenant_isolation": "none",
         "deployment_context": deployment_context,

--- a/src/codex_a2a_serve/jsonrpc_ext.py
+++ b/src/codex_a2a_serve/jsonrpc_ext.py
@@ -203,7 +203,10 @@ def _as_a2a_session_task(session: Any) -> dict[str, Any] | None:
         context_id=session_id,
         # Model Codex sessions as completed A2A Tasks for stable downstream rendering.
         status=TaskStatus(state=TaskState.completed),
-        metadata={"codex": {"raw": session, "title": title}},
+        metadata={
+            "shared": {"session": {"id": session_id, "title": title}},
+            "codex": {"raw": session},
+        },
     )
     return task.model_dump(by_alias=True, exclude_none=True)
 
@@ -234,7 +237,10 @@ def _as_a2a_message(session_id: str, item: Any) -> dict[str, Any] | None:
         role=role,
         parts=[TextPart(text=text)],
         context_id=session_id,
-        metadata={"codex": {"raw": item, "session_id": session_id}},
+        metadata={
+            "shared": {"session": {"id": session_id}},
+            "codex": {"raw": item},
+        },
     )
     return msg.model_dump(by_alias=True, exclude_none=True)
 
@@ -562,6 +568,22 @@ class OpencodeSessionQueryJSONRPCApplication(A2AFastAPIApplication):
                     )
                 ),
             )
+        unknown_metadata_fields = sorted(set(metadata) - {"codex"})
+        if unknown_metadata_fields:
+            return None, self._generate_error_response(
+                request_id,
+                A2AError(
+                    root=InvalidParamsError(
+                        message=(
+                            f"Unsupported metadata fields: {', '.join(unknown_metadata_fields)}"
+                        ),
+                        data={
+                            "type": "INVALID_FIELD",
+                            "fields": [f"metadata.{field}" for field in unknown_metadata_fields],
+                        },
+                    )
+                ),
+            )
         raw_codex_metadata = metadata.get("codex")
         if raw_codex_metadata is None:
             return None, None
@@ -790,23 +812,18 @@ class OpencodeSessionQueryJSONRPCApplication(A2AFastAPIApplication):
                 ),
             )
         request_id = request_id.strip()
-        directory = params.get("directory")
-        if directory is not None and not isinstance(directory, str):
-            return self._generate_error_response(
-                base_request.id,
-                A2AError(
-                    root=InvalidParamsError(
-                        message="directory must be a string",
-                        data={"type": "INVALID_FIELD", "field": "directory"},
-                    )
-                ),
-            )
+        directory, metadata_error = self._extract_directory_from_metadata(
+            request_id=base_request.id,
+            params=params,
+        )
+        if metadata_error is not None:
+            return metadata_error
         if base_request.method == self._method_reply_permission:
-            allowed_fields = {"request_id", "reply", "message", "directory"}
+            allowed_fields = {"request_id", "reply", "message", "metadata"}
         elif base_request.method == self._method_reply_question:
-            allowed_fields = {"request_id", "answers", "directory"}
+            allowed_fields = {"request_id", "answers", "metadata"}
         else:
-            allowed_fields = {"request_id", "directory"}
+            allowed_fields = {"request_id", "metadata"}
         unknown_fields = sorted(set(params) - allowed_fields)
         if unknown_fields:
             return self._generate_error_response(

--- a/tests/test_agent_card.py
+++ b/tests/test_agent_card.py
@@ -2,6 +2,7 @@ from codex_a2a_serve.app import (
     INTERRUPT_CALLBACK_EXTENSION_URI,
     SESSION_BINDING_EXTENSION_URI,
     SESSION_QUERY_EXTENSION_URI,
+    STREAMING_EXTENSION_URI,
     build_agent_card,
 )
 from tests.helpers import make_settings
@@ -41,20 +42,40 @@ def test_agent_card_injects_deployment_context_into_extensions() -> None:
     assert context["variant"] == "safe"
     assert context["allow_directory_override"] is False
     assert context["shared_workspace_across_consumers"] is True
+    assert binding.params["metadata_field"] == "metadata.shared.session.id"
+    assert binding.params["supported_metadata"] == [
+        "shared.session.id",
+        "codex.directory",
+    ]
+    assert binding.params["provider_private_metadata"] == ["codex.directory"]
     assert binding.params["directory_override_enabled"] is False
     assert binding.params["shared_workspace_across_consumers"] is True
     assert binding.params["tenant_isolation"] == "none"
+
+    streaming = ext_by_uri[STREAMING_EXTENSION_URI]
+    assert streaming.params["artifact_metadata_field"] == "metadata.shared.stream"
+    assert streaming.params["interrupt_metadata_field"] == "metadata.shared.interrupt"
+    assert streaming.params["usage_metadata_field"] == "metadata.shared.usage"
+    assert streaming.params["stream_fields"]["sequence"] == "metadata.shared.stream.sequence"
 
     session_query = ext_by_uri[SESSION_QUERY_EXTENSION_URI]
     assert session_query.params["deployment_context"]["project"] == "alpha"
     assert session_query.params["shared_workspace_across_consumers"] is True
     assert session_query.params["tenant_isolation"] == "none"
     assert session_query.params["supported_metadata"] == ["codex.directory"]
+    assert session_query.params["provider_private_metadata"] == ["codex.directory"]
+    assert (
+        session_query.params["context_semantics"]["upstream_session_id_field"]
+        == "metadata.shared.session.id"
+    )
 
     interrupt = ext_by_uri[INTERRUPT_CALLBACK_EXTENSION_URI]
     assert interrupt.params["deployment_context"]["project"] == "alpha"
     assert interrupt.params["shared_workspace_across_consumers"] is True
     assert interrupt.params["tenant_isolation"] == "none"
+    assert interrupt.params["request_id_field"] == "metadata.shared.interrupt.request_id"
+    assert interrupt.params["supported_metadata"] == ["codex.directory"]
+    assert interrupt.params["provider_private_metadata"] == ["codex.directory"]
 
 
 def test_agent_card_chat_examples_include_project_hint_when_configured() -> None:

--- a/tests/test_directory_validation.py
+++ b/tests/test_directory_validation.py
@@ -78,7 +78,7 @@ async def test_execute_with_invalid_directory(mock_client):
     context = make_request_context_mock(
         task_id="task-1",
         context_id="ctx-1",
-        metadata={"directory": "/etc"},  # Illegal
+        metadata={"codex": {"directory": "/etc"}},  # Illegal
         call_context_enabled=False,
     )
 

--- a/tests/test_opencode_agent_session_binding.py
+++ b/tests/test_opencode_agent_session_binding.py
@@ -9,7 +9,7 @@ from tests.helpers import DummyChatOpencodeClient, DummyEventQueue, make_request
 
 
 @pytest.mark.asyncio
-async def test_agent_prefers_metadata_codex_session_id() -> None:
+async def test_agent_prefers_metadata_shared_session_id() -> None:
     client = DummyChatOpencodeClient()
     executor = OpencodeAgentExecutor(client, streaming_enabled=False)
     q = DummyEventQueue()
@@ -18,7 +18,7 @@ async def test_agent_prefers_metadata_codex_session_id() -> None:
         task_id="t-1",
         context_id="c-1",
         text="hello",
-        metadata={"codex_session_id": "ses-bound"},
+        metadata={"shared": {"session": {"id": "ses-bound"}}},
     )
     await executor.execute(ctx, q)
 
@@ -41,7 +41,7 @@ async def test_agent_caches_bound_session_id_for_followup_requests() -> None:
         task_id="t-1",
         context_id="c-1",
         text="hello",
-        metadata={"codex_session_id": "ses-bound"},
+        metadata={"shared": {"session": {"id": "ses-bound"}}},
     )
     await executor.execute(ctx1, q)
 
@@ -117,7 +117,7 @@ async def test_agent_uses_stable_fallback_message_id_when_upstream_missing_messa
     )
 
     task = next(event for event in q.events if isinstance(event, Task))
-    assert task.metadata["codex"]["message_id"] == "t-fallback:c-fallback:assistant"
+    assert "message_id" not in task.metadata["shared"]["session"]
     assert task.status.message.message_id == "t-fallback:c-fallback:assistant"
 
 
@@ -161,7 +161,7 @@ async def test_agent_includes_usage_in_non_stream_task_metadata() -> None:
     )
 
     task = next(event for event in q.events if isinstance(event, Task))
-    usage = task.metadata["codex"]["usage"]
+    usage = task.metadata["shared"]["usage"]
     assert usage["input_tokens"] == 7
     assert usage["output_tokens"] == 3
     assert usage["total_tokens"] == 10

--- a/tests/test_opencode_session_extension.py
+++ b/tests/test_opencode_session_extension.py
@@ -75,8 +75,9 @@ async def test_session_query_extension_returns_jsonrpc_result(monkeypatch):
         session = payload["result"]["items"][0]
         assert session["id"] == "s-1"
         assert session["contextId"] == "s-1"
+        assert session["metadata"]["shared"]["session"]["id"] == "s-1"
+        assert session["metadata"]["shared"]["session"]["title"] == "Session s-1"
         assert session["metadata"]["codex"]["raw"]["id"] == "s-1"
-        assert session["metadata"]["codex"]["title"] == "Session s-1"
         assert dummy.last_sessions_params is not None
         assert dummy.last_sessions_params.get("limit") == 10
 
@@ -98,7 +99,7 @@ async def test_session_query_extension_returns_jsonrpc_result(monkeypatch):
         message = payload["result"]["items"][0]
         assert message["contextId"] == "s-1"
         assert message["parts"][0]["text"] == "SECRET_HISTORY"
-        assert message["metadata"]["codex"]["session_id"] == "s-1"
+        assert message["metadata"]["shared"]["session"]["id"] == "s-1"
         assert dummy.last_messages_params is not None
         assert dummy.last_messages_params.get("limit") == 5
 
@@ -161,7 +162,7 @@ async def test_session_query_extension_session_title_is_extracted_or_placeholder
         payload = resp.json()
         session = payload["result"]["items"][0]
         assert session["id"] == "s-1"
-        assert session["metadata"]["codex"]["title"] == "My Session"
+        assert session["metadata"]["shared"]["session"]["title"] == "My Session"
 
 
 @pytest.mark.asyncio
@@ -738,12 +739,12 @@ async def test_interrupt_callback_extension_permission_reply(monkeypatch):
             json={
                 "jsonrpc": "2.0",
                 "id": 11,
-                "method": "codex.permission.reply",
+                "method": "a2a.interrupt.permission.reply",
                 "params": {
                     "request_id": "perm-1",
                     "reply": "once",
                     "message": "approved by operator",
-                    "directory": "/workspace",
+                    "metadata": {"codex": {"directory": "/workspace"}},
                 },
             },
         )
@@ -779,7 +780,7 @@ async def test_interrupt_callback_extension_rejects_legacy_permission_fields(mon
             json={
                 "jsonrpc": "2.0",
                 "id": 111,
-                "method": "codex.permission.reply",
+                "method": "a2a.interrupt.permission.reply",
                 "params": {"requestID": "perm-legacy", "decision": "allow"},
             },
         )
@@ -835,7 +836,7 @@ async def test_interrupt_callback_extension_question_reply_and_reject(monkeypatc
             json={
                 "jsonrpc": "2.0",
                 "id": 12,
-                "method": "codex.question.reply",
+                "method": "a2a.interrupt.question.reply",
                 "params": {"request_id": "q-1", "answers": [["A"], ["B"]]},
             },
         )
@@ -850,7 +851,7 @@ async def test_interrupt_callback_extension_question_reply_and_reject(monkeypatc
             json={
                 "jsonrpc": "2.0",
                 "id": 13,
-                "method": "codex.question.reject",
+                "method": "a2a.interrupt.question.reject",
                 "params": {"request_id": "q-2"},
             },
         )
@@ -891,7 +892,7 @@ async def test_interrupt_callback_extension_maps_404_to_interrupt_not_found(monk
             json={
                 "jsonrpc": "2.0",
                 "id": 14,
-                "method": "codex.permission.reply",
+                "method": "a2a.interrupt.permission.reply",
                 "params": {"request_id": "perm-404", "reply": "reject"},
             },
         )

--- a/tests/test_session_ownership.py
+++ b/tests/test_session_ownership.py
@@ -89,7 +89,7 @@ async def test_session_hijack_prevention(mock_client):
         context_id="context-B",
         identity="user-2",
         user_input="hello",
-        metadata={"codex_session_id": "session-1"},
+        metadata={"shared": {"session": {"id": "session-1"}}},
     )
 
     # This should fail and emit an error
@@ -250,7 +250,7 @@ async def test_preferred_session_claim_is_released_on_upstream_failure():
         context_id="context-A",
         identity="user-1",
         user_input="hello",
-        metadata={"codex_session_id": "session-X"},
+        metadata={"shared": {"session": {"id": "session-X"}}},
     )
 
     await executor.execute(context, event_queue)
@@ -283,7 +283,7 @@ async def test_preferred_session_claim_is_released_on_upstream_cancellation():
         context_id="context-A",
         identity="user-1",
         user_input="hello",
-        metadata={"codex_session_id": "session-X"},
+        metadata={"shared": {"session": {"id": "session-X"}}},
     )
 
     with pytest.raises(asyncio.CancelledError):

--- a/tests/test_streaming_output_contract.py
+++ b/tests/test_streaming_output_contract.py
@@ -191,6 +191,18 @@ def _part_text(event: TaskArtifactUpdateEvent) -> str:
     return getattr(part, "text", None) or getattr(part.root, "text", "")
 
 
+def _artifact_stream_meta(event: TaskArtifactUpdateEvent) -> dict:
+    return event.artifact.metadata["shared"]["stream"]
+
+
+def _status_shared_meta(event: TaskStatusUpdateEvent) -> dict:
+    return (event.metadata or {})["shared"]
+
+
+def _interrupt_meta(event: TaskStatusUpdateEvent) -> dict:
+    return _status_shared_meta(event)["interrupt"]
+
+
 @pytest.mark.asyncio
 async def test_streaming_filters_user_echo_and_emits_single_artifact_block_types() -> None:
     user_text = "who are you"
@@ -220,13 +232,13 @@ async def test_streaming_filters_user_echo_and_emits_single_artifact_block_types
     assert updates
     texts = [_part_text(event) for event in updates]
     assert user_text not in texts
-    block_types = [event.artifact.metadata["codex"]["block_type"] for event in updates]
+    block_types = [_artifact_stream_meta(event)["block_type"] for event in updates]
     assert _unique(block_types) == ["reasoning", "tool_call", "text"]
     artifact_ids = [event.artifact.artifact_id for event in updates]
     assert len(set(artifact_ids)) == 1
-    sequences = [event.artifact.metadata["codex"]["sequence"] for event in updates]
+    sequences = [_artifact_stream_meta(event)["sequence"] for event in updates]
     assert sequences == list(range(1, len(updates) + 1))
-    event_ids = [event.artifact.metadata["codex"]["event_id"] for event in updates]
+    event_ids = [_artifact_stream_meta(event)["event_id"] for event in updates]
     assert event_ids == [f"task-1:ctx-1:task-1:stream:{seq}" for seq in sequences]
 
 
@@ -254,11 +266,11 @@ async def test_streaming_does_not_send_duplicate_final_snapshot_when_chunks_exis
     final_updates = [
         event
         for event in _artifact_updates(queue)
-        if event.artifact.metadata["codex"]["block_type"] == "text"
+        if _artifact_stream_meta(event)["block_type"] == "text"
     ]
     assert len(final_updates) == 1
     assert _part_text(final_updates[0]) == "stable final answer"
-    assert final_updates[0].artifact.metadata["codex"]["source"] != "final_snapshot"
+    assert _artifact_stream_meta(final_updates[0])["source"] != "final_snapshot"
 
 
 @pytest.mark.asyncio
@@ -280,12 +292,12 @@ async def test_streaming_emits_final_snapshot_only_when_stream_has_no_final_answ
     final_updates = [
         event
         for event in _artifact_updates(queue)
-        if event.artifact.metadata["codex"]["block_type"] == "text"
+        if _artifact_stream_meta(event)["block_type"] == "text"
     ]
     assert len(final_updates) == 1
     final_event = final_updates[0]
     assert _part_text(final_event) == "final answer from send_message"
-    assert final_event.artifact.metadata["codex"]["source"] == "final_snapshot"
+    assert _artifact_stream_meta(final_event)["source"] == "final_snapshot"
     assert final_event.append is True
     assert final_event.last_chunk is True
 
@@ -300,7 +312,7 @@ async def test_execute_serializes_send_message_per_session() -> None:
     executor = OpencodeAgentExecutor(client, streaming_enabled=False)
     queue_1 = DummyEventQueue()
     queue_2 = DummyEventQueue()
-    metadata = {"codex_session_id": "ses-shared"}
+    metadata = {"shared": {"session": {"id": "ses-shared"}}}
 
     await asyncio.gather(
         executor.execute(
@@ -347,15 +359,18 @@ async def test_streaming_emits_events_without_message_id_using_stable_fallback()
     assert len(updates) == 1
     update = updates[0]
     assert _part_text(update) == "stream chunk without id"
-    assert update.artifact.metadata["codex"]["source"] == "delta"
-    assert update.artifact.metadata["codex"]["block_type"] == "text"
-    assert update.artifact.metadata["codex"]["message_id"] == "task-6:ctx-6:assistant"
-    assert update.artifact.metadata["codex"]["event_id"] == "task-6:ctx-6:task-6:stream:1"
+    assert _artifact_stream_meta(update)["source"] == "delta"
+    assert _artifact_stream_meta(update)["block_type"] == "text"
+    assert _artifact_stream_meta(update)["message_id"] == "task-6:ctx-6:assistant"
+    assert _artifact_stream_meta(update)["event_id"] == "task-6:ctx-6:task-6:stream:1"
     final_status = [
         event for event in queue.events if isinstance(event, TaskStatusUpdateEvent) and event.final
     ][-1]
-    assert final_status.metadata["codex"]["message_id"] == "task-6:ctx-6:assistant"
-    assert final_status.metadata["codex"]["event_id"] == "task-6:ctx-6:task-6:stream:status"
+    assert _status_shared_meta(final_status)["stream"]["message_id"] == "task-6:ctx-6:assistant"
+    assert (
+        _status_shared_meta(final_status)["stream"]["event_id"]
+        == "task-6:ctx-6:task-6:stream:status"
+    )
 
 
 @pytest.mark.asyncio
@@ -396,7 +411,7 @@ async def test_streaming_includes_usage_in_final_status_metadata() -> None:
     final_status = [
         event for event in queue.events if isinstance(event, TaskStatusUpdateEvent) and event.final
     ][-1]
-    usage = final_status.metadata["codex"]["usage"]
+    usage = _status_shared_meta(final_status)["usage"]
     assert usage["input_tokens"] == 12
     assert usage["output_tokens"] == 4
     assert usage["total_tokens"] == 16
@@ -427,15 +442,20 @@ async def test_streaming_emits_interrupt_status_for_permission_asked_event() -> 
         for event in queue.events
         if isinstance(event, TaskStatusUpdateEvent)
         and event.final is False
-        and (event.metadata or {}).get("codex", {}).get("interrupt", {}).get("type") == "permission"
+        and (event.metadata or {}).get("shared", {}).get("interrupt", {}).get("type")
+        == "permission"
     ]
     assert len(interrupt_statuses) == 1
-    interrupt = interrupt_statuses[0].metadata["codex"]["interrupt"]
+    interrupt = _interrupt_meta(interrupt_statuses[0])
     assert interrupt["request_id"] == "perm-req-1"
-    assert interrupt["event_type"] == "permission.asked"
     assert interrupt["details"]["permission"] == "read"
     assert "/data/project/.env.secret" in interrupt["details"]["patterns"]
-    assert interrupt["details"]["metadata"]["path"] == "/data/project/.env.secret"
+    assert "metadata" not in interrupt["details"]
+    assert "tool" not in interrupt["details"]
+    assert (
+        interrupt_statuses[0].metadata["codex"]["interrupt"]["metadata"]["path"]
+        == "/data/project/.env.secret"
+    )
     assert interrupt_statuses[0].status.state == TaskState.input_required
 
 
@@ -491,7 +511,7 @@ async def test_streaming_treats_embedded_markers_as_plain_text_without_typed_par
     def _final_state(block_type: str) -> str:
         parts = []
         for ev in updates:
-            if ev.artifact.metadata["codex"]["block_type"] == block_type:
+            if _artifact_stream_meta(ev)["block_type"] == block_type:
                 if not ev.append:
                     parts = [_part_text(ev)]
                 else:
@@ -556,9 +576,7 @@ async def test_streaming_emits_structured_tool_part_updates() -> None:
     )
 
     updates = _artifact_updates(queue)
-    tool_updates = [
-        ev for ev in updates if ev.artifact.metadata["codex"]["block_type"] == "tool_call"
-    ]
+    tool_updates = [ev for ev in updates if _artifact_stream_meta(ev)["block_type"] == "tool_call"]
     assert len(tool_updates) == 3
     merged = "".join(_part_text(ev) for ev in tool_updates)
     assert '"status":"pending"' in merged
@@ -586,7 +604,7 @@ async def test_streaming_flushes_partial_marker_on_eof_as_current_block_type() -
     updates = _artifact_updates(queue)
     assert updates
     assert "".join(_part_text(ev) for ev in updates) == "hello <thin"
-    assert all(ev.artifact.metadata["codex"]["block_type"] == "text" for ev in updates)
+    assert all(_artifact_stream_meta(ev)["block_type"] == "text" for ev in updates)
 
 
 @pytest.mark.asyncio
@@ -681,7 +699,7 @@ async def test_streaming_suppresses_reasoning_snapshot_reset_after_delta() -> No
     reasoning_updates = [
         event
         for event in _artifact_updates(queue)
-        if event.artifact.metadata["codex"]["block_type"] == "reasoning"
+        if _artifact_stream_meta(event)["block_type"] == "reasoning"
     ]
     assert len(reasoning_updates) == 1
     assert _part_text(reasoning_updates[0]) == "reasoning line\n\n"
@@ -716,7 +734,7 @@ async def test_streaming_supports_message_part_delta_events() -> None:
     reasoning_updates = [
         event
         for event in _artifact_updates(queue)
-        if event.artifact.metadata["codex"]["block_type"] == "reasoning"
+        if _artifact_stream_meta(event)["block_type"] == "reasoning"
     ]
     assert reasoning_updates
     merged = "".join(_part_text(ev) for ev in reasoning_updates)
@@ -754,7 +772,7 @@ async def test_streaming_buffers_delta_until_part_updated_arrives() -> None:
     reasoning_updates = [
         event
         for event in _artifact_updates(queue)
-        if event.artifact.metadata["codex"]["block_type"] == "reasoning"
+        if _artifact_stream_meta(event)["block_type"] == "reasoning"
     ]
     assert reasoning_updates
     merged = "".join(_part_text(ev) for ev in reasoning_updates)
@@ -795,6 +813,6 @@ async def test_streaming_keeps_multiple_message_ids_in_same_request_window() -> 
     )
 
     updates = _artifact_updates(queue)
-    message_ids = [ev.artifact.metadata["codex"].get("message_id") for ev in updates]
+    message_ids = [_artifact_stream_meta(ev).get("message_id") for ev in updates]
     assert "msg-a" in message_ids
     assert "msg-b" in message_ids


### PR DESCRIPTION
## 关联关系
- Closes #22
- Relates to #10
- Relates to https://github.com/liujuanjuan1984/a2a-client-hub/issues/443

## 相关提交
- `b51fa0b` `refactor: align codex adapter with shared A2A extension contracts #22`

## 模块改动

### 1. Agent Card 与扩展契约
- 将 session binding 扩展 URI 切换到共享契约 `urn:a2a:session-binding/v1`
- 新增共享 streaming 扩展 `urn:a2a:stream-hints/v1`
- 将 interrupt callback 扩展 URI 切换到共享契约 `urn:a2a:interactive-interrupt/v1`
- 统一扩展参数说明，明确 `metadata.shared.session.id` 为会话绑定主入口，`metadata.codex.directory` 仅保留为 provider-private override

### 2. 运行时元数据输出
- 会话绑定入口从旧私有字段切换为 `metadata.shared.session.id`
- 流式 artifact / status 的 block_type、message_id、event_id、sequence、source 改为输出到 `metadata.shared.stream`
- token usage 改为输出到 `metadata.shared.usage`
- interrupt 共享字段改为输出到 `metadata.shared.interrupt`
- `metadata.codex.*` 收敛为 provider-private raw/debug 信息，不再作为主消费链路依赖

### 3. JSON-RPC 扩展对齐
- session list / history 结果补齐 `metadata.shared.session`
- interrupt callback 方法名切换为：
  - `a2a.interrupt.permission.reply`
  - `a2a.interrupt.question.reply`
  - `a2a.interrupt.question.reject`
- session control / interrupt callback 的目录参数统一收敛到 `metadata.codex.directory`

### 4. 文档与测试
- README 与 `docs/guide.md` 全量切换到共享契约说明与示例
- 更新 Agent Card、session binding、streaming output、session extension、directory validation、session ownership 等测试

## 回归验证
- `uv run pre-commit run --all-files`
- `uv run pytest`
- 结果：`83 passed`

## 审查备注
- 本 PR 完成 `#22` 的共享契约收敛目标
- 身份注入未闭环的问题仍由 `#10` 跟踪，因此本 PR 使用 `Relates to #10`，不关闭该 issue
