### PR TITLE
[bug] 补齐 interrupt callback 生命周期与类型校验

### DIFF
--- a/src/codex_a2a_serve/agent.py
+++ b/src/codex_a2a_serve/agent.py
@@ -720,6 +720,16 @@ class OpencodeAgentExecutor(AgentExecutor):
     async def release_session_claim(self, *, identity: str, session_id: str) -> None:
         await self._release_preferred_session_claim(identity=identity, session_id=session_id)
 
+    async def session_owner_matches(self, *, identity: str, session_id: str) -> bool | None:
+        async with self._lock:
+            owner = self._session_owners.get(session_id)
+            if owner:
+                return owner == identity
+            pending_owner = self._pending_session_claims.get(session_id)
+            if pending_owner:
+                return pending_owner == identity
+        return None
+
     def resolve_directory(self, requested: str | None) -> str | None:
         return self._resolve_and_validate_directory(requested)
 

--- a/src/codex_a2a_serve/app.py
+++ b/src/codex_a2a_serve/app.py
@@ -346,7 +346,10 @@ def create_app(settings: Settings) -> FastAPI:
         session_claim=executor.claim_session,
         session_claim_finalize=executor.finalize_session_claim,
         session_claim_release=executor.release_session_claim,
+        session_owner_matcher=executor.session_owner_matches,
     ).build(title=settings.a2a_title, version=settings.a2a_version, lifespan=lifespan)
+    app.state.codex_client = client
+    app.state.codex_executor = executor
 
     rest_adapter = RESTAdapter(
         agent_card=agent_card,

--- a/src/codex_a2a_serve/codex_client.py
+++ b/src/codex_a2a_serve/codex_client.py
@@ -7,6 +7,7 @@ import logging
 import os
 import shlex
 import shutil
+import time
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 from typing import Any
@@ -20,6 +21,7 @@ _DEFAULT_CLIENT_NAME = "codex_a2a_serve"
 _DEFAULT_CLIENT_TITLE = "Codex A2A Serve"
 _DEFAULT_CLIENT_VERSION = "0.1.0"
 _EVENT_QUEUE_MAXSIZE = 2048
+_INTERRUPT_REQUEST_TTL_SECONDS = 3600
 
 
 @dataclass(frozen=True)
@@ -37,10 +39,35 @@ class CodexRPCError(RuntimeError):
         self.data = data
 
 
+class InterruptRequestError(RuntimeError):
+    def __init__(
+        self,
+        *,
+        error_type: str,
+        request_id: str,
+        expected_interrupt_type: str | None = None,
+        actual_interrupt_type: str | None = None,
+    ) -> None:
+        super().__init__(error_type)
+        self.error_type = error_type
+        self.request_id = request_id
+        self.expected_interrupt_type = expected_interrupt_type
+        self.actual_interrupt_type = actual_interrupt_type
+
+
+@dataclass(frozen=True)
+class InterruptRequestBinding:
+    request_id: str
+    interrupt_type: str
+    session_id: str
+    created_at: float
+    provider_method: str
+
+
 @dataclass
-class _PendingServerRequest:
-    method: str
-    request_id: str | int
+class _PendingInterruptRequest:
+    binding: InterruptRequestBinding
+    rpc_request_id: str | int
     params: dict[str, Any]
 
 
@@ -85,7 +112,7 @@ class OpencodeClient:
         self._initialized = False
         self._next_request_id = 1
         self._pending_requests: dict[str, asyncio.Future[Any]] = {}
-        self._pending_server_requests: dict[str, _PendingServerRequest] = {}
+        self._pending_server_requests: dict[str, _PendingInterruptRequest] = {}
         self._event_subscribers: set[asyncio.Queue[dict[str, Any]]] = set()
         self._turn_trackers: dict[tuple[str, str], _TurnTracker] = {}
 
@@ -488,10 +515,18 @@ class OpencodeClient:
             "applyPatchApproval",
             "execCommandApproval",
         }:
-            self._pending_server_requests[request_key] = _PendingServerRequest(
-                method=method, request_id=request_id, params=params
-            )
             session_id = str(params.get("threadId") or params.get("conversationId") or "").strip()
+            self._pending_server_requests[request_key] = _PendingInterruptRequest(
+                binding=InterruptRequestBinding(
+                    request_id=request_key,
+                    interrupt_type="permission",
+                    session_id=session_id,
+                    created_at=time.monotonic(),
+                    provider_method=method,
+                ),
+                rpc_request_id=request_id,
+                params=params,
+            )
             await self._enqueue_stream_event(
                 {
                     "type": "permission.asked",
@@ -508,10 +543,18 @@ class OpencodeClient:
             return
 
         if method == "item/tool/requestUserInput":
-            self._pending_server_requests[request_key] = _PendingServerRequest(
-                method=method, request_id=request_id, params=params
+            session_id = str(params.get("threadId") or params.get("conversationId") or "").strip()
+            self._pending_server_requests[request_key] = _PendingInterruptRequest(
+                binding=InterruptRequestBinding(
+                    request_id=request_key,
+                    interrupt_type="question",
+                    session_id=session_id,
+                    created_at=time.monotonic(),
+                    provider_method=method,
+                ),
+                rpc_request_id=request_id,
+                params=params,
             )
-            session_id = str(params.get("threadId") or "").strip()
             questions = params.get("questions")
             await self._enqueue_stream_event(
                 {
@@ -787,18 +830,76 @@ class OpencodeClient:
             "raw": result,
         }
 
-    async def _reply_to_server_request(self, request_id: str, result: dict[str, Any]) -> None:
-        pending = self._pending_server_requests.get(request_id)
-        if not pending:
-            raise RuntimeError(f"interrupt request not found: {request_id}")
-        await self._send_json_message({"id": pending.request_id, "result": result})
+    def _interrupt_request_status(
+        self,
+        binding: InterruptRequestBinding,
+    ) -> str:
+        expires_at = binding.created_at + float(_INTERRUPT_REQUEST_TTL_SECONDS)
+        if expires_at <= time.monotonic():
+            return "expired"
+        return "active"
 
-        session_id = str(
-            pending.params.get("threadId") or pending.params.get("conversationId") or ""
-        ).strip()
+    def resolve_interrupt_request(
+        self, request_id: str
+    ) -> tuple[str, InterruptRequestBinding | None]:
+        request_key = request_id.strip()
+        pending = self._pending_server_requests.get(request_key)
+        if pending is None:
+            return "missing", None
+        status = self._interrupt_request_status(pending.binding)
+        if status == "expired":
+            self._pending_server_requests.pop(request_key, None)
+            return status, pending.binding
+        return status, pending.binding
+
+    def discard_interrupt_request(self, request_id: str) -> None:
+        self._pending_server_requests.pop(request_id.strip(), None)
+
+    def _require_pending_interrupt_request(
+        self,
+        request_id: str,
+        *,
+        expected_interrupt_type: str,
+    ) -> _PendingInterruptRequest:
+        request_key = request_id.strip()
+        status, binding = self.resolve_interrupt_request(request_key)
+        if status == "missing":
+            raise InterruptRequestError(
+                error_type="INTERRUPT_REQUEST_NOT_FOUND",
+                request_id=request_key,
+            )
+        if status == "expired" or binding is None:
+            raise InterruptRequestError(
+                error_type="INTERRUPT_REQUEST_EXPIRED",
+                request_id=request_key,
+            )
+        if binding.interrupt_type != expected_interrupt_type:
+            raise InterruptRequestError(
+                error_type="INTERRUPT_TYPE_MISMATCH",
+                request_id=request_key,
+                expected_interrupt_type=expected_interrupt_type,
+                actual_interrupt_type=binding.interrupt_type,
+            )
+        pending = self._pending_server_requests.get(request_key)
+        if pending is None:
+            raise InterruptRequestError(
+                error_type="INTERRUPT_REQUEST_NOT_FOUND",
+                request_id=request_key,
+            )
+        return pending
+
+    async def _reply_to_server_request(
+        self,
+        *,
+        request_id: str,
+        pending: _PendingInterruptRequest,
+        result: dict[str, Any],
+    ) -> None:
+        await self._send_json_message({"id": pending.rpc_request_id, "result": result})
+
         resolved_type = (
             "question.replied"
-            if pending.method == "item/tool/requestUserInput"
+            if pending.binding.interrupt_type == "question"
             else "permission.replied"
         )
         await self._enqueue_stream_event(
@@ -807,11 +908,11 @@ class OpencodeClient:
                 "properties": {
                     "id": request_id,
                     "requestID": request_id,
-                    "sessionID": session_id,
+                    "sessionID": pending.binding.session_id,
                 },
             }
         )
-        self._pending_server_requests.pop(request_id, None)
+        self.discard_interrupt_request(request_id)
 
     async def permission_reply(
         self,
@@ -823,6 +924,10 @@ class OpencodeClient:
     ) -> bool:
         del message, directory
         normalized = (reply or "").strip().lower()
+        pending = self._require_pending_interrupt_request(
+            request_id,
+            expected_interrupt_type="permission",
+        )
         decision = "decline"
         if normalized == "once":
             decision = "accept"
@@ -831,7 +936,11 @@ class OpencodeClient:
         elif normalized in {"reject", "deny"}:
             decision = "decline"
 
-        await self._reply_to_server_request(request_id, {"decision": decision})
+        await self._reply_to_server_request(
+            request_id=request_id,
+            pending=pending,
+            result={"decision": decision},
+        )
         return True
 
     async def question_reply(
@@ -842,10 +951,11 @@ class OpencodeClient:
         directory: str | None = None,
     ) -> bool:
         del directory
+        pending = self._require_pending_interrupt_request(
+            request_id,
+            expected_interrupt_type="question",
+        )
         # requestUserInput expects a dict keyed by question id.
-        pending = self._pending_server_requests.get(request_id)
-        if not pending:
-            raise RuntimeError(f"interrupt request not found: {request_id}")
         questions = pending.params.get("questions")
         answer_map: dict[str, dict[str, list[str]]] = {}
         if isinstance(questions, list):
@@ -858,7 +968,11 @@ class OpencodeClient:
                 selected = answers[index] if index < len(answers) else []
                 selected = [v for v in selected if isinstance(v, str)]
                 answer_map[qid] = {"answers": selected}
-        await self._reply_to_server_request(request_id, {"answers": answer_map})
+        await self._reply_to_server_request(
+            request_id=request_id,
+            pending=pending,
+            result={"answers": answer_map},
+        )
         return True
 
     async def question_reject(
@@ -868,23 +982,23 @@ class OpencodeClient:
         directory: str | None = None,
     ) -> bool:
         del directory
-        pending = self._pending_server_requests.get(request_id)
-        if not pending:
-            raise RuntimeError(f"interrupt request not found: {request_id}")
+        pending = self._require_pending_interrupt_request(
+            request_id,
+            expected_interrupt_type="question",
+        )
         # For requestUserInput, an empty answers map acts as reject/abort.
-        await self._send_json_message({"id": pending.request_id, "result": {"answers": {}}})
-        session_id = str(pending.params.get("threadId") or "").strip()
+        await self._send_json_message({"id": pending.rpc_request_id, "result": {"answers": {}}})
         await self._enqueue_stream_event(
             {
                 "type": "question.rejected",
                 "properties": {
                     "id": request_id,
                     "requestID": request_id,
-                    "sessionID": session_id,
+                    "sessionID": pending.binding.session_id,
                 },
             }
         )
-        self._pending_server_requests.pop(request_id, None)
+        self.discard_interrupt_request(request_id)
         return True
 
 

--- a/src/codex_a2a_serve/extension_contracts.py
+++ b/src/codex_a2a_serve/extension_contracts.py
@@ -178,15 +178,25 @@ INTERRUPT_CALLBACK_METHODS: dict[str, str] = {
 INTERRUPT_SUCCESS_RESULT_FIELDS: tuple[str, ...] = ("ok", "request_id")
 INTERRUPT_ERROR_BUSINESS_CODES: dict[str, int] = {
     "INTERRUPT_REQUEST_NOT_FOUND": -32004,
+    "INTERRUPT_REQUEST_EXPIRED": -32007,
+    "INTERRUPT_TYPE_MISMATCH": -32008,
     "UPSTREAM_UNREACHABLE": -32002,
     "UPSTREAM_HTTP_ERROR": -32003,
 }
 INTERRUPT_ERROR_TYPES: tuple[str, ...] = (
     "INTERRUPT_REQUEST_NOT_FOUND",
+    "INTERRUPT_REQUEST_EXPIRED",
+    "INTERRUPT_TYPE_MISMATCH",
     "UPSTREAM_UNREACHABLE",
     "UPSTREAM_HTTP_ERROR",
 )
-INTERRUPT_ERROR_DATA_FIELDS: tuple[str, ...] = ("type", "request_id", "upstream_status")
+INTERRUPT_ERROR_DATA_FIELDS: tuple[str, ...] = (
+    "type",
+    "request_id",
+    "expected_interrupt_type",
+    "actual_interrupt_type",
+    "upstream_status",
+)
 INTERRUPT_INVALID_PARAMS_DATA_FIELDS: tuple[str, ...] = (
     "type",
     "field",

--- a/src/codex_a2a_serve/jsonrpc_ext.py
+++ b/src/codex_a2a_serve/jsonrpc_ext.py
@@ -23,7 +23,7 @@ from fastapi.responses import JSONResponse
 from starlette.requests import Request
 from starlette.responses import Response
 
-from .codex_client import OpencodeClient
+from .codex_client import InterruptRequestBinding, InterruptRequestError, OpencodeClient
 from .extension_contracts import (
     COMMAND_ALLOWED_FIELDS,
     PROMPT_ASYNC_ALLOWED_FIELDS,
@@ -39,6 +39,8 @@ ERR_UPSTREAM_UNREACHABLE = -32002
 ERR_UPSTREAM_HTTP_ERROR = -32003
 ERR_INTERRUPT_NOT_FOUND = -32004
 ERR_UPSTREAM_PAYLOAD_ERROR = -32005
+ERR_INTERRUPT_EXPIRED = -32007
+ERR_INTERRUPT_TYPE_MISMATCH = -32008
 
 
 def _normalize_permission_reply(value: Any) -> str:
@@ -88,6 +90,12 @@ def _parse_positive_int(value: Any, *, field: str) -> int | None:
     if parsed < 1:
         raise ValueError(f"{field} must be >= 1")
     return parsed
+
+
+def _interrupt_expected_type(method: str, *, permission_method: str) -> str:
+    if method == permission_method:
+        return "permission"
+    return "question"
 
 
 class _ControlValidationError(ValueError):
@@ -283,6 +291,7 @@ class OpencodeSessionQueryJSONRPCApplication(A2AFastAPIApplication):
         session_claim=None,
         session_claim_finalize=None,
         session_claim_release=None,
+        session_owner_matcher=None,
         **kwargs: Any,
     ):
         super().__init__(*args, **kwargs)
@@ -299,6 +308,7 @@ class OpencodeSessionQueryJSONRPCApplication(A2AFastAPIApplication):
         self._session_claim = session_claim
         self._session_claim_finalize = session_claim_finalize
         self._session_claim_release = session_claim_release
+        self._session_owner_matcher = session_owner_matcher
 
     async def _handle_requests(self, request: Request) -> Response:
         # Fast path: sniff method first then either handle here or delegate.
@@ -352,7 +362,7 @@ class OpencodeSessionQueryJSONRPCApplication(A2AFastAPIApplication):
             return await self._handle_session_query_request(base_request, params)
         if base_request.method in session_control_methods:
             return await self._handle_session_control_request(base_request, params, request=request)
-        return await self._handle_interrupt_callback_request(base_request, params)
+        return await self._handle_interrupt_callback_request(base_request, params, request=request)
 
     async def _handle_session_query_request(
         self,
@@ -799,6 +809,8 @@ class OpencodeSessionQueryJSONRPCApplication(A2AFastAPIApplication):
         self,
         base_request: JSONRPCRequest,
         params: dict[str, Any],
+        *,
+        request: Request,
     ) -> Response:
         request_id = params.get("request_id")
         if not isinstance(request_id, str) or not request_id.strip():
@@ -836,6 +848,52 @@ class OpencodeSessionQueryJSONRPCApplication(A2AFastAPIApplication):
                 ),
             )
 
+        expected_interrupt_type = _interrupt_expected_type(
+            base_request.method,
+            permission_method=self._method_reply_permission,
+        )
+        interrupt_status, binding = self._codex_client.resolve_interrupt_request(request_id)
+        if interrupt_status == "missing":
+            return self._interrupt_error_response(
+                base_request.id,
+                code=ERR_INTERRUPT_NOT_FOUND,
+                message="Interrupt request not found",
+                data={
+                    "type": "INTERRUPT_REQUEST_NOT_FOUND",
+                    "request_id": request_id,
+                },
+            )
+        if interrupt_status == "expired":
+            return self._interrupt_error_response(
+                base_request.id,
+                code=ERR_INTERRUPT_EXPIRED,
+                message="Interrupt request expired",
+                data={
+                    "type": "INTERRUPT_REQUEST_EXPIRED",
+                    "request_id": request_id,
+                },
+            )
+        if binding is not None and binding.interrupt_type != expected_interrupt_type:
+            return self._interrupt_error_response(
+                base_request.id,
+                code=ERR_INTERRUPT_TYPE_MISMATCH,
+                message="Interrupt callback type mismatch",
+                data={
+                    "type": "INTERRUPT_TYPE_MISMATCH",
+                    "request_id": request_id,
+                    "expected_interrupt_type": expected_interrupt_type,
+                    "actual_interrupt_type": binding.interrupt_type,
+                },
+            )
+        owner_error = await self._validate_interrupt_owner(
+            request=request,
+            binding=binding,
+            request_id=request_id,
+            response_id=base_request.id,
+        )
+        if owner_error is not None:
+            return owner_error
+
         try:
             if base_request.method == self._method_reply_permission:
                 reply = _normalize_permission_reply(params.get("reply"))
@@ -871,6 +929,9 @@ class OpencodeSessionQueryJSONRPCApplication(A2AFastAPIApplication):
                     "ok": True,
                     "request_id": request_id,
                 }
+            self._codex_client.discard_interrupt_request(request_id)
+        except InterruptRequestError as exc:
+            return self._interrupt_error_from_exception(base_request.id, exc)
         except ValueError as exc:
             return self._generate_error_response(
                 base_request.id,
@@ -884,16 +945,15 @@ class OpencodeSessionQueryJSONRPCApplication(A2AFastAPIApplication):
         except httpx.HTTPStatusError as exc:
             upstream_status = exc.response.status_code
             if upstream_status == 404:
-                return self._generate_error_response(
+                self._codex_client.discard_interrupt_request(request_id)
+                return self._interrupt_error_response(
                     base_request.id,
-                    JSONRPCError(
-                        code=ERR_INTERRUPT_NOT_FOUND,
-                        message="Interrupt request not found",
-                        data={
-                            "type": "INTERRUPT_REQUEST_NOT_FOUND",
-                            "request_id": request_id,
-                        },
-                    ),
+                    code=ERR_INTERRUPT_NOT_FOUND,
+                    message="Interrupt request not found",
+                    data={
+                        "type": "INTERRUPT_REQUEST_NOT_FOUND",
+                        "request_id": request_id,
+                    },
                 )
             return self._generate_error_response(
                 base_request.id,
@@ -926,6 +986,89 @@ class OpencodeSessionQueryJSONRPCApplication(A2AFastAPIApplication):
         if base_request.id is None:
             return Response(status_code=204)
         return self._jsonrpc_success_response(base_request.id, result)
+
+    async def _validate_interrupt_owner(
+        self,
+        *,
+        request: Request,
+        binding: InterruptRequestBinding | None,
+        request_id: str,
+        response_id: str | int | None,
+    ) -> Response | None:
+        identity = getattr(request.state, "user_identity", None)
+        if not isinstance(identity, str) or not identity.strip():
+            return None
+        if binding is None or not binding.session_id or self._session_owner_matcher is None:
+            return None
+        matches = await self._session_owner_matcher(
+            identity=identity.strip(),
+            session_id=binding.session_id,
+        )
+        if matches is False:
+            return self._interrupt_error_response(
+                response_id,
+                code=ERR_INTERRUPT_NOT_FOUND,
+                message="Interrupt request not found",
+                data={
+                    "type": "INTERRUPT_REQUEST_NOT_FOUND",
+                    "request_id": request_id,
+                },
+            )
+        return None
+
+    def _interrupt_error_from_exception(
+        self,
+        request_id: str | int | None,
+        exc: InterruptRequestError,
+    ) -> JSONResponse:
+        if exc.error_type == "INTERRUPT_REQUEST_EXPIRED":
+            return self._interrupt_error_response(
+                request_id,
+                code=ERR_INTERRUPT_EXPIRED,
+                message="Interrupt request expired",
+                data={
+                    "type": exc.error_type,
+                    "request_id": exc.request_id,
+                },
+            )
+        if exc.error_type == "INTERRUPT_TYPE_MISMATCH":
+            return self._interrupt_error_response(
+                request_id,
+                code=ERR_INTERRUPT_TYPE_MISMATCH,
+                message="Interrupt callback type mismatch",
+                data={
+                    "type": exc.error_type,
+                    "request_id": exc.request_id,
+                    "expected_interrupt_type": exc.expected_interrupt_type,
+                    "actual_interrupt_type": exc.actual_interrupt_type,
+                },
+            )
+        return self._interrupt_error_response(
+            request_id,
+            code=ERR_INTERRUPT_NOT_FOUND,
+            message="Interrupt request not found",
+            data={
+                "type": "INTERRUPT_REQUEST_NOT_FOUND",
+                "request_id": exc.request_id,
+            },
+        )
+
+    def _interrupt_error_response(
+        self,
+        request_id: str | int | None,
+        *,
+        code: int,
+        message: str,
+        data: dict[str, Any],
+    ) -> JSONResponse:
+        return self._generate_error_response(
+            request_id,
+            JSONRPCError(
+                code=code,
+                message=message,
+                data=data,
+            ),
+        )
 
     def _jsonrpc_success_response(self, request_id: str | int, result: Any) -> JSONResponse:
         return JSONResponse(

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -7,7 +7,7 @@ from a2a.server.agent_execution import RequestContext
 from a2a.server.context import ServerCallContext
 from a2a.types import Message, MessageSendParams, Role, TextPart
 
-from codex_a2a_serve.codex_client import OpencodeMessage
+from codex_a2a_serve.codex_client import InterruptRequestBinding, OpencodeMessage
 from codex_a2a_serve.config import Settings
 
 
@@ -165,6 +165,10 @@ class DummySessionQueryOpencodeClient:
         self.last_prompt_async: dict[str, Any] | None = None
         self.last_command: dict[str, Any] | None = None
         self.last_shell: dict[str, Any] | None = None
+        self.permission_reply_calls: list[dict[str, Any]] = []
+        self.question_reply_calls: list[dict[str, Any]] = []
+        self.question_reject_calls: list[dict[str, Any]] = []
+        self._interrupt_requests: dict[str, InterruptRequestBinding] = {}
 
     async def close(self) -> None:
         return None
@@ -237,7 +241,14 @@ class DummySessionQueryOpencodeClient:
         message: str | None = None,
         directory: str | None = None,
     ) -> bool:
-        del request_id, reply, message, directory
+        self.permission_reply_calls.append(
+            {
+                "request_id": request_id,
+                "reply": reply,
+                "message": message,
+                "directory": directory,
+            }
+        )
         return True
 
     async def question_reply(
@@ -247,7 +258,9 @@ class DummySessionQueryOpencodeClient:
         answers: list[list[str]],
         directory: str | None = None,
     ) -> bool:
-        del request_id, answers, directory
+        self.question_reply_calls.append(
+            {"request_id": request_id, "answers": answers, "directory": directory}
+        )
         return True
 
     async def question_reject(
@@ -256,5 +269,44 @@ class DummySessionQueryOpencodeClient:
         *,
         directory: str | None = None,
     ) -> bool:
-        del request_id, directory
+        self.question_reject_calls.append({"request_id": request_id, "directory": directory})
         return True
+
+    def prime_interrupt_request(
+        self,
+        request_id: str,
+        *,
+        interrupt_type: str,
+        session_id: str = "ses-1",
+        created_at: float = 0.0,
+        provider_method: str | None = None,
+    ) -> None:
+        resolved_method = provider_method
+        if resolved_method is None:
+            resolved_method = (
+                "item/tool/requestUserInput"
+                if interrupt_type == "question"
+                else "item/commandExecution/requestApproval"
+            )
+        self._interrupt_requests[request_id] = InterruptRequestBinding(
+            request_id=request_id,
+            interrupt_type=interrupt_type,
+            session_id=session_id,
+            created_at=created_at,
+            provider_method=resolved_method,
+        )
+
+    def resolve_interrupt_request(
+        self,
+        request_id: str,
+    ) -> tuple[str, InterruptRequestBinding | None]:
+        binding = self._interrupt_requests.get(request_id)
+        if binding is None:
+            return "missing", None
+        if binding.created_at == 0.0:
+            return "active", binding
+        self._interrupt_requests.pop(request_id, None)
+        return "expired", binding
+
+    def discard_interrupt_request(self, request_id: str) -> None:
+        self._interrupt_requests.pop(request_id, None)

--- a/tests/test_agent_card.py
+++ b/tests/test_agent_card.py
@@ -76,6 +76,10 @@ def test_agent_card_injects_deployment_context_into_extensions() -> None:
     assert interrupt.params["request_id_field"] == "metadata.shared.interrupt.request_id"
     assert interrupt.params["supported_metadata"] == ["codex.directory"]
     assert interrupt.params["provider_private_metadata"] == ["codex.directory"]
+    assert interrupt.params["errors"]["business_codes"]["INTERRUPT_REQUEST_EXPIRED"] == -32007
+    assert interrupt.params["errors"]["business_codes"]["INTERRUPT_TYPE_MISMATCH"] == -32008
+    assert "expected_interrupt_type" in interrupt.params["errors"]["error_data_fields"]
+    assert "actual_interrupt_type" in interrupt.params["errors"]["error_data_fields"]
 
 
 def test_agent_card_chat_examples_include_project_hint_when_configured() -> None:

--- a/tests/test_opencode_client_params.py
+++ b/tests/test_opencode_client_params.py
@@ -1,8 +1,13 @@
 import asyncio
+import time
 
 import pytest
 
-from codex_a2a_serve.codex_client import OpencodeClient, _PendingServerRequest
+from codex_a2a_serve.codex_client import (
+    InterruptRequestBinding,
+    OpencodeClient,
+    _PendingInterruptRequest,
+)
 from tests.helpers import make_settings
 
 
@@ -43,9 +48,15 @@ async def test_list_calls_use_expected_rpc_params() -> None:
 @pytest.mark.asyncio
 async def test_permission_reply_maps_to_codex_decision() -> None:
     client = OpencodeClient(make_settings(a2a_bearer_token="t-1", codex_timeout=1.0))
-    client._pending_server_requests["100"] = _PendingServerRequest(
-        method="item/commandExecution/requestApproval",
-        request_id=100,
+    client._pending_server_requests["100"] = _PendingInterruptRequest(
+        binding=InterruptRequestBinding(
+            request_id="100",
+            interrupt_type="permission",
+            session_id="thr-1",
+            created_at=time.monotonic(),
+            provider_method="item/commandExecution/requestApproval",
+        ),
+        rpc_request_id=100,
         params={"threadId": "thr-1"},
     )
 
@@ -73,9 +84,15 @@ async def test_permission_reply_maps_to_codex_decision() -> None:
 @pytest.mark.asyncio
 async def test_question_reply_builds_answer_map() -> None:
     client = OpencodeClient(make_settings(a2a_bearer_token="t-1", codex_timeout=1.0))
-    client._pending_server_requests["200"] = _PendingServerRequest(
-        method="item/tool/requestUserInput",
-        request_id=200,
+    client._pending_server_requests["200"] = _PendingInterruptRequest(
+        binding=InterruptRequestBinding(
+            request_id="200",
+            interrupt_type="question",
+            session_id="thr-2",
+            created_at=time.monotonic(),
+            provider_method="item/tool/requestUserInput",
+        ),
+        rpc_request_id=200,
         params={
             "threadId": "thr-2",
             "questions": [

--- a/tests/test_opencode_session_extension.py
+++ b/tests/test_opencode_session_extension.py
@@ -699,32 +699,10 @@ async def test_session_control_rejects_invalid_metadata_directory(monkeypatch):
 async def test_interrupt_callback_extension_permission_reply(monkeypatch):
     import codex_a2a_serve.app as app_module
 
-    class InterruptClient(DummyOpencodeClient):
-        def __init__(self, _settings: Settings) -> None:
-            super().__init__(_settings)
-            self.permission_reply_calls: list[dict] = []
-
-        async def permission_reply(
-            self,
-            request_id: str,
-            *,
-            reply: str,
-            message: str | None = None,
-            directory: str | None = None,
-        ) -> bool:
-            self.permission_reply_calls.append(
-                {
-                    "request_id": request_id,
-                    "reply": reply,
-                    "message": message,
-                    "directory": directory,
-                }
-            )
-            return True
-
-    dummy = InterruptClient(
+    dummy = DummyOpencodeClient(
         make_settings(a2a_bearer_token="t-1", a2a_log_payloads=False, **_BASE_SETTINGS)
     )
+    dummy.prime_interrupt_request("perm-1", interrupt_type="permission")
     monkeypatch.setattr(app_module, "OpencodeClient", lambda _settings: dummy)
     app = app_module.create_app(
         make_settings(a2a_bearer_token="t-1", a2a_log_payloads=False, **_BASE_SETTINGS)
@@ -757,6 +735,8 @@ async def test_interrupt_callback_extension_permission_reply(monkeypatch):
         assert dummy.permission_reply_calls[0]["request_id"] == "perm-1"
         assert dummy.permission_reply_calls[0]["reply"] == "once"
         assert dummy.permission_reply_calls[0]["directory"] == "/workspace"
+        status, _ = dummy.resolve_interrupt_request("perm-1")
+        assert status == "missing"
 
 
 @pytest.mark.asyncio
@@ -792,36 +772,11 @@ async def test_interrupt_callback_extension_rejects_legacy_permission_fields(mon
 async def test_interrupt_callback_extension_question_reply_and_reject(monkeypatch):
     import codex_a2a_serve.app as app_module
 
-    class InterruptClient(DummyOpencodeClient):
-        def __init__(self, _settings: Settings) -> None:
-            super().__init__(_settings)
-            self.question_reply_calls: list[dict] = []
-            self.question_reject_calls: list[dict] = []
-
-        async def question_reply(
-            self,
-            request_id: str,
-            *,
-            answers: list[list[str]],
-            directory: str | None = None,
-        ) -> bool:
-            self.question_reply_calls.append(
-                {"request_id": request_id, "answers": answers, "directory": directory}
-            )
-            return True
-
-        async def question_reject(
-            self,
-            request_id: str,
-            *,
-            directory: str | None = None,
-        ) -> bool:
-            self.question_reject_calls.append({"request_id": request_id, "directory": directory})
-            return True
-
-    dummy = InterruptClient(
+    dummy = DummyOpencodeClient(
         make_settings(a2a_bearer_token="t-1", a2a_log_payloads=False, **_BASE_SETTINGS)
     )
+    dummy.prime_interrupt_request("q-1", interrupt_type="question")
+    dummy.prime_interrupt_request("q-2", interrupt_type="question")
     monkeypatch.setattr(app_module, "OpencodeClient", lambda _settings: dummy)
     app = app_module.create_app(
         make_settings(a2a_bearer_token="t-1", a2a_log_payloads=False, **_BASE_SETTINGS)
@@ -858,6 +813,8 @@ async def test_interrupt_callback_extension_question_reply_and_reject(monkeypatc
         reject_payload = reject_resp.json()
         assert reject_payload["result"]["ok"] is True
         assert dummy.question_reject_calls[0]["request_id"] == "q-2"
+        assert dummy.resolve_interrupt_request("q-1")[0] == "missing"
+        assert dummy.resolve_interrupt_request("q-2")[0] == "missing"
 
 
 @pytest.mark.asyncio
@@ -878,7 +835,11 @@ async def test_interrupt_callback_extension_maps_404_to_interrupt_not_found(monk
             response = httpx.Response(404, request=request)
             raise httpx.HTTPStatusError("Not Found", request=request, response=response)
 
-    monkeypatch.setattr(app_module, "OpencodeClient", NotFoundInterruptClient)
+    dummy = NotFoundInterruptClient(
+        make_settings(a2a_bearer_token="t-1", a2a_log_payloads=False, **_BASE_SETTINGS)
+    )
+    dummy.prime_interrupt_request("perm-404", interrupt_type="permission")
+    monkeypatch.setattr(app_module, "OpencodeClient", lambda _settings: dummy)
     app = app_module.create_app(
         make_settings(a2a_bearer_token="t-1", a2a_log_payloads=False, **_BASE_SETTINGS)
     )
@@ -899,3 +860,147 @@ async def test_interrupt_callback_extension_maps_404_to_interrupt_not_found(monk
         payload = resp.json()
         assert payload["error"]["code"] == -32004
         assert payload["error"]["data"]["type"] == "INTERRUPT_REQUEST_NOT_FOUND"
+        assert dummy.resolve_interrupt_request("perm-404")[0] == "missing"
+
+
+@pytest.mark.asyncio
+async def test_interrupt_callback_extension_returns_not_found_for_missing_local_request(
+    monkeypatch,
+):
+    import codex_a2a_serve.app as app_module
+
+    dummy = DummyOpencodeClient(
+        make_settings(a2a_bearer_token="t-1", a2a_log_payloads=False, **_BASE_SETTINGS)
+    )
+    monkeypatch.setattr(app_module, "OpencodeClient", lambda _settings: dummy)
+    app = app_module.create_app(
+        make_settings(a2a_bearer_token="t-1", a2a_log_payloads=False, **_BASE_SETTINGS)
+    )
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        headers = {"Authorization": "Bearer t-1"}
+        resp = await client.post(
+            "/",
+            headers=headers,
+            json={
+                "jsonrpc": "2.0",
+                "id": 15,
+                "method": "a2a.interrupt.permission.reply",
+                "params": {"request_id": "perm-missing", "reply": "reject"},
+            },
+        )
+        payload = resp.json()
+        assert payload["error"]["code"] == -32004
+        assert payload["error"]["data"]["type"] == "INTERRUPT_REQUEST_NOT_FOUND"
+        assert dummy.permission_reply_calls == []
+
+
+@pytest.mark.asyncio
+async def test_interrupt_callback_extension_returns_expired_for_stale_request(monkeypatch):
+    import codex_a2a_serve.app as app_module
+
+    dummy = DummyOpencodeClient(
+        make_settings(a2a_bearer_token="t-1", a2a_log_payloads=False, **_BASE_SETTINGS)
+    )
+    dummy.prime_interrupt_request("perm-expired", interrupt_type="permission", created_at=1.0)
+    monkeypatch.setattr(app_module, "OpencodeClient", lambda _settings: dummy)
+    app = app_module.create_app(
+        make_settings(a2a_bearer_token="t-1", a2a_log_payloads=False, **_BASE_SETTINGS)
+    )
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        headers = {"Authorization": "Bearer t-1"}
+        resp = await client.post(
+            "/",
+            headers=headers,
+            json={
+                "jsonrpc": "2.0",
+                "id": 16,
+                "method": "a2a.interrupt.permission.reply",
+                "params": {"request_id": "perm-expired", "reply": "reject"},
+            },
+        )
+        payload = resp.json()
+        assert payload["error"]["code"] == -32007
+        assert payload["error"]["data"]["type"] == "INTERRUPT_REQUEST_EXPIRED"
+        assert dummy.resolve_interrupt_request("perm-expired")[0] == "missing"
+
+
+@pytest.mark.asyncio
+async def test_interrupt_callback_extension_rejects_interrupt_type_mismatch(monkeypatch):
+    import codex_a2a_serve.app as app_module
+
+    dummy = DummyOpencodeClient(
+        make_settings(a2a_bearer_token="t-1", a2a_log_payloads=False, **_BASE_SETTINGS)
+    )
+    dummy.prime_interrupt_request("perm-type", interrupt_type="permission")
+    monkeypatch.setattr(app_module, "OpencodeClient", lambda _settings: dummy)
+    app = app_module.create_app(
+        make_settings(a2a_bearer_token="t-1", a2a_log_payloads=False, **_BASE_SETTINGS)
+    )
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        headers = {"Authorization": "Bearer t-1"}
+        resp = await client.post(
+            "/",
+            headers=headers,
+            json={
+                "jsonrpc": "2.0",
+                "id": 17,
+                "method": "a2a.interrupt.question.reply",
+                "params": {"request_id": "perm-type", "answers": [["A"]]},
+            },
+        )
+        payload = resp.json()
+        assert payload["error"]["code"] == -32008
+        assert payload["error"]["data"]["type"] == "INTERRUPT_TYPE_MISMATCH"
+        assert payload["error"]["data"]["expected_interrupt_type"] == "question"
+        assert payload["error"]["data"]["actual_interrupt_type"] == "permission"
+        assert dummy.question_reply_calls == []
+        assert dummy.resolve_interrupt_request("perm-type")[0] == "active"
+
+
+@pytest.mark.asyncio
+async def test_interrupt_callback_extension_masks_owner_mismatch_as_not_found(monkeypatch):
+    import codex_a2a_serve.app as app_module
+
+    dummy = DummyOpencodeClient(
+        make_settings(a2a_bearer_token="t-1", a2a_log_payloads=False, **_BASE_SETTINGS)
+    )
+    dummy.prime_interrupt_request("perm-owned", interrupt_type="permission", session_id="ses-owned")
+    monkeypatch.setattr(app_module, "OpencodeClient", lambda _settings: dummy)
+    app = app_module.create_app(
+        make_settings(a2a_bearer_token="t-1", a2a_log_payloads=False, **_BASE_SETTINGS)
+    )
+
+    @app.middleware("http")
+    async def inject_identity(request, call_next):  # noqa: ANN001
+        request.state.user_identity = "user-1"
+        return await call_next(request)
+
+    await app.state.codex_executor.finalize_session_claim(
+        identity="other-user",
+        session_id="ses-owned",
+    )
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        headers = {"Authorization": "Bearer t-1"}
+        resp = await client.post(
+            "/",
+            headers=headers,
+            json={
+                "jsonrpc": "2.0",
+                "id": 18,
+                "method": "a2a.interrupt.permission.reply",
+                "params": {"request_id": "perm-owned", "reply": "once"},
+            },
+        )
+        payload = resp.json()
+        assert payload["error"]["code"] == -32004
+        assert payload["error"]["data"]["type"] == "INTERRUPT_REQUEST_NOT_FOUND"
+        assert dummy.permission_reply_calls == []
+        assert dummy.resolve_interrupt_request("perm-owned")[0] == "active"


### PR DESCRIPTION
## 关联

- Relates to #26
- 基于 `feat/issue-25-tool-call-datapart` 的 stacked PR

## 变更说明

- 在 `codex_client.py` 增加 interrupt request registry 查询与清理能力，补齐 `active / expired / missing` 生命周期判定
- 在 `jsonrpc_ext.py` 的 interrupt callback 入口增加前置校验：`not found`、`expired`、`type mismatch`
- 新增基于 session owner 的 best-effort 归属校验；当运行时存在 identity 且 owner 不匹配时按 `NOT_FOUND` 处理
- 更新 Agent Card interrupt 扩展契约，补齐 `INTERRUPT_REQUEST_EXPIRED` 与 `INTERRUPT_TYPE_MISMATCH` 错误类型及 data 字段说明
- 补充回归测试，覆盖成功清理、404 清理、missing、expired、type mismatch、owner mismatch masking

## 验证

- `uv run pre-commit run --all-files`
- `uv run pytest`
