### PR TITLE
feat: inherit local codex config in light deploy

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -23,6 +23,8 @@ navigation, start from [README.md](../README.md) instead.
 - `CODEX_APP_SERVER_LISTEN`: Codex app-server listen target, default `stdio://`
 - `CODEX_MODEL`: default model passed to `thread/start`, default `gpt-5.1-codex`
 - `CODEX_MODEL_ID`: per-turn model override passed to `turn/start` (optional)
+- `CODEX_MODEL_REASONING_EFFORT`: explicit reasoning effort override passed to
+  Codex CLI app-server via `-c model_reasoning_effort=...` (optional)
 - `CODEX_DIRECTORY`: default Codex working directory (optional)
 - `CODEX_PROVIDER_ID`: deployment metadata only (optional)
 - `CODEX_AGENT`: deployment metadata only (optional)
@@ -60,6 +62,22 @@ navigation, start from [README.md](../README.md) instead.
 
 Compatibility note:
 - Legacy `OPENCODE_*` keys are accepted as fallback aliases for the corresponding `CODEX_*` settings.
+
+## Lightweight Deploy Inheritance
+
+- `scripts/deploy_light.sh` is designed for local/interactive quick start.
+- It preserves already-exported `CODEX_*` shell variables when present.
+- By default it best-effort reads `~/.codex/config.toml` and inherits:
+  - `model`
+  - `model_reasoning_effort`
+- Explicit instance parameters still win over shell / local Codex config:
+  - `codex_model=...`
+  - `codex_model_id=...`
+  - `codex_model_reasoning_effort=...`
+- Before launch, the script prints a Codex config summary so the effective
+  model / reasoning combination is visible.
+- Known high-risk combinations are blocked before startup. Currently this
+  includes `reasoning_effort=xhigh` together with `gpt-5.1-codex*`.
 
 ## Service Behavior
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -20,6 +20,11 @@ overview, runtime contracts, or deployment rationale in detail.
   create/update one long-running systemd instance.
 - [`scripts/deploy_light.sh`](./deploy_light.sh):
   lightweight background runner on current user (no system user/workspace setup).
+  It preserves exported `CODEX_*` shell variables, inherits local
+  `~/.codex/config.toml` by default, supports explicit instance overrides such
+  as `codex_model=...` and
+  `codex_model_reasoning_effort=...`, and blocks known-invalid model /
+  reasoning combinations before launch.
 - [`scripts/start_services.sh`](./start_services.sh):
   local foreground runner without systemd.
 - [`scripts/uninstall.sh`](./uninstall.sh):

--- a/scripts/deploy_light.sh
+++ b/scripts/deploy_light.sh
@@ -3,7 +3,7 @@
 # No system users, no workspace scaffolding, no permission management.
 #
 # Usage:
-#   A2A_BEARER_TOKEN=<token> ./scripts/deploy_light.sh start workdir=/abs/path [instance=dev] [a2a_host=127.0.0.1] [a2a_port=8000] [a2a_public_url=http://127.0.0.1:8000] [a2a_log_level=INFO] [a2a_streaming=true] [a2a_log_payloads=false] [a2a_log_body_limit=0] [codex_cli_bin=codex] [codex_model=<id>] [codex_model_id=<id>] [codex_provider_id=<id>] [codex_timeout=120] [codex_timeout_stream=300] [log_root=./logs/light] [pid_root=./run/light]
+#   A2A_BEARER_TOKEN=<token> ./scripts/deploy_light.sh start workdir=/abs/path [instance=dev] [a2a_host=127.0.0.1] [a2a_port=8000] [a2a_public_url=http://127.0.0.1:8000] [a2a_log_level=INFO] [a2a_streaming=true] [a2a_log_payloads=false] [a2a_log_body_limit=0] [codex_cli_bin=codex] [codex_model=<id>] [codex_model_id=<id>] [codex_model_reasoning_effort=<low|medium|high|xhigh>] [codex_provider_id=<id>] [codex_timeout=120] [codex_timeout_stream=300] [log_root=./logs/light] [pid_root=./run/light]
 #   ./scripts/deploy_light.sh stop [instance=dev] [pid_root=./run/light]
 #   ./scripts/deploy_light.sh status [instance=dev] [pid_root=./run/light]
 #   A2A_BEARER_TOKEN=<token> ./scripts/deploy_light.sh restart workdir=/abs/path [instance=dev]
@@ -26,19 +26,25 @@ A2A_LOG_LEVEL="INFO"
 A2A_STREAMING="true"
 A2A_LOG_PAYLOADS="false"
 A2A_LOG_BODY_LIMIT="0"
-CODEX_CLI_BIN="codex"
-CODEX_MODEL=""
-CODEX_MODEL_ID=""
-CODEX_PROVIDER_ID=""
-CODEX_TIMEOUT=""
-CODEX_TIMEOUT_STREAM=""
+CODEX_CLI_BIN="${CODEX_CLI_BIN:-codex}"
+CODEX_MODEL="${CODEX_MODEL:-}"
+CODEX_MODEL_ID="${CODEX_MODEL_ID:-}"
+CODEX_MODEL_REASONING_EFFORT="${CODEX_MODEL_REASONING_EFFORT:-}"
+CODEX_PROVIDER_ID="${CODEX_PROVIDER_ID:-}"
+CODEX_TIMEOUT="${CODEX_TIMEOUT:-}"
+CODEX_TIMEOUT_STREAM="${CODEX_TIMEOUT_STREAM:-}"
 LOG_ROOT="${ROOT_DIR}/logs/light"
 PID_ROOT="${ROOT_DIR}/run/light"
+LOCAL_CODEX_MODEL=""
+LOCAL_CODEX_MODEL_REASONING_EFFORT=""
+EFFECTIVE_CODEX_MODEL=""
+EFFECTIVE_CODEX_REASONING_EFFORT=""
+SERVICE_DEFAULT_CODEX_MODEL="gpt-5.1-codex"
 
 usage() {
   cat <<'USAGE'
 Usage:
-  A2A_BEARER_TOKEN=<token> ./scripts/deploy_light.sh start workdir=/abs/path [instance=dev] [a2a_host=127.0.0.1] [a2a_port=8000] [a2a_public_url=http://127.0.0.1:8000] [a2a_log_level=INFO] [a2a_streaming=true] [a2a_log_payloads=false] [a2a_log_body_limit=0] [codex_cli_bin=codex] [codex_model=<id>] [codex_model_id=<id>] [codex_provider_id=<id>] [codex_timeout=120] [codex_timeout_stream=300] [log_root=./logs/light] [pid_root=./run/light]
+  A2A_BEARER_TOKEN=<token> ./scripts/deploy_light.sh start workdir=/abs/path [instance=dev] [a2a_host=127.0.0.1] [a2a_port=8000] [a2a_public_url=http://127.0.0.1:8000] [a2a_log_level=INFO] [a2a_streaming=true] [a2a_log_payloads=false] [a2a_log_body_limit=0] [codex_cli_bin=codex] [codex_model=<id>] [codex_model_id=<id>] [codex_model_reasoning_effort=<low|medium|high|xhigh>] [codex_provider_id=<id>] [codex_timeout=120] [codex_timeout_stream=300] [log_root=./logs/light] [pid_root=./run/light]
   ./scripts/deploy_light.sh stop [instance=dev] [pid_root=./run/light]
   ./scripts/deploy_light.sh status [instance=dev] [pid_root=./run/light]
   A2A_BEARER_TOKEN=<token> ./scripts/deploy_light.sh restart workdir=/abs/path [instance=dev]
@@ -90,6 +96,9 @@ for arg in "$@"; do
     codex_model_id)
       CODEX_MODEL_ID="$value"
       ;;
+    codex_model_reasoning_effort)
+      CODEX_MODEL_REASONING_EFFORT="$value"
+      ;;
     codex_provider_id)
       CODEX_PROVIDER_ID="$value"
       ;;
@@ -137,6 +146,92 @@ is_running() {
   kill -0 "$pid" >/dev/null 2>&1
 }
 
+read_local_codex_config_value() {
+  local key="$1"
+  local config_path="${HOME:-}/.codex/config.toml"
+  if [[ -z "${HOME:-}" || ! -f "$config_path" ]]; then
+    return 0
+  fi
+
+  local in_root=true
+  local line
+  while IFS= read -r line; do
+    if [[ "$line" =~ ^[[:space:]]*\[ ]]; then
+      in_root=false
+    fi
+    if [[ "$in_root" != true ]]; then
+      break
+    fi
+    if [[ "$line" =~ ^[[:space:]]*# || -z "${line//[[:space:]]/}" ]]; then
+      continue
+    fi
+    if [[ "$line" =~ ^[[:space:]]*${key}[[:space:]]*=[[:space:]]*\"([^\"]*)\" ]]; then
+      printf '%s\n' "${BASH_REMATCH[1]}"
+      return 0
+    fi
+  done <"$config_path"
+}
+
+display_or_unset() {
+  local value="$1"
+  if [[ -n "$value" ]]; then
+    printf '%s\n' "$value"
+    return 0
+  fi
+  printf '<unset>\n'
+}
+
+resolve_effective_codex_config() {
+  LOCAL_CODEX_MODEL="$(read_local_codex_config_value model)"
+  LOCAL_CODEX_MODEL_REASONING_EFFORT="$(read_local_codex_config_value model_reasoning_effort)"
+
+  if [[ -z "$CODEX_MODEL" && -z "$CODEX_MODEL_ID" && -n "$LOCAL_CODEX_MODEL" ]]; then
+    CODEX_MODEL="$LOCAL_CODEX_MODEL"
+  fi
+  if [[ -z "$CODEX_MODEL_REASONING_EFFORT" && -n "$LOCAL_CODEX_MODEL_REASONING_EFFORT" ]]; then
+    CODEX_MODEL_REASONING_EFFORT="$LOCAL_CODEX_MODEL_REASONING_EFFORT"
+  fi
+
+  if [[ -n "$CODEX_MODEL_ID" ]]; then
+    EFFECTIVE_CODEX_MODEL="$CODEX_MODEL_ID"
+  elif [[ -n "$CODEX_MODEL" ]]; then
+    EFFECTIVE_CODEX_MODEL="$CODEX_MODEL"
+  else
+    EFFECTIVE_CODEX_MODEL="$SERVICE_DEFAULT_CODEX_MODEL"
+  fi
+
+  if [[ -n "$CODEX_MODEL_REASONING_EFFORT" ]]; then
+    EFFECTIVE_CODEX_REASONING_EFFORT="$CODEX_MODEL_REASONING_EFFORT"
+  else
+    EFFECTIVE_CODEX_REASONING_EFFORT=""
+  fi
+}
+
+print_codex_config_summary() {
+  echo "Codex config summary:"
+  echo "  local config model: $(display_or_unset "$LOCAL_CODEX_MODEL")"
+  echo "  local config reasoning_effort: $(display_or_unset "$LOCAL_CODEX_MODEL_REASONING_EFFORT")"
+  echo "  effective instance model: ${EFFECTIVE_CODEX_MODEL}"
+  if [[ -n "$EFFECTIVE_CODEX_REASONING_EFFORT" ]]; then
+    echo "  effective instance reasoning_effort: ${EFFECTIVE_CODEX_REASONING_EFFORT}"
+  else
+    echo "  effective instance reasoning_effort: <codex-default>"
+  fi
+}
+
+validate_codex_config() {
+  local normalized_model="${EFFECTIVE_CODEX_MODEL,,}"
+  local normalized_effort="${EFFECTIVE_CODEX_REASONING_EFFORT,,}"
+
+  if [[ "$normalized_effort" == "xhigh" && "$normalized_model" == gpt-5.1-codex* ]]; then
+    echo "Refusing to start '${INSTANCE}': reasoning_effort=xhigh is not supported with model ${EFFECTIVE_CODEX_MODEL}." >&2
+    echo "Suggested fixes:" >&2
+    echo "  1. Add codex_model_reasoning_effort=high" >&2
+    echo "  2. Or switch to codex_model=gpt-5.4" >&2
+    exit 1
+  fi
+}
+
 require_start_prerequisites() {
   if [[ -z "${A2A_BEARER_TOKEN:-}" ]]; then
     echo "A2A_BEARER_TOKEN is required for start/restart." >&2
@@ -163,6 +258,9 @@ require_start_prerequisites() {
     echo "codex binary not found in PATH: $CODEX_CLI_BIN" >&2
     exit 1
   fi
+  resolve_effective_codex_config
+  print_codex_config_summary
+  validate_codex_config
 }
 
 start_instance() {
@@ -189,6 +287,9 @@ start_instance() {
     fi
     if [[ -n "$CODEX_MODEL_ID" ]]; then
       export CODEX_MODEL_ID
+    fi
+    if [[ -n "$CODEX_MODEL_REASONING_EFFORT" ]]; then
+      export CODEX_MODEL_REASONING_EFFORT
     fi
     if [[ -n "$CODEX_PROVIDER_ID" ]]; then
       export CODEX_PROVIDER_ID

--- a/src/codex_a2a_serve/codex_client.py
+++ b/src/codex_a2a_serve/codex_client.py
@@ -98,6 +98,7 @@ class OpencodeClient:
         self._cli_bin = settings.codex_cli_bin
         self._listen = settings.codex_app_server_listen
         self._default_model = settings.codex_model
+        self._model_reasoning_effort = settings.codex_model_reasoning_effort
         self._log_payloads = settings.a2a_log_payloads
 
         self._process: asyncio.subprocess.Process | None = None
@@ -192,11 +193,24 @@ class OpencodeClient:
                 if os.path.exists(npm_global_bin):
                     cli_bin = npm_global_bin
 
+            cli_args: list[str] = [cli_bin]
+            if self._model_reasoning_effort:
+                cli_args.extend(
+                    [
+                        "-c",
+                        f"model_reasoning_effort={json.dumps(self._model_reasoning_effort)}",
+                    ]
+                )
+            cli_args.extend(
+                [
+                    "app-server",
+                    "--listen",
+                    self._listen,
+                ]
+            )
+
             process = await asyncio.create_subprocess_exec(
-                cli_bin,
-                "app-server",
-                "--listen",
-                self._listen,
+                *cli_args,
                 stdin=asyncio.subprocess.PIPE,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,

--- a/src/codex_a2a_serve/config.py
+++ b/src/codex_a2a_serve/config.py
@@ -65,6 +65,13 @@ class Settings(BaseSettings):
         default="gpt-5.1-codex",
         validation_alias=AliasChoices("CODEX_MODEL", "OPENCODE_MODEL"),
     )
+    codex_model_reasoning_effort: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices(
+            "CODEX_MODEL_REASONING_EFFORT",
+            "OPENCODE_MODEL_REASONING_EFFORT",
+        ),
+    )
 
     # A2A settings
     a2a_public_url: str = Field(default="http://127.0.0.1:8000", alias="A2A_PUBLIC_URL")

--- a/tests/test_opencode_client_params.py
+++ b/tests/test_opencode_client_params.py
@@ -1,5 +1,6 @@
 import asyncio
 import time
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -211,3 +212,67 @@ async def test_unsupported_server_request_returns_jsonrpc_error() -> None:
             },
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_ensure_started_passes_reasoning_effort_override_to_codex_cli() -> None:
+    client = OpencodeClient(
+        make_settings(
+            a2a_bearer_token="t-1",
+            codex_timeout=1.0,
+            codex_cli_bin="codex-custom",
+            codex_model_reasoning_effort="high",
+        )
+    )
+
+    captured: list[tuple] = []
+
+    class _DummyStdin:
+        def write(self, _data: bytes) -> None:
+            return None
+
+        async def drain(self) -> None:
+            return None
+
+    dummy_process = MagicMock()
+    dummy_process.stdin = _DummyStdin()
+    dummy_process.stdout = object()
+    dummy_process.stderr = object()
+    dummy_process.returncode = 0
+
+    async def fake_create_subprocess_exec(*args, **kwargs):
+        captured.append((args, kwargs))
+        return dummy_process
+
+    async def fake_rpc_request(
+        method: str, params: dict | None = None, *, _skip_ensure: bool = False
+    ):
+        assert method == "initialize"
+        assert _skip_ensure is True
+        return {}
+
+    async def fake_send_json(payload: dict) -> None:
+        assert payload == {"method": "initialized", "params": {}}
+
+    async def fake_stdout_loop() -> None:
+        return None
+
+    async def fake_stderr_loop() -> None:
+        return None
+
+    client._rpc_request = fake_rpc_request  # type: ignore[method-assign]
+    client._send_json_message = fake_send_json  # type: ignore[method-assign]
+    client._read_stdout_loop = fake_stdout_loop  # type: ignore[method-assign]
+    client._read_stderr_loop = fake_stderr_loop  # type: ignore[method-assign]
+
+    original = asyncio.create_subprocess_exec
+    asyncio.create_subprocess_exec = fake_create_subprocess_exec  # type: ignore[assignment]
+    try:
+        await client._ensure_started()
+    finally:
+        asyncio.create_subprocess_exec = original  # type: ignore[assignment]
+        await client.close()
+
+    assert captured
+    args, _kwargs = captured[0]
+    assert args[:4] == ("codex-custom", "-c", 'model_reasoning_effort="high"', "app-server")

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -21,11 +21,13 @@ def test_settings_valid():
     env = {
         "A2A_BEARER_TOKEN": "test-token",
         "OPENCODE_TIMEOUT": "300",
+        "CODEX_MODEL_REASONING_EFFORT": "high",
     }
     with mock.patch.dict(os.environ, env, clear=True):
         settings = Settings.from_env()
         assert settings.a2a_bearer_token == "test-token"
         assert settings.codex_timeout == 300.0
+        assert settings.codex_model_reasoning_effort == "high"
 
 
 def test_parse_oauth_scopes():


### PR DESCRIPTION
## 关联

- Closes #34

## 变更概览

### 1. 轻量部署继承与覆盖优先级收敛

本 PR 将 `scripts/deploy_light.sh` 的行为调整为更符合快速部署定位：

- 保留当前 shell 已导出的 `CODEX_*` 环境变量
- 若实例未显式传参，则 best-effort 继承 `~/.codex/config.toml` 中的 `model` 与 `model_reasoning_effort`
- 若通过启动参数显式传入 `codex_model` / `codex_model_id` / `codex_model_reasoning_effort`，则这些实例参数优先

同时脚本会在启动前打印 Codex config summary，明确展示：

- local config model
- local config reasoning_effort
- effective instance model
- effective instance reasoning_effort

### 2. 冲突检测与 fail-fast

本 PR 在轻量部署路径下增加已知高风险组合的启动前阻断，避免实例成功启动后首个 turn 才在运行时报 400。

当前已覆盖：

- `effective reasoning_effort = xhigh`
- `effective model = gpt-5.1-codex*`

命中时脚本会直接退出，并提示建议修正方式，例如：

- `codex_model_reasoning_effort=high`
- `codex_model=gpt-5.4`

### 3. 服务侧显式 reasoning 覆盖

新增服务配置：

- `CODEX_MODEL_REASONING_EFFORT`

当该值存在时，`codex-a2a-serve` 启动 Codex CLI app-server 时会使用：

- `-c model_reasoning_effort=...`

从而让实例最终生效配置与轻量部署脚本的摘要和覆盖逻辑保持一致，而不是重新漂回用户全局默认。

### 4. 文档与测试

同步更新：

- `docs/guide.md`
- `scripts/README.md`
- `tests/test_settings.py`
- `tests/test_opencode_client_params.py`

覆盖点包括：

- `CODEX_MODEL_REASONING_EFFORT` 配置读取
- Codex CLI 启动参数中带有 `-c model_reasoning_effort=...`
- 脚本继承与冲突处理行为的文档说明

## 验证

已执行：

- `bash -n scripts/deploy_light.sh`
- `uv run pre-commit run --all-files`
- `uv run pytest`

补充脚本级实测：

- 默认继承本机 `gpt-5.4 + xhigh` 时，实例按该组合启动
- 显式切回 `codex_model=gpt-5.1-codex` 时，会在启动前 fail-fast
- 显式 `codex_model=gpt-5.4 codex_model_reasoning_effort=high` 时，可正常完成 `start/status/stop`
