### PR TITLE
fix: update init system repo url to renamed server repo

### DIFF
--- a/scripts/init_system.sh
+++ b/scripts/init_system.sh
@@ -14,7 +14,7 @@ UV_PYTHON_DIR_FINAL_MODE="755"
 UV_PYTHON_DIR_GROUP=""
 UV_PYTHON_INSTALL_DIR="$UV_PYTHON_DIR"
 DATA_ROOT="/data/codex-a2a"
-CODEX_A2A_REPO="https://github.com/liujuanjuan1984/codex-a2a-serve.git"
+CODEX_A2A_REPO="https://github.com/liujuanjuan1984/codex-a2a-server.git"
 CODEX_A2A_BRANCH="main"
 CODEX_INSTALL_CMD="curl -fsSL https://codex.ai/install | bash"
 


### PR DESCRIPTION
## 关联 Issue
Closes #54

## 变更概述
本 PR 收尾 `#54` 最后一处遗留：`scripts/init_system.sh` 默认 clone URL 仍指向旧仓库 `codex-a2a-serve.git`，会导致新机器初始化时拉取到旧地址。

## 模块变更

### `scripts/init_system.sh`
- 将 `CODEX_A2A_REPO` 默认值从旧仓库地址更新为当前真实仓库地址：
  `https://github.com/liujuanjuan1984/codex-a2a-server.git`
- 使初始化脚本默认 clone 行为与仓库 rename 后的实际远端保持一致。

## 验证
- `bash -n scripts/deploy.sh scripts/deploy/install_units.sh scripts/deploy/run_a2a.sh scripts/deploy/run_codex.sh scripts/deploy/setup_instance.sh scripts/deploy/update_a2a.sh scripts/deploy_light.sh scripts/init_system.sh scripts/start_services.sh`
- `uv run pre-commit run --all-files`
- `uv run pytest`
