### PR TITLE
feat: support PyPI release and uv tool distribution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,9 @@ jobs:
 
       - name: Run pytest
         run: uv run pytest
+
+      - name: Build package artifacts
+        run: uv build --no-sources
+
+      - name: Smoke test built CLI
+        run: bash ./scripts/smoke_test_built_cli.sh

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,66 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Build package artifacts
+        run: uv build --no-sources
+
+      - name: Verify published version matches tag
+        run: |
+          python - <<'PY'
+          import os
+          import pathlib
+
+          dist_dir = pathlib.Path("dist")
+          wheels = sorted(dist_dir.glob("codex_a2a_server-*.whl"))
+          if not wheels:
+              raise SystemExit("No wheel produced in dist/")
+          wheel = wheels[0].name
+          version = wheel.removeprefix("codex_a2a_server-").split("-py3", 1)[0]
+          tag = os.environ["GITHUB_REF_NAME"].removeprefix("v")
+          if version != tag:
+              raise SystemExit(f"Wheel version {version!r} does not match tag {tag!r}")
+          print(f"Validated release version: {version}")
+          PY
+
+      - name: Smoke test wheel install
+        run: bash ./scripts/smoke_test_built_cli.sh
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: |
+            dist/*.tar.gz
+            dist/*.whl

--- a/README.md
+++ b/README.md
@@ -98,7 +98,51 @@ It is a better place for client concerns such as A2A consumption, upstream
 adapter normalization, and application-facing integration, while
 `codex-a2a-server` stays focused on the server/runtime boundary around Codex.
 
-## Quick Start
+## Install Released CLI
+
+Released versions are published to PyPI and mapped to Git tags / GitHub
+Releases. This is the recommended entry point for users.
+
+Release gate:
+
+- create a PR from the working branch
+- merge into `main` after human review
+- create a `v*` tag only from a commit already contained in `main`
+- let the tag trigger PyPI and GitHub Release publication
+
+This repository does not publish directly from an unmerged feature branch.
+
+Install the latest release:
+
+```bash
+uv tool install codex-a2a-server
+```
+
+Upgrade an existing installation:
+
+```bash
+uv tool upgrade codex-a2a-server
+```
+
+Install an exact release:
+
+```bash
+uv tool install "codex-a2a-server==<version>"
+```
+
+Start the released CLI:
+
+```bash
+export A2A_BEARER_TOKEN="$(python -c 'import secrets; print(secrets.token_hex(24))')"
+codex-a2a-server
+```
+
+Default address: `http://127.0.0.1:8000`
+
+## Development From Source
+
+Use the repository checkout directly only for development, local debugging, or
+validation against unreleased changes on `main`.
 
 1. Install dependencies:
 
@@ -106,13 +150,13 @@ adapter normalization, and application-facing integration, while
 uv sync --all-extras
 ```
 
-2. Generate a temporary local bearer token:
+2. Generate a local bearer token:
 
 ```bash
 export A2A_BEARER_TOKEN="$(python -c 'import secrets; print(secrets.token_hex(24))')"
 ```
 
-3. Start the service:
+3. Start this service from the source tree:
 
 ```bash
 uv run codex-a2a-server

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,28 @@
+[build-system]
+requires = ["setuptools>=77", "setuptools-scm[toml]>=8"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "codex-a2a-server"
-version = "0.1.0"
+dynamic = ["version"]
 description = "A2A wrapper service for codex"
 readme = "README.md"
 requires-python = ">=3.11"
+license = "Apache-2.0"
+authors = [
+    { name = "liujuanjuan1984@Intelligent-Internet" },
+]
+keywords = ["a2a", "codex", "fastapi", "json-rpc", "sse"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Framework :: FastAPI",
+    "Topic :: Internet :: WWW/HTTP",
+]
 dependencies = [
     "a2a-sdk==0.3.22",
     "fastapi>=0.110",
@@ -25,6 +44,11 @@ dev = [
 [project.scripts]
 codex-a2a-server = "codex_a2a_server.app:main"
 
+[project.urls]
+Homepage = "https://github.com/liujuanjuan1984/codex-a2a-server"
+Repository = "https://github.com/liujuanjuan1984/codex-a2a-server"
+Issues = "https://github.com/liujuanjuan1984/codex-a2a-server/issues"
+
 [tool.ruff]
 line-length = 100
 src = ["src"]
@@ -37,6 +61,10 @@ quote-style = "double"
 
 [tool.uv]
 package = true
+
+[tool.setuptools_scm]
+fallback_version = "0.1.0"
+tag_regex = "^v?(?P<version>.+)$"
 
 [tool.pytest.ini_options]
 filterwarnings = [

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -40,8 +40,11 @@ overview, runtime contracts, or deployment rationale in detail.
 - [`scripts/deploy_light.sh`](./deploy_light.sh)
 - [`scripts/start_services.sh`](./start_services.sh)
 - [`scripts/uninstall.sh`](./uninstall.sh)
+- [`scripts/smoke_test_built_cli.sh`](./smoke_test_built_cli.sh)
 
 ## Notes
 
 - `scripts/deploy/` contains helper scripts orchestrated by `scripts/deploy.sh`.
+- `scripts/smoke_test_built_cli.sh` validates that the built wheel can be installed by
+  `uv tool` and that the released CLI becomes healthy.
 - Keep long-form documentation changes in `docs/` to avoid divergence.

--- a/scripts/smoke_test_built_cli.sh
+++ b/scripts/smoke_test_built_cli.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Validate that a locally built wheel can be installed as a uv tool and serves /health.
+set -euo pipefail
+
+if ! command -v uv >/dev/null 2>&1; then
+  echo "uv not found in PATH" >&2
+  exit 1
+fi
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "curl not found in PATH" >&2
+  exit 1
+fi
+
+python_bin="${PYTHON_BIN:-}"
+if [[ -z "${python_bin}" ]]; then
+  if command -v python3 >/dev/null 2>&1; then
+    python_bin="python3"
+  elif command -v python >/dev/null 2>&1; then
+    python_bin="python"
+  else
+    echo "python3 or python not found in PATH" >&2
+    exit 1
+  fi
+fi
+
+shopt -s nullglob
+wheel_paths=(dist/codex_a2a_server-*.whl)
+shopt -u nullglob
+
+if [[ "${#wheel_paths[@]}" -eq 0 ]]; then
+  echo "No built wheel found in dist/" >&2
+  exit 1
+fi
+
+wheel_path="$(ls -1t "${wheel_paths[@]}" | head -n 1)"
+
+if [[ ! -f "${wheel_path}" ]]; then
+  echo "Wheel path does not exist: ${wheel_path}" >&2
+  exit 1
+fi
+
+tmpdir="$(mktemp -d)"
+tool_dir="${tmpdir}/tools"
+tool_bin_dir="${tmpdir}/bin"
+server_log="${tmpdir}/server.log"
+
+cleanup() {
+  local exit_code="$1"
+  if [[ -n "${server_pid:-}" ]] && kill -0 "${server_pid}" >/dev/null 2>&1; then
+    kill "${server_pid}" >/dev/null 2>&1 || true
+    wait "${server_pid}" >/dev/null 2>&1 || true
+  fi
+  rm -rf "${tmpdir}"
+  exit "${exit_code}"
+}
+
+trap 'cleanup $?' EXIT
+
+mkdir -p "${tool_dir}" "${tool_bin_dir}"
+
+UV_TOOL_DIR="${tool_dir}" \
+UV_TOOL_BIN_DIR="${tool_bin_dir}" \
+uv tool install "${wheel_path}" --python 3.13
+
+port="$(
+  "${python_bin}" - <<'PY'
+import socket
+
+with socket.socket() as sock:
+    sock.bind(("127.0.0.1", 0))
+    print(sock.getsockname()[1])
+PY
+)"
+
+bearer_token="smoke-test-token"
+
+A2A_BEARER_TOKEN="${bearer_token}" \
+A2A_PORT="${port}" \
+A2A_HOST="127.0.0.1" \
+"${tool_bin_dir}/codex-a2a-server" >"${server_log}" 2>&1 &
+server_pid="$!"
+
+health_url="http://127.0.0.1:${port}/health"
+for _ in $(seq 1 50); do
+  if curl -fsS -H "Authorization: Bearer ${bearer_token}" "${health_url}" >/dev/null; then
+    exit 0
+  fi
+  sleep 0.2
+done
+
+echo "CLI smoke test failed; server did not become healthy at ${health_url}" >&2
+cat "${server_log}" >&2
+exit 1

--- a/src/codex_a2a_server/__init__.py
+++ b/src/codex_a2a_server/__init__.py
@@ -1,1 +1,13 @@
 """A2A wrapper for codex."""
+
+from importlib.metadata import PackageNotFoundError, version
+
+
+def get_package_version() -> str:
+    try:
+        return version("codex-a2a-server")
+    except PackageNotFoundError:
+        return "0.1.0"
+
+
+__version__ = get_package_version()

--- a/src/codex_a2a_server/app.py
+++ b/src/codex_a2a_server/app.py
@@ -359,6 +359,10 @@ def create_app(settings: Settings) -> FastAPI:
     for route, callback in rest_adapter.routes().items():
         app.add_api_route(route[0], callback, methods=[route[1]])
 
+    @app.get("/health")
+    async def health_check():
+        return {"status": "ok"}
+
     def _parse_json_body(body_bytes: bytes) -> dict | None:
         try:
             payload = json.loads(body_bytes.decode("utf-8", errors="replace"))

--- a/src/codex_a2a_server/config.py
+++ b/src/codex_a2a_server/config.py
@@ -5,6 +5,8 @@ from typing import Any
 from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+from codex_a2a_server import __version__
+
 
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(
@@ -74,7 +76,7 @@ class Settings(BaseSettings):
     a2a_project: str | None = Field(default=None, alias="A2A_PROJECT")
     a2a_title: str = Field(default="Codex A2A", alias="A2A_TITLE")
     a2a_description: str = Field(default="A2A wrapper service for Codex", alias="A2A_DESCRIPTION")
-    a2a_version: str = Field(default="0.1.0", alias="A2A_VERSION")
+    a2a_version: str = Field(default=__version__, alias="A2A_VERSION")
     a2a_protocol_version: str = Field(default="0.3.0", alias="A2A_PROTOCOL_VERSION")
     a2a_streaming: bool = Field(default=True, alias="A2A_STREAMING")
     a2a_log_level: str = Field(default="INFO", alias="A2A_LOG_LEVEL")

--- a/tests/test_release_distribution_contract.py
+++ b/tests/test_release_distribution_contract.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+
+README_TEXT = Path("README.md").read_text()
+SCRIPTS_README_TEXT = Path("scripts/README.md").read_text()
+PUBLISH_WORKFLOW_TEXT = Path(".github/workflows/publish.yml").read_text()
+
+
+def test_readme_documents_released_cli_installation_via_uv_tool() -> None:
+    assert "uv tool install codex-a2a-server" in README_TEXT
+    assert "uv tool upgrade codex-a2a-server" in README_TEXT
+    assert 'uv tool install "codex-a2a-server==<version>"' in README_TEXT
+    assert "Install Released CLI" in README_TEXT
+    assert "create a PR from the working branch" in README_TEXT
+    assert "merge into `main` after human review" in README_TEXT
+
+
+def test_publish_workflow_builds_and_smoke_tests_release_artifacts() -> None:
+    assert 'tags:\n      - "v*"' in PUBLISH_WORKFLOW_TEXT
+    assert "workflow_dispatch" in PUBLISH_WORKFLOW_TEXT
+    assert "uv build --no-sources" in PUBLISH_WORKFLOW_TEXT
+    assert "bash ./scripts/smoke_test_built_cli.sh" in PUBLISH_WORKFLOW_TEXT
+    assert "gh-action-pypi-publish" in PUBLISH_WORKFLOW_TEXT
+
+
+def test_scripts_index_exposes_built_cli_smoke_test() -> None:
+    assert "smoke_test_built_cli.sh" in SCRIPTS_README_TEXT
+    assert "`uv tool`" in SCRIPTS_README_TEXT

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -4,6 +4,7 @@ from unittest import mock
 import pytest
 from pydantic import ValidationError
 
+from codex_a2a_server import __version__
 from codex_a2a_server.config import Settings
 
 
@@ -28,6 +29,7 @@ def test_settings_valid():
         assert settings.a2a_bearer_token == "test-token"
         assert settings.codex_timeout == 300.0
         assert settings.codex_model_reasoning_effort == "high"
+        assert settings.a2a_version == __version__
 
 
 def test_parse_oauth_scopes():

--- a/tests/test_transport_contract.py
+++ b/tests/test_transport_contract.py
@@ -21,6 +21,7 @@ def test_rest_subscription_route_matches_current_sdk_contract() -> None:
     app = create_app(make_settings(a2a_bearer_token="test-token"))
     route_paths = {route.path for route in app.router.routes if hasattr(route, "path")}
 
+    assert "/health" in route_paths
     assert "/v1/tasks/{id}:subscribe" in route_paths
     assert "/v1/tasks/{id}:resubscribe" not in route_paths
 

--- a/uv.lock
+++ b/uv.lock
@@ -158,7 +158,6 @@ wheels = [
 
 [[package]]
 name = "codex-a2a-server"
-version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## 摘要

本 PR 为 `codex-a2a-server` 补齐 PyPI 发布与 `uv tool` 分发所需的最小发布链路，并保持 `publish.yml` 与 `opencode-a2a-server` 的实现风格一致。

相关提交：
- `a1603a4` `feat: support PyPI release and uv tool distribution (#67)`

## 模块改动

### 1. 打包与版本元数据
- 在 `pyproject.toml` 中引入 `setuptools` / `setuptools_scm`，将包版本改为动态生成。
- 补充 PyPI 所需的项目元数据、项目链接与脚本入口声明。
- 运行时通过 `src/codex_a2a_server/__init__.py` 统一解析已安装包版本，并让 `A2A_VERSION` 默认跟随包版本。
- 同步更新 `uv.lock` 以反映动态版本包元数据。

### 2. 发布与构建验证
- 新增 `.github/workflows/publish.yml`，在 `v*` tag 或手工触发时执行构建、版本校验、wheel 烟雾测试、PyPI 发布和 GitHub Release。
- 保持 `publish.yml` 与 `opencode-a2a-server` 的风格一致，不在 workflow 内额外引入 `main` 分支门禁；“先合并主干再打 tag” 由团队发布流程约束执行。
- 在现有 CI 中补充 `uv build --no-sources` 与 `scripts/smoke_test_built_cli.sh`，把 wheel 构建与 CLI 安装验证纳入质量门。
- 新增 `scripts/smoke_test_built_cli.sh`，验证构建出的 wheel 可被 `uv tool install` 安装，并能正常启动服务。

### 3. 运行时健康检查
- 在 `src/codex_a2a_server/app.py` 中补充 `/health` 端点，供发布包 smoke test 和部署检查复用。

### 4. 文档与测试
- 更新 `README.md`，补充已发布 CLI 的安装、升级、指定版本安装以及从源码运行的说明。
- 更新 `scripts/README.md`，把 wheel smoke test 脚本纳入脚本索引。
- 补充发布链路相关测试，覆盖运行时版本来源、`/health` 路由以及 README / publish workflow 的发布契约。

## 验证

已执行：
- `uv run pre-commit run --all-files`
- `uv run pytest`
- `uv build --no-sources`
- `bash ./scripts/smoke_test_built_cli.sh`

## 关联 Issue

Closes #67
