### PR TITLE
chore: clarify session-scoped shell semantics

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -118,6 +118,10 @@ managed systemd deployment flow.
   status plus deployment-relevant flags such as streaming, session shell, and
   interrupt TTL; it does not call upstream Codex.
 - The service forwards A2A `message:send` to Codex session/message calls.
+- `codex.sessions.shell` is a session-scoped shell control method for
+  ownership, attribution, and traceability. It keeps `session_id` in the A2A
+  contract, but the underlying execution still uses Codex `command/exec`
+  rather than resuming or creating an upstream Codex thread.
 - Task state defaults to `input-required` to support multi-turn interactions.
 - Streaming (`/v1/message:stream`) emits incremental
   `TaskArtifactUpdateEvent` and then

--- a/src/codex_a2a_server/codex_client.py
+++ b/src/codex_a2a_server/codex_client.py
@@ -966,6 +966,8 @@ class CodexClient:
         command_text = str(request["command"]).strip()
         if not command_text:
             raise RuntimeError("shell command must not be empty")
+        # Shell execution remains a standalone Codex command/exec call. session_id
+        # is preserved here for ownership/attribution, not to bind upstream thread context.
         result = await self._rpc_request(
             "command/exec",
             _build_shell_exec_params(

--- a/src/codex_a2a_server/extension_contracts.py
+++ b/src/codex_a2a_server/extension_contracts.py
@@ -23,6 +23,10 @@ class SessionQueryMethodContract:
     items_field: str | None = None
     notification_response_status: int | None = None
     pagination_mode: str | None = None
+    execution_binding: str | None = None
+    session_binding: str | None = None
+    uses_upstream_session_context: bool | None = None
+    notes: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -117,6 +121,19 @@ SESSION_QUERY_METHOD_CONTRACTS: dict[str, SessionQueryMethodContract] = {
         optional_params=(CODEX_DIRECTORY_METADATA_FIELD,),
         result_fields=("item",),
         notification_response_status=204,
+        execution_binding="standalone_command_exec",
+        session_binding="ownership_attribution_only",
+        uses_upstream_session_context=False,
+        notes=(
+            (
+                "Shell requests run through Codex command/exec and do not resume or "
+                "create an upstream thread."
+            ),
+            (
+                "session_id is used for ownership checks and A2A result attribution; "
+                "it does not provide an upstream session-bound shell context."
+            ),
+        ),
     ),
 }
 
@@ -323,6 +340,16 @@ def build_session_query_extension_params(
             contract_doc["notification_response_status"] = (
                 method_contract.notification_response_status
             )
+        if method_contract.execution_binding is not None:
+            contract_doc["execution_binding"] = method_contract.execution_binding
+        if method_contract.session_binding is not None:
+            contract_doc["session_binding"] = method_contract.session_binding
+        if method_contract.uses_upstream_session_context is not None:
+            contract_doc["uses_upstream_session_context"] = (
+                method_contract.uses_upstream_session_context
+            )
+        if method_contract.notes:
+            contract_doc["notes"] = list(method_contract.notes)
         method_contracts[method_contract.method] = contract_doc
 
         envelope_doc: dict[str, Any] = {"fields": list(method_contract.result_fields)}

--- a/tests/test_agent_card.py
+++ b/tests/test_agent_card.py
@@ -76,6 +76,11 @@ def test_agent_card_injects_deployment_context_into_extensions() -> None:
         session_query.params["context_semantics"]["upstream_session_id_field"]
         == "metadata.shared.session.id"
     )
+    shell_contract = session_query.params["method_contracts"]["codex.sessions.shell"]
+    assert shell_contract["execution_binding"] == "standalone_command_exec"
+    assert shell_contract["session_binding"] == "ownership_attribution_only"
+    assert shell_contract["uses_upstream_session_context"] is False
+    assert any("command/exec" in note for note in shell_contract["notes"])
 
     interrupt = ext_by_uri[INTERRUPT_CALLBACK_EXTENSION_URI]
     assert interrupt.params["deployment_context"]["project"] == "alpha"
@@ -109,5 +114,6 @@ def test_agent_card_omits_shell_method_when_disabled() -> None:
 
     assert "shell" not in session_query.params["methods"]
     assert "shell" not in session_query.params["control_methods"]
+    assert "codex.sessions.shell" not in session_query.params["method_contracts"]
     assert session_query.params["deployment_context"]["session_shell_enabled"] is False
     assert session_query.params["deployment_context"]["interrupt_request_ttl_seconds"] == 45

--- a/tests/test_codex_client_params.py
+++ b/tests/test_codex_client_params.py
@@ -48,6 +48,31 @@ async def test_list_calls_use_expected_rpc_params() -> None:
 
 
 @pytest.mark.asyncio
+async def test_session_shell_uses_command_exec_without_thread_context() -> None:
+    client = CodexClient(
+        make_settings(
+            a2a_bearer_token="t-1",
+            codex_directory="/safe",
+            codex_timeout=1.0,
+        )
+    )
+
+    seen: list[tuple[str, dict | None]] = []
+
+    async def fake_rpc_request(method: str, params: dict | None = None):
+        seen.append((method, params))
+        return {"stdout": "/safe\n", "stderr": "", "exitCode": 0}
+
+    client._rpc_request = fake_rpc_request  # type: ignore[method-assign]
+
+    result = await client.session_shell("thr-1", {"command": "pwd"})
+
+    assert seen == [("command/exec", {"command": ["pwd"], "cwd": "/safe"})]
+    assert result["info"]["id"].startswith("shell:thr-1:")
+    assert result["parts"][0]["text"] == "exit_code: 0\nstdout:\n/safe"
+
+
+@pytest.mark.asyncio
 async def test_permission_reply_maps_to_codex_decision() -> None:
     client = CodexClient(make_settings(a2a_bearer_token="t-1", codex_timeout=1.0))
     client._pending_server_requests["100"] = _PendingInterruptRequest(


### PR DESCRIPTION
Closes #76
Relates to #58

## 概要

本 PR 收敛 `codex.sessions.shell` 的对外语义，明确它是面向 A2A 会话的 session-scoped shell 控制方法：`session_id` 用于 ownership、归属和追踪，不表示上游 Codex 会在该 session/thread 的专属 shell 上下文中执行命令。

本次不修改现有方法名、请求参数和返回结构，不改变现有运行时行为，只补充契约说明、文档表述和测试保护。

## 契约

- 在 session query extension 的 `method_contracts["codex.sessions.shell"]` 中新增机器可读语义字段：
  - `execution_binding=standalone_command_exec`
  - `session_binding=ownership_attribution_only`
  - `uses_upstream_session_context=false`
- 新增 `notes`，明确 shell 底层通过 Codex `command/exec` 执行，`session_id` 仅用于 ownership、归属和追踪。
- 保持现有 `methods`、`control_methods`、请求参数和结果 envelope 不变，避免影响下游消费方。

## 运行时说明

- 为 `CodexClient.session_shell()` 补充英文注释，明确该调用路径不是 upstream thread-bound shell。
- 不改动现有 JSON-RPC 路由、claim 流程和响应映射。

## 文档

- 在 `docs/guide.md` 中补充 `codex.sessions.shell` 的技术语义说明，明确它不是通过 `thread/resume` 或 `turn/start` 建立的上游会话 shell。

## 测试

- 更新 Agent Card 测试，直接断言 shell 契约中的新语义字段。
- 新增客户端参数测试，锁定 `session_shell()` 走 `command/exec`，而不是 thread/turn RPC。
- 保持现有 session extension 行为测试不变。

## 兼容性

- 不变更 `codex.sessions.shell` 的方法名和请求/响应形态。
- 不变更 `contextId` / `metadata.shared.session.id` 的现有语义边界。
- 机器可读字段仅作为向后兼容的契约补充，不要求现有下游立即消费。

## 验证

- `uv run pre-commit run --all-files`
- `uv run pytest`
