### PR TITLE
test: guard stream disconnect cleanup regression

### DIFF
--- a/tests/test_request_handler.py
+++ b/tests/test_request_handler.py
@@ -102,3 +102,53 @@ async def test_stream_disconnect_cancels_producer() -> None:
 
     assert handler._producer_task.cancelled()
     handler._queue.close.assert_awaited_once_with(immediate=True)
+
+
+@pytest.mark.asyncio
+async def test_stream_disconnect_does_not_leave_unretrieved_loop_exceptions() -> None:
+    class _FakeAggregator:
+        async def consume_and_emit(self, _consumer):
+            task = Task(
+                id="task-1",
+                context_id="ctx-1",
+                status=TaskStatus(state=TaskState.working),
+            )
+            yield task
+            await asyncio.sleep(10)
+
+    class _TestHandler(CodexRequestHandler):
+        async def _setup_message_execution(self, params, context=None):  # noqa: ANN001
+            del params, context
+            queue = AsyncMock()
+            producer_task = asyncio.create_task(asyncio.sleep(10))
+            self._producer_task = producer_task
+            self._queue = queue
+            return MagicMock(), "task-1", queue, _FakeAggregator(), producer_task
+
+        async def _cleanup_producer(self, producer_task, task_id):  # noqa: ANN001
+            del task_id
+            try:
+                await producer_task
+            except asyncio.CancelledError:
+                pass
+
+    handler = _TestHandler(agent_executor=MagicMock(), task_store=InMemoryTaskStore())
+    loop = asyncio.get_running_loop()
+    loop_exceptions: list[dict] = []
+    previous_handler = loop.get_exception_handler()
+    loop.set_exception_handler(lambda _loop, context: loop_exceptions.append(context))
+
+    try:
+        stream = handler.on_message_send_stream(_make_message_send_params())
+        first_event = await stream.__anext__()
+        assert isinstance(first_event, Task)
+
+        await stream.aclose()
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+    finally:
+        loop.set_exception_handler(previous_handler)
+
+    assert handler._producer_task.cancelled()
+    assert loop_exceptions == []
+    assert handler._background_tasks == set()


### PR DESCRIPTION
## 关联

- Closes #43

## 评估结论

- 当前主干上，issue 原始描述中的运行时噪声路径已基本被后续生命周期治理消化，未再直接复现 `Task exception was never retrieved` / `StopAsyncIteration`。
- 因此本 PR 不继续改 `request_handler.py` 或 `streaming.py` 的运行时代码，而是补充回归保护，锁定客户端断连场景下的清理行为。

## 测试改动

- 在 `tests/test_request_handler.py` 新增流式断连回归测试。
- 模拟 client disconnect during stream，断言 producer 会被取消。
- 额外断言 event loop 不会收到未检索异常上下文，且后台 cleanup task 会收口完成。

## 风险与兼容性

- 本 PR 仅新增测试，不改业务逻辑和对外契约。
- 风险较低，主要价值是防止未来对流式清理路径的改动重新引入日志噪声。

## 验证

- `uv run pre-commit run --all-files`
- `uv run pytest`
