### PR TITLE
test: add raw JSON-RPC replay coverage

### DIFF
--- a/src/codex_a2a_server/codex_client.py
+++ b/src/codex_a2a_server/codex_client.py
@@ -393,6 +393,12 @@ class CodexClient:
                 except json.JSONDecodeError:
                     logger.debug("drop non-json line from codex app-server: %s", raw)
                     continue
+                if not isinstance(message, dict):
+                    logger.debug(
+                        "drop non-object jsonrpc payload from codex app-server: %s",
+                        type(message).__name__,
+                    )
+                    continue
                 await self._dispatch_message(message)
         except asyncio.CancelledError:
             raise

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -45,6 +45,62 @@ async def replay_codex_notification_fixture(
     return fixture, events
 
 
+async def replay_codex_jsonrpc_line_fixture(
+    *relative_parts: str,
+    prefix_lines: list[bytes] | None = None,
+    suffix_lines: list[bytes] | None = None,
+    chunk_sizes: tuple[int, ...] | None = None,
+) -> tuple[dict[str, Any], list[dict]]:
+    fixture = load_json_fixture(*relative_parts)
+    client = CodexClient(make_settings(a2a_bearer_token="test-token", codex_timeout=1.0))
+    events: list[dict] = []
+
+    async def fake_enqueue(event: dict) -> None:
+        events.append(event)
+
+    client._enqueue_stream_event = fake_enqueue  # type: ignore[method-assign]
+
+    raw_lines: list[bytes] = []
+    if prefix_lines:
+        raw_lines.extend(prefix_lines)
+    raw_lines.extend(
+        (json.dumps(notification, ensure_ascii=False) + "\n").encode("utf-8")
+        for notification in fixture["notifications"]
+    )
+    if suffix_lines:
+        raw_lines.extend(suffix_lines)
+
+    encoded = b"".join(raw_lines)
+    if chunk_sizes:
+        chunks: list[bytes] = []
+        cursor = 0
+        for size in chunk_sizes:
+            if cursor >= len(encoded):
+                break
+            chunks.append(encoded[cursor : cursor + size])
+            cursor += size
+        if cursor < len(encoded):
+            chunks.append(encoded[cursor:])
+    else:
+        chunks = [encoded]
+
+    class _ChunkedStream:
+        def __init__(self, items: list[bytes]) -> None:
+            self._items = list(items)
+
+        async def read(self, _size: int) -> bytes:
+            if not self._items:
+                return b""
+            return self._items.pop(0)
+
+    process = MagicMock()
+    process.stdout = _ChunkedStream(chunks)
+    client._process = process
+
+    await client._read_stdout_loop()
+    return fixture, events
+
+
 class DummyEventQueue:
     def __init__(self) -> None:
         self.events: list[Any] = []

--- a/tests/test_codex_client_params.py
+++ b/tests/test_codex_client_params.py
@@ -10,7 +10,11 @@ from codex_a2a_server.codex_client import (
     InterruptRequestBinding,
     _PendingInterruptRequest,
 )
-from tests.helpers import make_settings, replay_codex_notification_fixture
+from tests.helpers import (
+    make_settings,
+    replay_codex_jsonrpc_line_fixture,
+    replay_codex_notification_fixture,
+)
 
 
 @pytest.mark.asyncio
@@ -482,6 +486,31 @@ async def test_handle_notification_replays_real_command_execution_fixture() -> N
 
 
 @pytest.mark.asyncio
+async def test_read_stdout_loop_replays_real_command_execution_jsonrpc_lines() -> None:
+    fixture, events = await replay_codex_jsonrpc_line_fixture(
+        "codex_app_server",
+        "command_execution_output_delta.json",
+        chunk_sizes=(97, 211, 503),
+    )
+    tool_events = [event for event in events if event["properties"]["part"]["type"] == "tool_call"]
+
+    assert fixture["response_text"] == "DONE"
+    assert [event["type"] for event in tool_events] == [
+        "message.part.updated",
+        "message.part.updated",
+        "message.part.updated",
+        "message.part.updated",
+    ]
+    assert [event["properties"]["delta"]["kind"] for event in tool_events] == [
+        "state",
+        "output_delta",
+        "output_delta",
+        "state",
+    ]
+    assert tool_events[-1]["properties"]["delta"]["status"] == "completed"
+
+
+@pytest.mark.asyncio
 async def test_handle_notification_replays_real_file_change_fixture() -> None:
     fixture, events = await replay_codex_notification_fixture(
         "codex_app_server",
@@ -527,6 +556,46 @@ async def test_handle_notification_replays_real_file_change_fixture() -> None:
             "change_count": 1,
         },
     }
+
+
+@pytest.mark.asyncio
+async def test_read_stdout_loop_replays_real_file_change_jsonrpc_lines() -> None:
+    fixture, events = await replay_codex_jsonrpc_line_fixture(
+        "codex_app_server",
+        "file_change_output_delta.json",
+        chunk_sizes=(41, 89, 233),
+    )
+    tool_events = [event for event in events if event["properties"]["part"]["type"] == "tool_call"]
+
+    assert fixture["response_text"] == "DONE"
+    assert [event["type"] for event in tool_events] == [
+        "message.part.updated",
+        "message.part.updated",
+        "message.part.updated",
+    ]
+    assert tool_events[1]["properties"]["delta"]["kind"] == "output_delta"
+    assert tool_events[2]["properties"]["delta"]["status"] == "completed"
+
+
+@pytest.mark.asyncio
+async def test_read_stdout_loop_drops_invalid_and_non_object_json_lines(caplog) -> None:
+    with caplog.at_level("DEBUG", logger="codex_a2a_server.codex_client"):
+        fixture, events = await replay_codex_jsonrpc_line_fixture(
+            "codex_app_server",
+            "command_execution_output_delta.json",
+            prefix_lines=[
+                b'{"method":"turn/started","params":\n',
+                b"42\n",
+                b"[1,2,3]\n",
+            ],
+            chunk_sizes=(19, 37, 211),
+        )
+
+    assert fixture["response_text"] == "DONE"
+    assert any(event["type"] == "message.part.updated" for event in events)
+    assert "drop non-json line from codex app-server" in caplog.text
+    assert "drop non-object jsonrpc payload from codex app-server: int" in caplog.text
+    assert "drop non-object jsonrpc payload from codex app-server: list" in caplog.text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 关联

- Closes #52

## 评估结论

- 当前仓库虽然已有基于真实 fixture 的通知级回放测试，但覆盖点主要停在 `_handle_notification()`。
- 本 PR 补的是更靠近上游协议入口的黑盒保护：从原始 JSON-RPC 行进入 `_read_stdout_loop()` / `_dispatch_message()` / 归一化事件分发。
- `#53` 关注 fixture 录制与脱敏工具链，不属于本 PR 实际完成范围，因此不在本 PR 中关联关闭。

## 运行时入口

- 在 `src/codex_a2a_server/codex_client.py` 为 stdout reader 增加非对象 JSON payload 的安全丢弃保护。
- 保持原有 JSON 解码失败容错逻辑，同时避免数组、数字等非对象 JSON 直接进入 dispatcher 异常路径。

## 测试辅助

- 在 `tests/helpers.py` 新增基于真实 fixture 生成原始 JSON-RPC 行并喂给 `_read_stdout_loop()` 的回放 helper。
- 支持前置噪声行、分块输入和真实通知序列组合，便于覆盖 reader 入口级行为。

## 回归测试

- 在 `tests/test_codex_client_params.py` 新增 command execution 与 file change 两类真实样本的 reader 入口级黑盒回放测试。
- 新增损坏行与非对象 JSON 行容错测试，直接锁定 reader 入口的协议健壮性。
- 保留原有 `_handle_notification()` 级测试，形成“入口回放 + 细粒度通知映射”两层保护。

## 风险与兼容性

- 本 PR 不改变对外扩展契约和业务语义，主要影响 reader 入口的容错边界。
- 现有样本仍主要覆盖 command execution / file change 两条主链路；后续若要扩大样本来源，应由 `#53` 补充录制与脱敏能力。

## 验证

- `uv run pre-commit run --all-files`
- `uv run pytest`
