### PR TITLE
chore: declare compatibility profile and retention policy

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -17,6 +17,48 @@ navigation, start from [README.md](../README.md) instead.
   - REST send payload usually uses `message.content` and role values like `ROLE_USER`
   - JSON-RPC `message/send` payload uses `params.message.parts` and role values `user` / `agent`
 
+## Compatibility Profile
+
+The service publishes a machine-readable compatibility profile through Agent
+Card and OpenAPI metadata. Its purpose is to declare:
+
+- the stable A2A core interoperability baseline
+- which custom JSON-RPC methods are deployment extensions
+- which extension surfaces are required runtime metadata contracts
+- which methods are deployment-conditional rather than always available
+
+Current profile shape:
+
+- `profile_id=codex-a2a-core-plus-extensions-v1`
+- core JSON-RPC methods:
+  - `message/send`
+  - `message/stream`
+  - `tasks/get`
+  - `tasks/cancel`
+  - `tasks/resubscribe`
+- core HTTP endpoints:
+  - `/v1/message:send`
+  - `/v1/message:stream`
+  - `/v1/tasks/{id}:subscribe`
+
+Retention guidance:
+
+- Treat core methods as the generic client interoperability baseline.
+- Treat shared session-binding and streaming metadata contracts as required for
+  the current deployment model; they are not optional documentation-only hints.
+- Treat `codex.*` and `a2a.interrupt.*` JSON-RPC methods as declared custom
+  extensions that remain stable within the current major line.
+- Treat `codex.sessions.shell` as deployment-conditional. Discover it from the
+  declared compatibility profile and extension contracts before calling it.
+
+Current implementation note:
+
+- The compatibility profile is declarative. It does not introduce a global
+  runtime `core-only` switch.
+- This is intentional: current shared session/stream/interrupt behavior is part
+  of the deployed interoperability contract, so a blanket runtime profile split
+  would be misleading without broader wire-level changes.
+
 ## Environment Variables
 
 - `CODEX_CLI_BIN`: Codex CLI binary path, default `codex`

--- a/src/codex_a2a_server/app.py
+++ b/src/codex_a2a_server/app.py
@@ -33,9 +33,15 @@ from .agent import CodexAgentExecutor
 from .codex_client import CodexClient
 from .config import Settings
 from .extension_contracts import (
+    COMPATIBILITY_PROFILE_EXTENSION_URI,
+    INTERRUPT_CALLBACK_EXTENSION_URI,
     INTERRUPT_CALLBACK_METHODS,
+    SESSION_BINDING_EXTENSION_URI,
     SESSION_CONTROL_METHODS,
+    SESSION_QUERY_EXTENSION_URI,
     SESSION_QUERY_METHODS,
+    STREAMING_EXTENSION_URI,
+    build_compatibility_profile_params,
     build_interrupt_callback_extension_params,
     build_session_binding_extension_params,
     build_session_query_extension_params,
@@ -56,11 +62,6 @@ logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from a2a.server.context import ServerCallContext
-
-SESSION_BINDING_EXTENSION_URI = "urn:a2a:session-binding/v1"
-STREAMING_EXTENSION_URI = "urn:a2a:stream-hints/v1"
-SESSION_QUERY_EXTENSION_URI = "urn:codex-a2a:codex-session-query/v1"
-INTERRUPT_CALLBACK_EXTENSION_URI = "urn:a2a:interactive-interrupt/v1"
 
 
 class IdentityAwareCallContextBuilder(DefaultCallContextBuilder):
@@ -123,7 +124,8 @@ def _build_agent_card_description(
         "(message/send, message/stream), task APIs (tasks/get, tasks/cancel, "
         "tasks/resubscribe; REST mapping: GET /v1/tasks/{id}:subscribe), "
         "shared session-binding and streaming contracts, Codex session-query "
-        "extensions, and shared interrupt callback extensions."
+        "extensions, shared interrupt callback extensions, and a machine-readable "
+        "compatibility profile."
     )
     parts: list[str] = [base, summary]
     parts.append(
@@ -168,6 +170,10 @@ def build_agent_card(settings: Settings) -> AgentCard:
     )
     interrupt_callback_extension_params = build_interrupt_callback_extension_params(
         deployment_context=deployment_context
+    )
+    compatibility_profile_params = build_compatibility_profile_params(
+        protocol_version=settings.a2a_protocol_version,
+        session_shell_enabled=settings.a2a_enable_session_shell,
     )
     security_schemes: dict[str, SecurityScheme] = {
         "bearerAuth": SecurityScheme(
@@ -247,6 +253,15 @@ def build_agent_card(settings: Settings) -> AgentCard:
                         "streaming through shared JSON-RPC methods."
                     ),
                     params=interrupt_callback_extension_params,
+                ),
+                AgentExtension(
+                    uri=COMPATIBILITY_PROFILE_EXTENSION_URI,
+                    required=False,
+                    description=(
+                        "Machine-readable compatibility profile for the current A2A core "
+                        "baseline, declared custom extensions, and retention policy."
+                    ),
+                    params=compatibility_profile_params,
                 ),
             ],
         ),
@@ -628,6 +643,7 @@ def create_app(settings: Settings) -> FastAPI:
         app,
         deployment_context=deployment_context,
         directory_override_enabled=settings.a2a_allow_directory_override,
+        protocol_version=settings.a2a_protocol_version,
         session_shell_enabled=settings.a2a_enable_session_shell,
     )
 

--- a/src/codex_a2a_server/extension_contracts.py
+++ b/src/codex_a2a_server/extension_contracts.py
@@ -3,6 +3,12 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
+COMPATIBILITY_PROFILE_EXTENSION_URI = "urn:codex-a2a:compatibility-profile/v1"
+SESSION_BINDING_EXTENSION_URI = "urn:a2a:session-binding/v1"
+STREAMING_EXTENSION_URI = "urn:a2a:stream-hints/v1"
+SESSION_QUERY_EXTENSION_URI = "urn:codex-a2a:codex-session-query/v1"
+INTERRUPT_CALLBACK_EXTENSION_URI = "urn:a2a:interactive-interrupt/v1"
+
 SHARED_METADATA_NAMESPACE = "shared"
 SHARED_SESSION_BINDING_FIELD = "metadata.shared.session.id"
 SHARED_SESSION_METADATA_FIELD = "metadata.shared.session"
@@ -193,6 +199,118 @@ INTERRUPT_INVALID_PARAMS_DATA_FIELDS: tuple[str, ...] = (
     "fields",
     "request_id",
 )
+
+CORE_JSONRPC_METHODS: tuple[str, ...] = (
+    "message/send",
+    "message/stream",
+    "tasks/get",
+    "tasks/cancel",
+    "tasks/resubscribe",
+)
+CORE_HTTP_ENDPOINTS: tuple[str, ...] = (
+    "/v1/message:send",
+    "/v1/message:stream",
+    "/v1/tasks/{id}:subscribe",
+)
+COMPATIBILITY_PROFILE_ID = "codex-a2a-core-plus-extensions-v1"
+
+
+def build_compatibility_profile_params(
+    *,
+    protocol_version: str,
+    session_shell_enabled: bool,
+) -> dict[str, Any]:
+    active_session_query_methods = [
+        SESSION_QUERY_METHODS["list_sessions"],
+        SESSION_QUERY_METHODS["get_session_messages"],
+        SESSION_CONTROL_METHODS["prompt_async"],
+        SESSION_CONTROL_METHODS["command"],
+    ]
+    if session_shell_enabled:
+        active_session_query_methods.append(SESSION_CONTROL_METHODS["shell"])
+
+    method_retention: dict[str, dict[str, Any]] = {
+        method: {
+            "surface": "core",
+            "availability": "always",
+            "retention": "required",
+        }
+        for method in CORE_JSONRPC_METHODS
+    }
+    method_retention.update(
+        {
+            method: {
+                "surface": "extension",
+                "availability": "always",
+                "retention": "stable",
+                "extension_uri": SESSION_QUERY_EXTENSION_URI,
+            }
+            for method in active_session_query_methods
+        }
+    )
+    method_retention[SESSION_CONTROL_METHODS["shell"]] = {
+        "surface": "extension",
+        "availability": "enabled" if session_shell_enabled else "disabled",
+        "retention": "deployment-conditional",
+        "extension_uri": SESSION_QUERY_EXTENSION_URI,
+        "toggle": "A2A_ENABLE_SESSION_SHELL",
+    }
+    method_retention.update(
+        {
+            method: {
+                "surface": "extension",
+                "availability": "always",
+                "retention": "stable",
+                "extension_uri": INTERRUPT_CALLBACK_EXTENSION_URI,
+            }
+            for method in INTERRUPT_CALLBACK_METHODS.values()
+        }
+    )
+
+    extension_retention = {
+        SESSION_BINDING_EXTENSION_URI: {
+            "surface": "core-runtime-metadata",
+            "availability": "always",
+            "retention": "required",
+        },
+        STREAMING_EXTENSION_URI: {
+            "surface": "core-runtime-metadata",
+            "availability": "always",
+            "retention": "required",
+        },
+        SESSION_QUERY_EXTENSION_URI: {
+            "surface": "jsonrpc-extension",
+            "availability": "always",
+            "retention": "stable",
+        },
+        INTERRUPT_CALLBACK_EXTENSION_URI: {
+            "surface": "jsonrpc-extension",
+            "availability": "always",
+            "retention": "stable",
+        },
+    }
+
+    return {
+        "profile_id": COMPATIBILITY_PROFILE_ID,
+        "protocol_version": protocol_version,
+        "core": {
+            "jsonrpc_methods": list(CORE_JSONRPC_METHODS),
+            "http_endpoints": list(CORE_HTTP_ENDPOINTS),
+        },
+        "extension_retention": extension_retention,
+        "method_retention": method_retention,
+        "consumer_guidance": [
+            ("Treat core A2A methods as the stable interoperability baseline for generic clients."),
+            (
+                "Treat codex.* and a2a.interrupt.* JSON-RPC methods as declared "
+                "custom extensions that remain stable within the current major line."
+            ),
+            (
+                "codex.sessions.shell is deployment-conditional: discover it from the "
+                "declared profile and current extension contracts before calling it."
+            ),
+        ],
+    }
 
 
 def _build_method_contract_params(

--- a/src/codex_a2a_server/openapi_contracts.py
+++ b/src/codex_a2a_server/openapi_contracts.py
@@ -8,6 +8,7 @@ from .extension_contracts import (
     INTERRUPT_CALLBACK_METHODS,
     SESSION_CONTROL_METHODS,
     SESSION_QUERY_METHODS,
+    build_compatibility_profile_params,
     build_interrupt_callback_extension_params,
     build_session_binding_extension_params,
     build_session_query_extension_params,
@@ -193,6 +194,7 @@ def patch_openapi_contract(
     *,
     deployment_context: dict[str, str | bool | int],
     directory_override_enabled: bool,
+    protocol_version: str,
     session_shell_enabled: bool,
 ) -> None:
     session_binding = build_session_binding_extension_params(
@@ -206,6 +208,10 @@ def patch_openapi_contract(
     )
     interrupt_callback = build_interrupt_callback_extension_params(
         deployment_context=deployment_context,
+    )
+    compatibility_profile = build_compatibility_profile_params(
+        protocol_version=protocol_version,
+        session_shell_enabled=session_shell_enabled,
     )
     original_openapi = app.openapi
 
@@ -229,6 +235,7 @@ def patch_openapi_contract(
                         "streaming": streaming,
                         "session_query": session_query,
                         "interrupt_callback": interrupt_callback,
+                        "compatibility_profile": compatibility_profile,
                     }
 
                     request_body = post.setdefault("requestBody", {})

--- a/tests/test_agent_card.py
+++ b/tests/test_agent_card.py
@@ -1,4 +1,5 @@
 from codex_a2a_server.app import (
+    COMPATIBILITY_PROFILE_EXTENSION_URI,
     INTERRUPT_CALLBACK_EXTENSION_URI,
     SESSION_BINDING_EXTENSION_URI,
     SESSION_QUERY_EXTENSION_URI,
@@ -14,6 +15,7 @@ def test_agent_card_description_reflects_actual_transport_capabilities() -> None
     assert "HTTP+JSON and JSON-RPC transports" in card.description
     assert "message/send, message/stream" in card.description
     assert "tasks/get, tasks/cancel" in card.description
+    assert "machine-readable compatibility profile" in card.description
     assert "all consumers share the same underlying Codex workspace/environment" in card.description
 
 
@@ -94,6 +96,21 @@ def test_agent_card_injects_deployment_context_into_extensions() -> None:
     assert "expected_interrupt_type" in interrupt.params["errors"]["error_data_fields"]
     assert "actual_interrupt_type" in interrupt.params["errors"]["error_data_fields"]
 
+    compatibility = ext_by_uri[COMPATIBILITY_PROFILE_EXTENSION_URI]
+    assert compatibility.params["profile_id"] == "codex-a2a-core-plus-extensions-v1"
+    assert compatibility.params["protocol_version"] == "0.3.0"
+    assert compatibility.params["core"]["jsonrpc_methods"] == [
+        "message/send",
+        "message/stream",
+        "tasks/get",
+        "tasks/cancel",
+        "tasks/resubscribe",
+    ]
+    shell_policy = compatibility.params["method_retention"]["codex.sessions.shell"]
+    assert shell_policy["availability"] == "enabled"
+    assert shell_policy["retention"] == "deployment-conditional"
+    assert shell_policy["toggle"] == "A2A_ENABLE_SESSION_SHELL"
+
 
 def test_agent_card_chat_examples_include_project_hint_when_configured() -> None:
     card = build_agent_card(make_settings(a2a_bearer_token="test-token", a2a_project="alpha"))
@@ -117,3 +134,6 @@ def test_agent_card_omits_shell_method_when_disabled() -> None:
     assert "codex.sessions.shell" not in session_query.params["method_contracts"]
     assert session_query.params["deployment_context"]["session_shell_enabled"] is False
     assert session_query.params["deployment_context"]["interrupt_request_ttl_seconds"] == 45
+    compatibility = ext_by_uri[COMPATIBILITY_PROFILE_EXTENSION_URI]
+    shell_policy = compatibility.params["method_retention"]["codex.sessions.shell"]
+    assert shell_policy["availability"] == "disabled"

--- a/tests/test_extension_contract_consistency.py
+++ b/tests/test_extension_contract_consistency.py
@@ -2,6 +2,7 @@ import httpx
 import pytest
 
 from codex_a2a_server.app import (
+    COMPATIBILITY_PROFILE_EXTENSION_URI,
     INTERRUPT_CALLBACK_EXTENSION_URI,
     SESSION_BINDING_EXTENSION_URI,
     SESSION_QUERY_EXTENSION_URI,
@@ -10,6 +11,7 @@ from codex_a2a_server.app import (
     create_app,
 )
 from codex_a2a_server.extension_contracts import (
+    build_compatibility_profile_params,
     build_interrupt_callback_extension_params,
     build_session_binding_extension_params,
     build_session_query_extension_params,
@@ -145,6 +147,7 @@ def test_openapi_jsonrpc_contract_extension_matches_ssot() -> None:
     streaming = contract["streaming"]
     session_query = contract["session_query"]
     interrupt_callback = contract["interrupt_callback"]
+    compatibility_profile = contract["compatibility_profile"]
     deployment_context = session_query["deployment_context"]
     expected_session_binding = build_session_binding_extension_params(
         deployment_context=deployment_context,
@@ -158,6 +161,10 @@ def test_openapi_jsonrpc_contract_extension_matches_ssot() -> None:
     expected_interrupt_callback = build_interrupt_callback_extension_params(
         deployment_context=deployment_context,
     )
+    expected_compatibility_profile = build_compatibility_profile_params(
+        protocol_version=settings.a2a_protocol_version,
+        session_shell_enabled=settings.a2a_enable_session_shell,
+    )
 
     assert session_binding == expected_session_binding, (
         "OpenAPI session binding contract drifted from extension_contracts SSOT."
@@ -170,6 +177,9 @@ def test_openapi_jsonrpc_contract_extension_matches_ssot() -> None:
     )
     assert interrupt_callback == expected_interrupt_callback, (
         "OpenAPI interrupt callback contract drifted from extension_contracts SSOT."
+    )
+    assert compatibility_profile == expected_compatibility_profile, (
+        "OpenAPI compatibility profile drifted from extension_contracts SSOT."
     )
 
 
@@ -185,6 +195,10 @@ def test_openapi_and_agent_card_extension_contracts_match() -> None:
     assert post_contract["session_query"] == ext_by_uri[SESSION_QUERY_EXTENSION_URI].params
     assert (
         post_contract["interrupt_callback"] == ext_by_uri[INTERRUPT_CALLBACK_EXTENSION_URI].params
+    )
+    assert (
+        post_contract["compatibility_profile"]
+        == ext_by_uri[COMPATIBILITY_PROFILE_EXTENSION_URI].params
     )
 
 


### PR DESCRIPTION
## 关联

- Closes #65
- Relates to #62

## 评估结论

本 PR 对 `#65` 的实现范围做了收敛：

- `#65` 仍然有效，但当前主干不适合直接引入一个会改变运行时行为边界的全局 `core-only` 开关。
- 现阶段更符合最佳实践的做法，是先建立机器可读的 compatibility profile 与 extension retention policy，明确：
  - 核心 A2A 互操作基线
  - 已声明的自定义扩展方法
  - 当前部署模型下必须保留的 runtime metadata contract
  - deployment-conditional 方法（当前即 `codex.sessions.shell`）
- 更广义的 unsupported/disabled method 运行时拦截与 wire-level 错误入口，仍建议继续由 `#62` 单独推进。

参考 `~/opencode-a2a-serve` 的对照结论：

- 参考仓库也没有完整的 compatibility profile 开关，因此本 PR 不是照搬现成实现。
- 可借鉴之处是：
  - 扩展契约集中收敛到 `extension_contracts.py` 作为 SSOT
  - deployment-conditional 方法应有明确声明边界
- 本 PR 采用了相同的 SSOT 思路，但仅在声明层落地，不扩大运行时行为变更范围。

## 契约 SSOT

- 在 `src/codex_a2a_server/extension_contracts.py` 新增 compatibility profile 定义：
  - `profile_id=codex-a2a-core-plus-extensions-v1`
  - core JSON-RPC methods
  - core HTTP endpoints
  - extension retention
  - method retention
  - consumer guidance
- 将 `codex.sessions.shell` 明确标记为 `deployment-conditional`，并绑定 `A2A_ENABLE_SESSION_SHELL`。

## Agent Card

- 在 `src/codex_a2a_server/app.py` 新增 Agent Card 扩展：
  - `urn:codex-a2a:compatibility-profile/v1`
- Agent Card 描述补充 compatibility profile 的能力说明。

## OpenAPI

- 在 `src/codex_a2a_server/openapi_contracts.py` 将 compatibility profile 注入 `POST /` 的 `x-a2a-extension-contracts`。
- 这样 OpenAPI / Agent Card / SSOT 对外暴露的是同一份兼容策略声明，而不是额外维护一层独立文案。

## 文档

- 在 `docs/guide.md` 新增 Compatibility Profile 章节，说明：
  - 当前 profile 的结构
  - 核心互操作基线
  - 扩展保留策略
  - `codex.sessions.shell` 的 deployment-conditional 语义
  - 当前实现为何暂不引入全局 runtime `core-only` 开关

## 测试

- `tests/test_agent_card.py`
  - 校验 compatibility profile 已进入 Agent Card
  - 校验 shell 启用/关闭时的 retention policy
- `tests/test_extension_contract_consistency.py`
  - 校验 compatibility profile 在 SSOT / Agent Card / OpenAPI 三层保持一致

## 风险与边界

- 本 PR 只补 compatibility profile 的声明层，不改变现有核心/扩展方法的运行时路由边界。
- 本 PR 没有引入新的 unsupported method 拦截策略，因此不应把 `#62` 视为完成。
- 当前实现是稳健的最小范围；如果未来需要真正按 profile 改变运行时方法可见性，应在 `#62` 中集中处理。

## 验证

已执行：

- `uv run pre-commit run --all-files`
- `uv run pytest`
