### PR TITLE
refactor: split streaming orchestration helpers

### DIFF
--- a/src/codex_a2a_server/agent.py
+++ b/src/codex_a2a_server/agent.py
@@ -33,12 +33,8 @@ from .output_mapping import (
     extract_token_usage,
     merge_token_usage,
 )
-from .streaming import (
-    BlockType,
-    StreamOutputState,
-    build_stream_artifact_metadata,
-    consume_codex_stream,
-)
+from .stream_state import BlockType, StreamOutputState, build_stream_artifact_metadata
+from .streaming import consume_codex_stream
 
 logger = logging.getLogger(__name__)
 

--- a/src/codex_a2a_server/stream_chunks.py
+++ b/src/codex_a2a_server/stream_chunks.py
@@ -1,0 +1,409 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from typing import Any
+
+from a2a.types import DataPart, TextPart
+
+from .stream_state import BlockType, NormalizedStreamChunk, StreamPartState
+from .tool_call_payloads import (
+    ToolCallPayload,
+    as_tool_call_payload,
+    normalize_tool_call_payload,
+    serialize_tool_call_payload,
+    tool_call_state_payload_from_part,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def normalize_role(role: Any) -> str | None:
+    if not isinstance(role, str):
+        return None
+    value = role.strip().lower()
+    if not value:
+        return None
+    if value.startswith("role_"):
+        value = value[5:]
+    if value in {"assistant", "agent", "model", "ai"}:
+        return "agent"
+    if value in {"user", "human"}:
+        return "user"
+    if value == "system":
+        return "system"
+    return value
+
+
+def extract_stream_role(part: Mapping[str, Any], props: Mapping[str, Any]) -> str | None:
+    role = part.get("role") or props.get("role")
+    if role is None:
+        message = props.get("message")
+        if isinstance(message, Mapping):
+            role = message.get("role")
+    return normalize_role(role)
+
+
+def extract_first_nonempty_string(
+    source: Mapping[str, Any] | None,
+    keys: tuple[str, ...],
+) -> str | None:
+    if not isinstance(source, Mapping):
+        return None
+    for key in keys:
+        value = source.get(key)
+        if isinstance(value, str):
+            normalized = value.strip()
+            if normalized:
+                return normalized
+    return None
+
+
+def _extract_first_nonempty_string_from_sources(
+    *sources: tuple[Mapping[str, Any] | None, tuple[str, ...]],
+) -> str | None:
+    for source, keys in sources:
+        candidate = extract_first_nonempty_string(source, keys)
+        if candidate:
+            return candidate
+    return None
+
+
+def _extract_mapping(source: Mapping[str, Any] | None, key: str) -> Mapping[str, Any] | None:
+    if not isinstance(source, Mapping):
+        return None
+    value = source.get(key)
+    if isinstance(value, Mapping):
+        return value
+    return None
+
+
+def extract_stream_session_id(part: Mapping[str, Any], props: Mapping[str, Any]) -> str | None:
+    return _extract_first_nonempty_string_from_sources(
+        (part, ("sessionID",)),
+        (props, ("sessionID",)),
+    )
+
+
+def extract_event_session_id(event: Mapping[str, Any]) -> str | None:
+    props = event.get("properties")
+    if not isinstance(props, Mapping):
+        return None
+    return _extract_first_nonempty_string_from_sources(
+        (props, ("sessionID",)),
+        (_extract_mapping(props, "info"), ("sessionID",)),
+        (_extract_mapping(props, "part"), ("sessionID",)),
+    )
+
+
+def extract_stream_message_id(part: Mapping[str, Any], props: Mapping[str, Any]) -> str | None:
+    return _extract_first_nonempty_string_from_sources(
+        (part, ("messageID",)),
+        (props, ("messageID",)),
+    )
+
+
+def extract_stream_part_id(part: Mapping[str, Any], props: Mapping[str, Any]) -> str | None:
+    return _extract_first_nonempty_string_from_sources(
+        (part, ("id",)),
+        (props, ("partID",)),
+    )
+
+
+def extract_stream_part_type(part: Mapping[str, Any], props: Mapping[str, Any]) -> str | None:
+    for value in (
+        part.get("type"),
+        part.get("kind"),
+        props.get("partType"),
+        props.get("part_type"),
+    ):
+        if isinstance(value, str):
+            normalized = value.strip().lower()
+            if normalized:
+                return normalized
+    return None
+
+
+def map_part_type_to_block_type(part_type: str | None) -> BlockType | None:
+    if not part_type:
+        return None
+    if part_type == "text":
+        return BlockType.TEXT
+    if part_type in {"reasoning", "thinking", "thought"}:
+        return BlockType.REASONING
+    if part_type in {
+        "tool",
+        "tool_call",
+        "toolcall",
+        "function_call",
+        "functioncall",
+        "action",
+    }:
+        return BlockType.TOOL_CALL
+    return None
+
+
+def resolve_stream_block_type(
+    part: Mapping[str, Any], props: Mapping[str, Any]
+) -> BlockType | None:
+    explicit_part_type = extract_stream_part_type(part, props)
+    if explicit_part_type is not None:
+        return map_part_type_to_block_type(explicit_part_type)
+    return classify_stream_block_type(part, props)
+
+
+def classify_stream_block_type(
+    part: Mapping[str, Any], props: Mapping[str, Any]
+) -> BlockType | None:
+    candidates: list[str] = []
+    for value in (
+        part.get("block_type"),
+        props.get("block_type"),
+        part.get("channel"),
+        props.get("channel"),
+        part.get("kind"),
+        props.get("kind"),
+        props.get("type"),
+        props.get("deltaType"),
+        props.get("phase"),
+        props.get("name"),
+    ):
+        if isinstance(value, str) and value.strip():
+            candidates.append(value.strip().lower())
+
+    if any(
+        any(keyword in candidate for keyword in ("reason", "thinking", "thought"))
+        for candidate in candidates
+    ):
+        return BlockType.REASONING
+    if any(
+        any(
+            keyword in candidate
+            for keyword in (
+                "tool",
+                "function_call",
+                "functioncall",
+                "tool_call",
+                "toolcall",
+                "action",
+            )
+        )
+        for candidate in candidates
+    ):
+        return BlockType.TOOL_CALL
+    if any(
+        any(keyword in candidate for keyword in ("text", "answer", "final"))
+        for candidate in candidates
+    ):
+        return BlockType.TEXT
+    return None
+
+
+def new_chunk(
+    *,
+    part: TextPart | DataPart,
+    content_key: str,
+    append: bool,
+    block_type: BlockType,
+    source: str,
+    message_id: str | None,
+    role: str | None,
+    part_id: str | None,
+) -> NormalizedStreamChunk:
+    return NormalizedStreamChunk(
+        part=part,
+        content_key=content_key,
+        append=append,
+        block_type=block_type,
+        source=source,
+        message_id=message_id,
+        role=role,
+        part_id=part_id,
+    )
+
+
+def upsert_stream_part_state(
+    *,
+    part_states: dict[str, StreamPartState],
+    part_id: str,
+    part: Mapping[str, Any],
+    props: Mapping[str, Any],
+    role: str | None,
+    message_id: str | None,
+) -> StreamPartState | None:
+    block_type = resolve_stream_block_type(part, props)
+    if block_type is None:
+        return None
+    state = part_states.get(part_id)
+    if state is None:
+        state = StreamPartState(
+            part_id=part_id,
+            block_type=block_type,
+            message_id=message_id,
+            role=role,
+        )
+        part_states[part_id] = state
+        return state
+    state.part_id = part_id
+    state.block_type = block_type
+    if role is not None:
+        state.role = role
+    if message_id:
+        state.message_id = message_id
+    return state
+
+
+def delta_chunks(
+    *,
+    state: StreamPartState,
+    delta_text: str,
+    message_id: str | None,
+    source: str,
+) -> list[NormalizedStreamChunk]:
+    if not delta_text:
+        return []
+    if message_id:
+        state.message_id = message_id
+    state.buffer = f"{state.buffer}{delta_text}"
+    state.saw_delta = True
+    return [
+        new_chunk(
+            part=TextPart(text=delta_text),
+            content_key=delta_text,
+            append=True,
+            block_type=state.block_type,
+            source=source,
+            message_id=state.message_id,
+            role=state.role,
+            part_id=state.part_id,
+        )
+    ]
+
+
+def snapshot_chunks(
+    *,
+    state: StreamPartState,
+    snapshot: str,
+    message_id: str | None,
+    task_id: str,
+    session_id: str,
+) -> list[NormalizedStreamChunk]:
+    if message_id:
+        state.message_id = message_id
+    previous = state.buffer
+    if snapshot == previous:
+        return []
+    if snapshot.startswith(previous):
+        delta_text = snapshot[len(previous) :]
+        state.buffer = snapshot
+        if not delta_text:
+            return []
+        return [
+            new_chunk(
+                part=TextPart(text=delta_text),
+                content_key=delta_text,
+                append=True,
+                block_type=state.block_type,
+                source="part_text_diff",
+                message_id=state.message_id,
+                role=state.role,
+                part_id=state.part_id,
+            )
+        ]
+    state.buffer = snapshot
+    logger.warning(
+        "Suppressing non-prefix snapshot rewrite "
+        "task_id=%s session_id=%s part_id=%s block_type=%s had_delta=%s",
+        task_id,
+        session_id,
+        state.part_id,
+        state.block_type.value,
+        state.saw_delta,
+    )
+    return []
+
+
+def emit_tool_payload_chunk(
+    *,
+    state: StreamPartState,
+    payload: ToolCallPayload,
+    message_id: str | None,
+    source: str,
+) -> list[NormalizedStreamChunk]:
+    tool_chunk = serialize_tool_call_payload(payload)
+    if message_id:
+        state.message_id = message_id
+    if payload.kind == "state" and tool_chunk == state.last_tool_state_payload:
+        return []
+    append = state.emitted_tool_chunks > 0
+    state.emitted_tool_chunks += 1
+    if payload.kind == "state":
+        state.last_tool_state_payload = tool_chunk
+    content_key = tool_chunk if not append else f"\n{tool_chunk}"
+    return [
+        new_chunk(
+            part=DataPart(data=as_tool_call_payload(payload)),
+            content_key=content_key,
+            append=append,
+            block_type=state.block_type,
+            source=source,
+            message_id=state.message_id,
+            role=state.role,
+            part_id=state.part_id,
+        )
+    ]
+
+
+def tool_part_chunks(
+    *,
+    state: StreamPartState,
+    part: Mapping[str, Any],
+    message_id: str | None,
+) -> list[NormalizedStreamChunk]:
+    payload = tool_call_state_payload_from_part(part)
+    if payload is None:
+        return []
+    return emit_tool_payload_chunk(
+        state=state,
+        payload=payload,
+        message_id=message_id,
+        source="tool_part_update",
+    )
+
+
+def tool_delta_chunks(
+    *,
+    state: StreamPartState,
+    delta_value: Any,
+    message_id: str | None,
+    source: str,
+    task_id: str,
+    session_id: str,
+) -> list[NormalizedStreamChunk]:
+    if not isinstance(delta_value, Mapping):
+        logger.warning(
+            "Suppressing non-structured tool_call payload "
+            "task_id=%s session_id=%s source=%s payload=%s",
+            task_id,
+            session_id,
+            source,
+            delta_value,
+        )
+        return []
+    payload = normalize_tool_call_payload(delta_value)
+    if payload is None:
+        logger.warning(
+            "Suppressing unrecognized tool_call payload "
+            "task_id=%s session_id=%s source=%s payload=%s",
+            task_id,
+            session_id,
+            source,
+            delta_value,
+        )
+        return []
+    return emit_tool_payload_chunk(
+        state=state,
+        payload=payload,
+        message_id=message_id,
+        source=source,
+    )

--- a/src/codex_a2a_server/stream_interrupts.py
+++ b/src/codex_a2a_server/stream_interrupts.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+_INTERRUPT_ASKED_EVENT_TYPES = {"permission.asked", "question.asked"}
+_INTERRUPT_RESOLVED_EVENT_TYPES = {"permission.replied", "question.replied", "question.rejected"}
+
+
+def extract_string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    result: list[str] = []
+    for item in value:
+        if not isinstance(item, str):
+            continue
+        normalized = item.strip()
+        if normalized:
+            result.append(normalized)
+    return result
+
+
+def extract_interrupt_asked_event(event: Mapping[str, Any]) -> dict[str, Any] | None:
+    event_type = event.get("type")
+    if event_type not in _INTERRUPT_ASKED_EVENT_TYPES:
+        return None
+    props = event.get("properties")
+    if not isinstance(props, Mapping):
+        return None
+    request_id = props.get("id")
+    if not isinstance(request_id, str):
+        return None
+    normalized_request_id = request_id.strip()
+    if not normalized_request_id:
+        return None
+    if event_type == "permission.asked":
+        details: dict[str, Any] = {
+            "permission": props.get("permission"),
+            "patterns": extract_string_list(props.get("patterns")),
+            "always": extract_string_list(props.get("always")),
+        }
+        codex_private: dict[str, Any] = {}
+        if isinstance(props.get("metadata"), Mapping):
+            codex_private["metadata"] = dict(props.get("metadata"))
+        tool = props.get("tool")
+        if isinstance(tool, Mapping):
+            codex_private["tool"] = dict(tool)
+        return {
+            "request_id": normalized_request_id,
+            "interrupt_type": "permission",
+            "details": details,
+            "codex_private": codex_private,
+        }
+    questions = props.get("questions")
+    details = {"questions": questions if isinstance(questions, list) else []}
+    codex_private = {}
+    tool = props.get("tool")
+    if isinstance(tool, Mapping):
+        codex_private["tool"] = dict(tool)
+    return {
+        "request_id": normalized_request_id,
+        "interrupt_type": "question",
+        "details": details,
+        "codex_private": codex_private,
+    }
+
+
+def extract_interrupt_resolved_event(event: Mapping[str, Any]) -> dict[str, str] | None:
+    event_type = event.get("type")
+    if event_type not in _INTERRUPT_RESOLVED_EVENT_TYPES:
+        return None
+    props = event.get("properties")
+    if not isinstance(props, Mapping):
+        return None
+    request_id = props.get("requestID") or props.get("id")
+    if not isinstance(request_id, str):
+        return None
+    normalized_request_id = request_id.strip()
+    if not normalized_request_id:
+        return None
+    if event_type == "permission.replied":
+        return {
+            "request_id": normalized_request_id,
+            "event_type": event_type,
+            "interrupt_type": "permission",
+            "resolution": "replied",
+        }
+    if event_type == "question.rejected":
+        return {
+            "request_id": normalized_request_id,
+            "event_type": event_type,
+            "interrupt_type": "question",
+            "resolution": "rejected",
+        }
+    return {
+        "request_id": normalized_request_id,
+        "event_type": event_type,
+        "interrupt_type": "question",
+        "resolution": "replied",
+    }

--- a/src/codex_a2a_server/stream_state.py
+++ b/src/codex_a2a_server/stream_state.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+from a2a.types import DataPart, TextPart
+
+from .output_mapping import merge_token_usage
+
+_STREAM_TEXT_FLUSH_CHARS = 120
+_STREAM_TEXT_FLUSH_SECONDS = 0.2
+_STREAM_REASONING_FLUSH_CHARS = 240
+_STREAM_REASONING_FLUSH_SECONDS = 0.35
+
+
+class BlockType(str, Enum):
+    TEXT = "text"
+    REASONING = "reasoning"
+    TOOL_CALL = "tool_call"
+
+
+def flush_char_limit(block_type: BlockType) -> int:
+    if block_type == BlockType.REASONING:
+        return _STREAM_REASONING_FLUSH_CHARS
+    return _STREAM_TEXT_FLUSH_CHARS
+
+
+def flush_time_limit(block_type: BlockType) -> float:
+    if block_type == BlockType.REASONING:
+        return _STREAM_REASONING_FLUSH_SECONDS
+    return _STREAM_TEXT_FLUSH_SECONDS
+
+
+@dataclass(frozen=True)
+class NormalizedStreamChunk:
+    part: TextPart | DataPart
+    content_key: str
+    append: bool
+    block_type: BlockType
+    source: str
+    message_id: str | None
+    role: str | None
+    part_id: str | None
+
+
+@dataclass(frozen=True)
+class PendingDelta:
+    field: str
+    delta: str
+    message_id: str | None
+
+
+@dataclass
+class StreamPartState:
+    part_id: str
+    block_type: BlockType
+    message_id: str | None
+    role: str | None
+    buffer: str = ""
+    saw_delta: bool = False
+    emitted_tool_chunks: int = 0
+    last_tool_state_payload: str | None = None
+
+
+@dataclass
+class BufferedTextChunk:
+    block_type: BlockType
+    part_id: str | None
+    message_id: str | None
+    role: str | None
+    source: str
+    append: bool
+    text: str
+    started_at: float
+
+    @classmethod
+    def from_chunk(cls, chunk: NormalizedStreamChunk, *, now: float) -> BufferedTextChunk:
+        text = chunk.part.text if isinstance(chunk.part, TextPart) else ""
+        return cls(
+            block_type=chunk.block_type,
+            part_id=chunk.part_id,
+            message_id=chunk.message_id,
+            role=chunk.role,
+            source=chunk.source,
+            append=chunk.append,
+            text=text,
+            started_at=now,
+        )
+
+    def can_merge(self, chunk: NormalizedStreamChunk) -> bool:
+        if not isinstance(chunk.part, TextPart):
+            return False
+        if chunk.block_type not in {BlockType.TEXT, BlockType.REASONING}:
+            return False
+        return (
+            self.block_type == chunk.block_type
+            and self.part_id == chunk.part_id
+            and self.message_id == chunk.message_id
+            and self.role == chunk.role
+            and self.source == chunk.source
+            and self.append == chunk.append
+        )
+
+    def append_chunk(self, chunk: NormalizedStreamChunk) -> None:
+        if not isinstance(chunk.part, TextPart):
+            return
+        self.text = f"{self.text}{chunk.part.text}"
+
+    def should_flush(self, *, now: float) -> bool:
+        return len(self.text) >= flush_char_limit(self.block_type) or (
+            now - self.started_at
+        ) >= flush_time_limit(self.block_type)
+
+    def to_chunk(self) -> NormalizedStreamChunk:
+        return NormalizedStreamChunk(
+            part=TextPart(text=self.text),
+            content_key=self.text,
+            append=self.append,
+            block_type=self.block_type,
+            source=self.source,
+            message_id=self.message_id,
+            role=self.role,
+            part_id=self.part_id,
+        )
+
+
+@dataclass
+class StreamOutputState:
+    user_text: str
+    stable_message_id: str
+    event_id_namespace: str
+    content_buffers: dict[BlockType, str] = field(default_factory=dict)
+    token_usage: dict[str, Any] | None = None
+    pending_interrupt_request_ids: set[str] = field(default_factory=set)
+    saw_any_chunk: bool = False
+    emitted_stream_chunk: bool = False
+    sequence: int = 0
+
+    def should_drop_initial_user_echo(
+        self,
+        text: str,
+        *,
+        block_type: BlockType,
+        role: str | None,
+    ) -> bool:
+        if role is not None:
+            return False
+        if block_type != BlockType.TEXT:
+            return False
+        if self.saw_any_chunk:
+            return False
+        user_text = self.user_text.strip()
+        return bool(user_text) and text.strip() == user_text
+
+    def register_chunk(
+        self, *, block_type: BlockType, content_key: str, append: bool
+    ) -> tuple[bool, bool]:
+        previous = self.content_buffers.get(block_type, "")
+        next_value = f"{previous}{content_key}" if append else content_key
+        if next_value == previous:
+            return False, False
+        self.content_buffers[block_type] = next_value
+        self.saw_any_chunk = True
+        effective_append = self.emitted_stream_chunk
+        self.emitted_stream_chunk = True
+        return True, effective_append
+
+    def should_emit_final_snapshot(self, text: str) -> bool:
+        if not text.strip():
+            return False
+        existing = self.content_buffers.get(BlockType.TEXT, "")
+        if existing.strip() == text.strip():
+            return False
+        self.content_buffers[BlockType.TEXT] = text
+        self.saw_any_chunk = True
+        return True
+
+    def next_sequence(self) -> int:
+        self.sequence += 1
+        return self.sequence
+
+    def resolve_message_id(self, message_id: str | None) -> str:
+        if isinstance(message_id, str):
+            normalized = message_id.strip()
+            if normalized:
+                return normalized
+        return self.stable_message_id
+
+    def build_event_id(self, sequence: int) -> str:
+        return f"{self.event_id_namespace}:{sequence}"
+
+    def ingest_token_usage(self, usage: dict[str, Any] | None) -> None:
+        self.token_usage = merge_token_usage(self.token_usage, usage)
+
+    def mark_interrupt_pending(self, request_id: str) -> bool:
+        normalized = request_id.strip()
+        if not normalized:
+            return False
+        if normalized in self.pending_interrupt_request_ids:
+            return False
+        self.pending_interrupt_request_ids.add(normalized)
+        return True
+
+    def clear_interrupt_pending(self, request_id: str) -> bool:
+        normalized = request_id.strip()
+        if not normalized or normalized not in self.pending_interrupt_request_ids:
+            return False
+        self.pending_interrupt_request_ids.discard(normalized)
+        return True
+
+
+def build_stream_artifact_metadata(
+    *,
+    block_type: BlockType,
+    source: str,
+    message_id: str | None = None,
+    role: str | None = None,
+    sequence: int | None = None,
+    event_id: str | None = None,
+) -> dict[str, Any]:
+    stream_meta: dict[str, Any] = {
+        "block_type": block_type.value,
+        "source": source,
+    }
+    if message_id:
+        stream_meta["message_id"] = message_id
+    if role:
+        stream_meta["role"] = role
+    if sequence is not None:
+        stream_meta["sequence"] = sequence
+    if event_id:
+        stream_meta["event_id"] = event_id
+    return {"shared": {"stream": stream_meta}}

--- a/src/codex_a2a_server/streaming.py
+++ b/src/codex_a2a_server/streaming.py
@@ -6,257 +6,58 @@ import time
 from collections import defaultdict
 from collections.abc import Mapping
 from contextlib import suppress
-from dataclasses import dataclass, field
-from enum import Enum
 from typing import Any
 
 from a2a.server.events.event_queue import EventQueue
-from a2a.types import DataPart, TaskState, TaskStatus, TaskStatusUpdateEvent, TextPart
+from a2a.types import TaskState, TaskStatus, TaskStatusUpdateEvent, TextPart
 
 from .codex_client import CodexClient
 from .output_mapping import (
     build_output_metadata,
     enqueue_artifact_update,
     extract_token_usage,
-    merge_token_usage,
 )
-from .tool_call_payloads import (
-    ToolCallPayload,
-    as_tool_call_payload,
-    normalize_tool_call_payload,
-    serialize_tool_call_payload,
-    tool_call_state_payload_from_part,
+from .stream_chunks import (
+    delta_chunks,
+    extract_event_session_id,
+    extract_stream_message_id,
+    extract_stream_part_id,
+    extract_stream_role,
+    extract_stream_session_id,
+    snapshot_chunks,
+    tool_delta_chunks,
+    tool_part_chunks,
+    upsert_stream_part_state,
+)
+from .stream_interrupts import (
+    extract_interrupt_asked_event,
+    extract_interrupt_resolved_event,
+)
+from .stream_state import (
+    BlockType,
+    BufferedTextChunk,
+    NormalizedStreamChunk,
+    PendingDelta,
+    StreamOutputState,
+    StreamPartState,
+    build_stream_artifact_metadata,
+    flush_time_limit,
 )
 
 logger = logging.getLogger(__name__)
 
-_INTERRUPT_ASKED_EVENT_TYPES = {"permission.asked", "question.asked"}
-_INTERRUPT_RESOLVED_EVENT_TYPES = {"permission.replied", "question.replied", "question.rejected"}
 _STREAM_COMPLETION_DRAIN_SECONDS = 0.05
-_STREAM_TEXT_FLUSH_CHARS = 120
-_STREAM_TEXT_FLUSH_SECONDS = 0.2
-_STREAM_REASONING_FLUSH_CHARS = 240
-_STREAM_REASONING_FLUSH_SECONDS = 0.35
-
-
-class BlockType(str, Enum):
-    TEXT = "text"
-    REASONING = "reasoning"
-    TOOL_CALL = "tool_call"
-
-
-def flush_char_limit(block_type: BlockType) -> int:
-    if block_type == BlockType.REASONING:
-        return _STREAM_REASONING_FLUSH_CHARS
-    return _STREAM_TEXT_FLUSH_CHARS
-
-
-def flush_time_limit(block_type: BlockType) -> float:
-    if block_type == BlockType.REASONING:
-        return _STREAM_REASONING_FLUSH_SECONDS
-    return _STREAM_TEXT_FLUSH_SECONDS
-
-
-@dataclass(frozen=True)
-class NormalizedStreamChunk:
-    part: TextPart | DataPart
-    content_key: str
-    append: bool
-    block_type: BlockType
-    source: str
-    message_id: str | None
-    role: str | None
-    part_id: str | None
-
-
-@dataclass(frozen=True)
-class PendingDelta:
-    field: str
-    delta: str
-    message_id: str | None
-
-
-@dataclass
-class StreamPartState:
-    part_id: str
-    block_type: BlockType
-    message_id: str | None
-    role: str | None
-    buffer: str = ""
-    saw_delta: bool = False
-    emitted_tool_chunks: int = 0
-    last_tool_state_payload: str | None = None
-
-
-@dataclass
-class BufferedTextChunk:
-    block_type: BlockType
-    part_id: str | None
-    message_id: str | None
-    role: str | None
-    source: str
-    append: bool
-    text: str
-    started_at: float
-
-    @classmethod
-    def from_chunk(cls, chunk: NormalizedStreamChunk, *, now: float) -> BufferedTextChunk:
-        text = chunk.part.text if isinstance(chunk.part, TextPart) else ""
-        return cls(
-            block_type=chunk.block_type,
-            part_id=chunk.part_id,
-            message_id=chunk.message_id,
-            role=chunk.role,
-            source=chunk.source,
-            append=chunk.append,
-            text=text,
-            started_at=now,
-        )
-
-    def can_merge(self, chunk: NormalizedStreamChunk) -> bool:
-        if not isinstance(chunk.part, TextPart):
-            return False
-        if chunk.block_type not in {BlockType.TEXT, BlockType.REASONING}:
-            return False
-        return (
-            self.block_type == chunk.block_type
-            and self.part_id == chunk.part_id
-            and self.message_id == chunk.message_id
-            and self.role == chunk.role
-            and self.source == chunk.source
-            and self.append == chunk.append
-        )
-
-    def append_chunk(self, chunk: NormalizedStreamChunk) -> None:
-        if not isinstance(chunk.part, TextPart):
-            return
-        self.text = f"{self.text}{chunk.part.text}"
-
-    def should_flush(self, *, now: float) -> bool:
-        return len(self.text) >= flush_char_limit(self.block_type) or (
-            now - self.started_at
-        ) >= flush_time_limit(self.block_type)
-
-    def to_chunk(self) -> NormalizedStreamChunk:
-        return NormalizedStreamChunk(
-            part=TextPart(text=self.text),
-            content_key=self.text,
-            append=self.append,
-            block_type=self.block_type,
-            source=self.source,
-            message_id=self.message_id,
-            role=self.role,
-            part_id=self.part_id,
-        )
-
-
-@dataclass
-class StreamOutputState:
-    user_text: str
-    stable_message_id: str
-    event_id_namespace: str
-    content_buffers: dict[BlockType, str] = field(default_factory=dict)
-    token_usage: dict[str, Any] | None = None
-    pending_interrupt_request_ids: set[str] = field(default_factory=set)
-    saw_any_chunk: bool = False
-    emitted_stream_chunk: bool = False
-    sequence: int = 0
-
-    def should_drop_initial_user_echo(
-        self,
-        text: str,
-        *,
-        block_type: BlockType,
-        role: str | None,
-    ) -> bool:
-        if role is not None:
-            return False
-        if block_type != BlockType.TEXT:
-            return False
-        if self.saw_any_chunk:
-            return False
-        user_text = self.user_text.strip()
-        return bool(user_text) and text.strip() == user_text
-
-    def register_chunk(
-        self, *, block_type: BlockType, content_key: str, append: bool
-    ) -> tuple[bool, bool]:
-        previous = self.content_buffers.get(block_type, "")
-        next_value = f"{previous}{content_key}" if append else content_key
-        if next_value == previous:
-            return False, False
-        self.content_buffers[block_type] = next_value
-        self.saw_any_chunk = True
-        effective_append = self.emitted_stream_chunk
-        self.emitted_stream_chunk = True
-        return True, effective_append
-
-    def should_emit_final_snapshot(self, text: str) -> bool:
-        if not text.strip():
-            return False
-        existing = self.content_buffers.get(BlockType.TEXT, "")
-        if existing.strip() == text.strip():
-            return False
-        self.content_buffers[BlockType.TEXT] = text
-        self.saw_any_chunk = True
-        return True
-
-    def next_sequence(self) -> int:
-        self.sequence += 1
-        return self.sequence
-
-    def resolve_message_id(self, message_id: str | None) -> str:
-        if isinstance(message_id, str):
-            normalized = message_id.strip()
-            if normalized:
-                return normalized
-        return self.stable_message_id
-
-    def build_event_id(self, sequence: int) -> str:
-        return f"{self.event_id_namespace}:{sequence}"
-
-    def ingest_token_usage(self, usage: Mapping[str, Any] | None) -> None:
-        self.token_usage = merge_token_usage(self.token_usage, usage)
-
-    def mark_interrupt_pending(self, request_id: str) -> bool:
-        normalized = request_id.strip()
-        if not normalized:
-            return False
-        if normalized in self.pending_interrupt_request_ids:
-            return False
-        self.pending_interrupt_request_ids.add(normalized)
-        return True
-
-    def clear_interrupt_pending(self, request_id: str) -> bool:
-        normalized = request_id.strip()
-        if not normalized or normalized not in self.pending_interrupt_request_ids:
-            return False
-        self.pending_interrupt_request_ids.discard(normalized)
-        return True
-
-
-def build_stream_artifact_metadata(
-    *,
-    block_type: BlockType,
-    source: str,
-    message_id: str | None = None,
-    role: str | None = None,
-    sequence: int | None = None,
-    event_id: str | None = None,
-) -> dict[str, Any]:
-    stream_meta: dict[str, Any] = {
-        "block_type": block_type.value,
-        "source": source,
-    }
-    if message_id:
-        stream_meta["message_id"] = message_id
-    if role:
-        stream_meta["role"] = role
-    if sequence is not None:
-        stream_meta["sequence"] = sequence
-    if event_id:
-        stream_meta["event_id"] = event_id
-    return {"shared": {"stream": stream_meta}}
+__all__ = [
+    "BlockType",
+    "StreamOutputState",
+    "build_stream_artifact_metadata",
+    "consume_codex_stream",
+    "extract_event_session_id",
+    "extract_interrupt_resolved_event",
+    "extract_stream_message_id",
+    "extract_stream_part_id",
+    "extract_stream_session_id",
+]
 
 
 async def consume_codex_stream(
@@ -400,205 +201,6 @@ async def consume_codex_stream(
             )
         )
 
-    def new_chunk(
-        *,
-        part: TextPart | DataPart,
-        content_key: str,
-        append: bool,
-        block_type: BlockType,
-        source: str,
-        message_id: str | None,
-        role: str | None,
-        part_id: str | None,
-    ) -> NormalizedStreamChunk:
-        return NormalizedStreamChunk(
-            part=part,
-            content_key=content_key,
-            append=append,
-            block_type=block_type,
-            source=source,
-            message_id=message_id,
-            role=role,
-            part_id=part_id,
-        )
-
-    def upsert_part_state(
-        *,
-        part_id: str,
-        part: Mapping[str, Any],
-        props: Mapping[str, Any],
-        role: str | None,
-        message_id: str | None,
-    ) -> StreamPartState | None:
-        block_type = resolve_stream_block_type(part, props)
-        if block_type is None:
-            return None
-        state = part_states.get(part_id)
-        if state is None:
-            state = StreamPartState(
-                part_id=part_id,
-                block_type=block_type,
-                message_id=message_id,
-                role=role,
-            )
-            part_states[part_id] = state
-            return state
-        state.part_id = part_id
-        state.block_type = block_type
-        if role is not None:
-            state.role = role
-        if message_id:
-            state.message_id = message_id
-        return state
-
-    def delta_chunks(
-        *,
-        state: StreamPartState,
-        delta_text: str,
-        message_id: str | None,
-        source: str,
-    ) -> list[NormalizedStreamChunk]:
-        if not delta_text:
-            return []
-        if message_id:
-            state.message_id = message_id
-        state.buffer = f"{state.buffer}{delta_text}"
-        state.saw_delta = True
-        return [
-            new_chunk(
-                part=TextPart(text=delta_text),
-                content_key=delta_text,
-                append=True,
-                block_type=state.block_type,
-                source=source,
-                message_id=state.message_id,
-                role=state.role,
-                part_id=state.part_id,
-            )
-        ]
-
-    def snapshot_chunks(
-        *,
-        state: StreamPartState,
-        snapshot: str,
-        message_id: str | None,
-        part_id: str,
-    ) -> list[NormalizedStreamChunk]:
-        if message_id:
-            state.message_id = message_id
-        previous = state.buffer
-        if snapshot == previous:
-            return []
-        if snapshot.startswith(previous):
-            delta_text = snapshot[len(previous) :]
-            state.buffer = snapshot
-            if not delta_text:
-                return []
-            return [
-                new_chunk(
-                    part=TextPart(text=delta_text),
-                    content_key=delta_text,
-                    append=True,
-                    block_type=state.block_type,
-                    source="part_text_diff",
-                    message_id=state.message_id,
-                    role=state.role,
-                    part_id=state.part_id,
-                )
-            ]
-        state.buffer = snapshot
-        logger.warning(
-            "Suppressing non-prefix snapshot rewrite "
-            "task_id=%s session_id=%s part_id=%s block_type=%s had_delta=%s",
-            task_id,
-            session_id,
-            part_id,
-            state.block_type.value,
-            state.saw_delta,
-        )
-        return []
-
-    def emit_tool_payload_chunk(
-        *,
-        state: StreamPartState,
-        payload: ToolCallPayload,
-        message_id: str | None,
-        source: str,
-    ) -> list[NormalizedStreamChunk]:
-        tool_chunk = serialize_tool_call_payload(payload)
-        if message_id:
-            state.message_id = message_id
-        if payload.kind == "state" and tool_chunk == state.last_tool_state_payload:
-            return []
-        append = state.emitted_tool_chunks > 0
-        state.emitted_tool_chunks += 1
-        if payload.kind == "state":
-            state.last_tool_state_payload = tool_chunk
-        content_key = tool_chunk if not append else f"\n{tool_chunk}"
-        return [
-            new_chunk(
-                part=DataPart(data=as_tool_call_payload(payload)),
-                content_key=content_key,
-                append=append,
-                block_type=state.block_type,
-                source=source,
-                message_id=state.message_id,
-                role=state.role,
-                part_id=state.part_id,
-            )
-        ]
-
-    def tool_part_chunks(
-        *,
-        state: StreamPartState,
-        part: Mapping[str, Any],
-        message_id: str | None,
-    ) -> list[NormalizedStreamChunk]:
-        payload = tool_call_state_payload_from_part(part)
-        if payload is None:
-            return []
-        return emit_tool_payload_chunk(
-            state=state,
-            payload=payload,
-            message_id=message_id,
-            source="tool_part_update",
-        )
-
-    def tool_delta_chunks(
-        *,
-        state: StreamPartState,
-        delta_value: Any,
-        message_id: str | None,
-        source: str,
-    ) -> list[NormalizedStreamChunk]:
-        if not isinstance(delta_value, Mapping):
-            logger.warning(
-                "Suppressing non-structured tool_call payload "
-                "task_id=%s session_id=%s source=%s payload=%s",
-                task_id,
-                session_id,
-                source,
-                delta_value,
-            )
-            return []
-        payload = normalize_tool_call_payload(delta_value)
-        if payload is None:
-            logger.warning(
-                "Suppressing unrecognized tool_call payload "
-                "task_id=%s session_id=%s source=%s payload=%s",
-                task_id,
-                session_id,
-                source,
-                delta_value,
-            )
-            return []
-        return emit_tool_payload_chunk(
-            state=state,
-            payload=payload,
-            message_id=message_id,
-            source=source,
-        )
-
     try:
         while not stop_event.is_set():
             try:
@@ -708,6 +310,8 @@ async def consume_codex_stream(
                                 delta_value=delta,
                                 message_id=message_id,
                                 source="delta_event",
+                                task_id=task_id,
+                                session_id=session_id,
                             )
                         else:
                             chunks = delta_chunks(
@@ -721,7 +325,8 @@ async def consume_codex_stream(
                         continue
 
                     role = extract_stream_role(part, props)
-                    state = upsert_part_state(
+                    state = upsert_stream_part_state(
+                        part_states=part_states,
                         part_id=part_id,
                         part=part,
                         props=props,
@@ -747,6 +352,8 @@ async def consume_codex_stream(
                                     delta_value=buffered.delta,
                                     message_id=buffered.message_id,
                                     source="delta_event_buffered",
+                                    task_id=task_id,
+                                    session_id=session_id,
                                 )
                             )
                         else:
@@ -768,6 +375,8 @@ async def consume_codex_stream(
                                     delta_value=delta,
                                     message_id=message_id,
                                     source="delta",
+                                    task_id=task_id,
+                                    session_id=session_id,
                                 )
                             )
                         else:
@@ -793,7 +402,8 @@ async def consume_codex_stream(
                                 state=state,
                                 snapshot=part["text"],
                                 message_id=message_id,
-                                part_id=part_id,
+                                task_id=task_id,
+                                session_id=session_id,
                             )
                         )
 
@@ -819,271 +429,3 @@ async def consume_codex_stream(
         logger.exception("Codex event stream failed task_id=%s session_id=%s", task_id, session_id)
     finally:
         logger.debug("Codex event stream closed task_id=%s session_id=%s", task_id, session_id)
-
-
-def normalize_role(role: Any) -> str | None:
-    if not isinstance(role, str):
-        return None
-    value = role.strip().lower()
-    if not value:
-        return None
-    if value.startswith("role_"):
-        value = value[5:]
-    if value in {"assistant", "agent", "model", "ai"}:
-        return "agent"
-    if value in {"user", "human"}:
-        return "user"
-    if value == "system":
-        return "system"
-    return value
-
-
-def extract_stream_role(part: Mapping[str, Any], props: Mapping[str, Any]) -> str | None:
-    role = part.get("role") or props.get("role")
-    if role is None:
-        message = props.get("message")
-        if isinstance(message, Mapping):
-            role = message.get("role")
-    return normalize_role(role)
-
-
-def extract_first_nonempty_string(
-    source: Mapping[str, Any] | None,
-    keys: tuple[str, ...],
-) -> str | None:
-    if not isinstance(source, Mapping):
-        return None
-    for key in keys:
-        value = source.get(key)
-        if isinstance(value, str):
-            normalized = value.strip()
-            if normalized:
-                return normalized
-    return None
-
-
-def _extract_first_nonempty_string_from_sources(
-    *sources: tuple[Mapping[str, Any] | None, tuple[str, ...]],
-) -> str | None:
-    for source, keys in sources:
-        candidate = extract_first_nonempty_string(source, keys)
-        if candidate:
-            return candidate
-    return None
-
-
-def _extract_mapping(source: Mapping[str, Any] | None, key: str) -> Mapping[str, Any] | None:
-    if not isinstance(source, Mapping):
-        return None
-    value = source.get(key)
-    if isinstance(value, Mapping):
-        return value
-    return None
-
-
-def extract_stream_session_id(part: Mapping[str, Any], props: Mapping[str, Any]) -> str | None:
-    return _extract_first_nonempty_string_from_sources(
-        (part, ("sessionID",)),
-        (props, ("sessionID",)),
-    )
-
-
-def extract_event_session_id(event: Mapping[str, Any]) -> str | None:
-    props = event.get("properties")
-    if not isinstance(props, Mapping):
-        return None
-    return _extract_first_nonempty_string_from_sources(
-        (props, ("sessionID",)),
-        (_extract_mapping(props, "info"), ("sessionID",)),
-        (_extract_mapping(props, "part"), ("sessionID",)),
-    )
-
-
-def extract_string_list(value: Any) -> list[str]:
-    if not isinstance(value, list):
-        return []
-    result: list[str] = []
-    for item in value:
-        if not isinstance(item, str):
-            continue
-        normalized = item.strip()
-        if normalized:
-            result.append(normalized)
-    return result
-
-
-def extract_interrupt_asked_event(event: Mapping[str, Any]) -> dict[str, Any] | None:
-    event_type = event.get("type")
-    if event_type not in _INTERRUPT_ASKED_EVENT_TYPES:
-        return None
-    props = event.get("properties")
-    if not isinstance(props, Mapping):
-        return None
-    request_id = extract_first_nonempty_string(props, ("id",))
-    if not request_id:
-        return None
-    if event_type == "permission.asked":
-        details: dict[str, Any] = {
-            "permission": props.get("permission"),
-            "patterns": extract_string_list(props.get("patterns")),
-            "always": extract_string_list(props.get("always")),
-        }
-        codex_private: dict[str, Any] = {}
-        if isinstance(props.get("metadata"), Mapping):
-            codex_private["metadata"] = dict(props.get("metadata"))
-        tool = props.get("tool")
-        if isinstance(tool, Mapping):
-            codex_private["tool"] = dict(tool)
-        return {
-            "request_id": request_id,
-            "interrupt_type": "permission",
-            "details": details,
-            "codex_private": codex_private,
-        }
-    questions = props.get("questions")
-    details = {"questions": questions if isinstance(questions, list) else []}
-    codex_private = {}
-    tool = props.get("tool")
-    if isinstance(tool, Mapping):
-        codex_private["tool"] = dict(tool)
-    return {
-        "request_id": request_id,
-        "interrupt_type": "question",
-        "details": details,
-        "codex_private": codex_private,
-    }
-
-
-def extract_interrupt_resolved_event(event: Mapping[str, Any]) -> dict[str, str] | None:
-    event_type = event.get("type")
-    if event_type not in _INTERRUPT_RESOLVED_EVENT_TYPES:
-        return None
-    props = event.get("properties")
-    if not isinstance(props, Mapping):
-        return None
-    request_id = extract_first_nonempty_string(props, ("requestID", "id"))
-    if not request_id:
-        return None
-    if event_type == "permission.replied":
-        return {
-            "request_id": request_id,
-            "event_type": event_type,
-            "interrupt_type": "permission",
-            "resolution": "replied",
-        }
-    if event_type == "question.rejected":
-        return {
-            "request_id": request_id,
-            "event_type": event_type,
-            "interrupt_type": "question",
-            "resolution": "rejected",
-        }
-    return {
-        "request_id": request_id,
-        "event_type": event_type,
-        "interrupt_type": "question",
-        "resolution": "replied",
-    }
-
-
-def extract_stream_message_id(part: Mapping[str, Any], props: Mapping[str, Any]) -> str | None:
-    return _extract_first_nonempty_string_from_sources(
-        (part, ("messageID",)),
-        (props, ("messageID",)),
-    )
-
-
-def extract_stream_part_id(part: Mapping[str, Any], props: Mapping[str, Any]) -> str | None:
-    return _extract_first_nonempty_string_from_sources(
-        (part, ("id",)),
-        (props, ("partID",)),
-    )
-
-
-def extract_stream_part_type(part: Mapping[str, Any], props: Mapping[str, Any]) -> str | None:
-    for value in (
-        part.get("type"),
-        part.get("kind"),
-        props.get("partType"),
-        props.get("part_type"),
-    ):
-        if isinstance(value, str):
-            normalized = value.strip().lower()
-            if normalized:
-                return normalized
-    return None
-
-
-def map_part_type_to_block_type(part_type: str | None) -> BlockType | None:
-    if not part_type:
-        return None
-    if part_type == "text":
-        return BlockType.TEXT
-    if part_type in {"reasoning", "thinking", "thought"}:
-        return BlockType.REASONING
-    if part_type in {
-        "tool",
-        "tool_call",
-        "toolcall",
-        "function_call",
-        "functioncall",
-        "action",
-    }:
-        return BlockType.TOOL_CALL
-    return None
-
-
-def resolve_stream_block_type(
-    part: Mapping[str, Any], props: Mapping[str, Any]
-) -> BlockType | None:
-    explicit_part_type = extract_stream_part_type(part, props)
-    if explicit_part_type is not None:
-        return map_part_type_to_block_type(explicit_part_type)
-    return classify_stream_block_type(part, props)
-
-
-def classify_stream_block_type(
-    part: Mapping[str, Any], props: Mapping[str, Any]
-) -> BlockType | None:
-    candidates: list[str] = []
-    for value in (
-        part.get("block_type"),
-        props.get("block_type"),
-        part.get("channel"),
-        props.get("channel"),
-        part.get("kind"),
-        props.get("kind"),
-        props.get("type"),
-        props.get("deltaType"),
-        props.get("phase"),
-        props.get("name"),
-    ):
-        if isinstance(value, str) and value.strip():
-            candidates.append(value.strip().lower())
-
-    if any(
-        any(keyword in candidate for keyword in ("reason", "thinking", "thought"))
-        for candidate in candidates
-    ):
-        return BlockType.REASONING
-    if any(
-        any(
-            keyword in candidate
-            for keyword in (
-                "tool",
-                "function_call",
-                "functioncall",
-                "tool_call",
-                "toolcall",
-                "action",
-            )
-        )
-        for candidate in candidates
-    ):
-        return BlockType.TOOL_CALL
-    if any(
-        any(keyword in candidate for keyword in ("text", "answer", "final"))
-        for candidate in candidates
-    ):
-        return BlockType.TEXT
-    return None

--- a/tests/test_stream_chunks.py
+++ b/tests/test_stream_chunks.py
@@ -1,0 +1,139 @@
+import logging
+
+from codex_a2a_server.stream_chunks import (
+    delta_chunks,
+    snapshot_chunks,
+    tool_delta_chunks,
+    upsert_stream_part_state,
+)
+from codex_a2a_server.stream_state import BlockType, StreamPartState
+
+
+def test_upsert_stream_part_state_creates_and_updates_existing_state() -> None:
+    part_states: dict[str, StreamPartState] = {}
+
+    created = upsert_stream_part_state(
+        part_states=part_states,
+        part_id="part-1",
+        part={"type": "text"},
+        props={},
+        role="agent",
+        message_id="msg-1",
+    )
+
+    assert created is not None
+    assert created.block_type == BlockType.TEXT
+    assert created.role == "agent"
+    assert created.message_id == "msg-1"
+
+    updated = upsert_stream_part_state(
+        part_states=part_states,
+        part_id="part-1",
+        part={"type": "reasoning"},
+        props={},
+        role=None,
+        message_id="msg-2",
+    )
+
+    assert updated is created
+    assert updated.block_type == BlockType.REASONING
+    assert updated.role == "agent"
+    assert updated.message_id == "msg-2"
+
+
+def test_snapshot_chunks_emits_prefix_delta_and_suppresses_non_prefix_rewrite(
+    caplog,
+) -> None:
+    state = StreamPartState(
+        part_id="part-1",
+        block_type=BlockType.TEXT,
+        message_id="msg-1",
+        role="agent",
+        buffer="hello",
+        saw_delta=True,
+    )
+
+    chunks = snapshot_chunks(
+        state=state,
+        snapshot="hello world",
+        message_id="msg-2",
+        task_id="task-1",
+        session_id="ses-1",
+    )
+
+    assert len(chunks) == 1
+    assert chunks[0].part.text == " world"
+    assert chunks[0].source == "part_text_diff"
+    assert state.buffer == "hello world"
+    assert state.message_id == "msg-2"
+
+    with caplog.at_level(logging.WARNING):
+        suppressed = snapshot_chunks(
+            state=state,
+            snapshot="rewritten",
+            message_id=None,
+            task_id="task-1",
+            session_id="ses-1",
+        )
+
+    assert suppressed == []
+    assert state.buffer == "rewritten"
+    assert "Suppressing non-prefix snapshot rewrite" in caplog.text
+
+
+def test_delta_chunks_appends_text_and_marks_state_as_delta() -> None:
+    state = StreamPartState(
+        part_id="part-1",
+        block_type=BlockType.TEXT,
+        message_id=None,
+        role="agent",
+    )
+
+    chunks = delta_chunks(
+        state=state,
+        delta_text="answer",
+        message_id="msg-1",
+        source="delta_event",
+    )
+
+    assert len(chunks) == 1
+    assert chunks[0].part.text == "answer"
+    assert chunks[0].append is True
+    assert state.buffer == "answer"
+    assert state.saw_delta is True
+    assert state.message_id == "msg-1"
+
+
+def test_tool_delta_chunks_normalizes_payload_and_rejects_unstructured_payload(caplog) -> None:
+    state = StreamPartState(
+        part_id="part-tool",
+        block_type=BlockType.TOOL_CALL,
+        message_id="msg-1",
+        role="agent",
+    )
+
+    chunks = tool_delta_chunks(
+        state=state,
+        delta_value={"kind": "state", "tool": "bash", "status": "running"},
+        message_id="msg-2",
+        source="delta",
+        task_id="task-1",
+        session_id="ses-1",
+    )
+
+    assert len(chunks) == 1
+    assert chunks[0].part.data == {"kind": "state", "tool": "bash", "status": "running"}
+    assert state.message_id == "msg-2"
+
+    with caplog.at_level(logging.WARNING):
+        rejected = tool_delta_chunks(
+            state=state,
+            delta_value="bad-payload",
+            message_id=None,
+            source="delta",
+            task_id="task-1",
+            session_id="ses-1",
+        )
+
+    assert rejected == []
+    assert "Suppressing non-structured tool_call payload" in caplog.text


### PR DESCRIPTION
## 关联
- Closes #46

## 评估结论
- `#46` 当前仍然有效，问题本质是 `streaming.py` 的结构复杂度债务，而不是流式契约本身需要重写。
- 本次实现采用保守重构：拆出状态模型、chunk 规划和 interrupt 提取，保留 `consume_codex_stream()` 作为编排层。
- 不将 `#51`、`#64`、`#44` 混入本 PR；它们分别属于指标、idle/终态可观测性和长静默诊断，边界不同。

## Stream State
- 新增 `src/codex_a2a_server/stream_state.py`
- 收敛 `BlockType`、`StreamOutputState`、`StreamPartState`、`BufferedTextChunk` 和 stream metadata 构造逻辑
- 保持原有 flush 策略与 event metadata 语义不变

## Stream Chunks
- 新增 `src/codex_a2a_server/stream_chunks.py`
- 收敛 session/message/part 提取、block type 归一化、delta/snapshot/tool_call chunk 规划逻辑
- 将高复杂度但偏纯函数的规则从 `streaming.py` 中抽离，降低编排层分支密度

## Stream Interrupts
- 新增 `src/codex_a2a_server/stream_interrupts.py`
- 收敛 interrupt asked/resolved 事件提取逻辑
- 保持现有 interrupt status 映射与 metadata 结构不变

## Streaming Orchestrator
- 更新 `src/codex_a2a_server/streaming.py`
- 将其职责收敛为事件循环、buffer flush、interrupt status 发射和 orchestrator
- 对外保留现有导入面，避免额外扩大改动面

## Agent Integration
- 更新 `src/codex_a2a_server/agent.py`
- 改为直接依赖新的 stream state 模块，减少内部继续经由 `streaming.py` 再导出状态类型

## 测试
- 新增 `tests/test_stream_chunks.py`
- 直接覆盖 snapshot、tool_call、part state 三条高复杂度路径
- 保留并通过 `tests/test_streaming_output_contract.py` 全量回归，确认 A2A 输出契约未漂移

## 风险与边界
- 本 PR 目标是降低结构复杂度，不改变 shared contract、A2A 输出事件语义或流式行为边界
- 目前仍保留 `streaming.py` 作为统一编排入口，这是有意的；继续下钻拆分应以后续独立 issue 推进，而不是在本 PR 中扩散范围

## 验证
- `uv run pre-commit run --all-files`
- `uv run pytest`
