### PR TITLE
ops: add stream idle diagnostics

### DIFF
--- a/src/codex_a2a_server/streaming.py
+++ b/src/codex_a2a_server/streaming.py
@@ -214,6 +214,12 @@ async def consume_codex_stream(
             - (time.monotonic() - buffered_text_chunk.started_at),
         )
 
+    def seconds_until_idle_diagnostic() -> float | None:
+        if completion_event.is_set():
+            return None
+        threshold_base = diagnostics.last_idle_log_at or diagnostics.started_at
+        return max(0.0, _STREAM_IDLE_DIAGNOSTIC_SECONDS - (time.monotonic() - threshold_base))
+
     async def flush_buffered_text_chunk() -> None:
         nonlocal buffered_text_chunk
         if buffered_text_chunk is None:
@@ -299,6 +305,13 @@ async def consume_codex_stream(
                     if pending_event_task is None:
                         pending_event_task = asyncio.create_task(anext(stream_iter))
                     wait_timeout = seconds_until_buffer_flush()
+                    idle_timeout = seconds_until_idle_diagnostic()
+                    if idle_timeout is not None:
+                        wait_timeout = (
+                            idle_timeout
+                            if wait_timeout is None
+                            else min(wait_timeout, idle_timeout)
+                        )
                     if completion_event.is_set():
                         if wait_timeout is None:
                             wait_timeout = _STREAM_COMPLETION_DRAIN_SECONDS

--- a/tests/test_streaming_output_contract.py
+++ b/tests/test_streaming_output_contract.py
@@ -1726,10 +1726,21 @@ async def test_streaming_logs_idle_diagnostics_when_only_transport_keepalive_is_
 
 @pytest.mark.asyncio
 async def test_streaming_logs_completion_observed_in_close_diagnostics(
+    monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
+    monkeypatch.setattr(streaming_module, "_STREAM_IDLE_DIAGNOSTIC_SECONDS", 0.01)
     client = DummyStreamingClient(
-        stream_events_payload=[],
+        stream_events_payload=[
+            _event(
+                session_id="ses-1",
+                role="assistant",
+                part_type="text",
+                part_id="prt-completion-log",
+                delta="late chunk",
+            ),
+        ],
+        stream_event_delays=[0.2],
         response_text="answer",
         send_delay=0.0,
     )


### PR DESCRIPTION
## 关联
Closes #44

## 相关 commits
- `ops: add stream idle diagnostic logging (#44)`
- `fix: schedule idle diagnostics during upstream silence (#44)`

## 评估结论
- `#44` 需求仍然合理且有效。
- 当前主干已经有 transport-level SSE keepalive 和基础 request lifecycle 日志，但当 stream 长时间没有新的可见 chunk 时，服务端仍缺少足够的静默诊断信息。
- 本 PR 采用更收敛的方案：只增强服务端日志诊断，不新增客户端可见 heartbeat，不改 A2A 协议 payload，也不引入新的配置、部署脚本或扩展契约。

## 按模块说明
### 1. Streaming Diagnostics
- 在 `src/codex_a2a_server/streaming.py` 增加轻量 `StreamDiagnostics`，记录：
  - stream started time
  - last upstream event time
  - last visible chunk time
  - completion observed flag
  - emitted / suppressed chunk counts
  - idle log count
- 在 `started`、`idle`、`completion observed`、`closed` 这几个关键节点补充结构化日志，帮助区分：
  - 上游长时间无事件
  - 上游有事件但没有可见输出
  - completion 已观察到但流仍在 drain/收口

### 2. Idle Scheduling
- 补充 idle 诊断调度逻辑，确保在“上游长时间完全没有事件”的场景下，stream 仍会按内部阈值定时打出 idle 诊断日志。
- 该调度仅用于服务端日志，不会向客户端发出新的 A2A status / artifact 事件。

### 3. 测试
- 在 `tests/test_streaming_output_contract.py` 增加回归测试，覆盖：
  - 长时间只有 transport keepalive、没有新的可见 chunk 时会留下 idle 诊断日志
  - 主请求已完成但上游流仍在等待时，会记录 `completion observed`
- 保留现有流式输出契约测试，确保这次改动不影响 artifact / status 发射行为。

## 风险与边界
- 本 PR 不解决客户端可见的 protocol-level idle heartbeat；相关大范围方案已单独放弃，不纳入本 PR。
- 这次改动只影响服务端日志面，不改变下游协议消费方式。
- idle 诊断阈值当前仍是内部常量，后续若确有运维需求，再单独评估是否需要配置化。
- 超长静默请求会新增周期性 info 日志，但频率受内部阈值控制，当前为低风险运维日志扩充。

## 验证
- `uv run pre-commit run --all-files`
- `uv run pytest`
