### PR TITLE
chore: tighten session guard and cancel semantics

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -151,6 +151,9 @@ Current implementation note:
 - `A2A_SESSION_CACHE_TTL_SECONDS`: in-memory TTL for
   `(identity, contextId) -> Codex session_id`, default `3600`
 - `A2A_SESSION_CACHE_MAXSIZE`: max cache entries, default `10000`
+- `A2A_CANCEL_ABORT_TIMEOUT_SECONDS`: how long `tasks/cancel` waits for
+  in-flight execution/session-create cleanup after issuing cancellation,
+  default `1.0`; `0` means best-effort cancel without waiting
 - `A2A_INTERRUPT_REQUEST_TTL_SECONDS`: TTL for pending interrupt callbacks
   before they become expired, default `3600`
 
@@ -212,6 +215,10 @@ managed systemd deployment flow.
   ownership, attribution, and traceability. It keeps `session_id` in the A2A
   contract, but the underlying execution still uses Codex `command/exec`
   rather than resuming or creating an upstream Codex thread.
+- Session query projections currently use the upstream Codex `session_id` as
+  the A2A `contextId`. This is intentional for the current deployment model:
+  `contextId` and `metadata.shared.session.id` refer to the same upstream
+  session identity, and the contract declares that equality explicitly.
 - Task state defaults to `input-required` to support multi-turn interactions.
 - Streaming (`/v1/message:stream`) emits incremental
   `TaskArtifactUpdateEvent` and then

--- a/src/codex_a2a_server/agent.py
+++ b/src/codex_a2a_server/agent.py
@@ -110,11 +110,13 @@ class CodexAgentExecutor(AgentExecutor):
         client: CodexClient,
         *,
         streaming_enabled: bool,
+        cancel_abort_timeout_seconds: float = 1.0,
         session_cache_ttl_seconds: int = 3600,
         session_cache_maxsize: int = 10_000,
     ) -> None:
         self._client = client
         self._streaming_enabled = streaming_enabled
+        self._cancel_abort_timeout_seconds = float(cancel_abort_timeout_seconds)
         self._sessions = _TTLCache(
             ttl_seconds=session_cache_ttl_seconds,
             maxsize=session_cache_maxsize,
@@ -465,10 +467,41 @@ class CodexAgentExecutor(AgentExecutor):
                 and not running_task.done()
             ):
                 running_task.cancel()
+            waitables: list[asyncio.Task[Any]] = []
+            if (
+                running_task
+                and running_task is not asyncio.current_task()
+                and not running_task.done()
+            ):
+                waitables.append(running_task)
             if inflight:
                 inflight.cancel()
-                with suppress(asyncio.CancelledError):
-                    await inflight
+                waitables.append(inflight)
+
+            if waitables and self._cancel_abort_timeout_seconds > 0:
+                done, pending = await asyncio.wait(
+                    set(waitables),
+                    timeout=self._cancel_abort_timeout_seconds,
+                )
+                for task in done:
+                    with suppress(asyncio.CancelledError, Exception):
+                        await task
+                if pending:
+                    logger.warning(
+                        "Cancel abort timeout exceeded task_id=%s context_id=%s "
+                        "abort_timeout_seconds=%.3f pending_tasks=%s",
+                        task_id,
+                        context_id,
+                        self._cancel_abort_timeout_seconds,
+                        len(pending),
+                    )
+            elif waitables:
+                logger.info(
+                    "Cancel abort wait skipped task_id=%s context_id=%s abort_timeout_seconds=%.3f",
+                    task_id,
+                    context_id,
+                    self._cancel_abort_timeout_seconds,
+                )
         except Exception as exc:
             logger.exception("Cancel failed")
             if task_id and context_id:

--- a/src/codex_a2a_server/app.py
+++ b/src/codex_a2a_server/app.py
@@ -367,6 +367,7 @@ def create_app(settings: Settings) -> FastAPI:
     executor = CodexAgentExecutor(
         client,
         streaming_enabled=settings.a2a_streaming,
+        cancel_abort_timeout_seconds=settings.a2a_cancel_abort_timeout_seconds,
         session_cache_ttl_seconds=settings.a2a_session_cache_ttl_seconds,
         session_cache_maxsize=settings.a2a_session_cache_maxsize,
     )

--- a/src/codex_a2a_server/config.py
+++ b/src/codex_a2a_server/config.py
@@ -101,6 +101,10 @@ class Settings(BaseSettings):
     # Session cache settings
     a2a_session_cache_ttl_seconds: int = Field(default=3600, alias="A2A_SESSION_CACHE_TTL_SECONDS")
     a2a_session_cache_maxsize: int = Field(default=10_000, alias="A2A_SESSION_CACHE_MAXSIZE")
+    a2a_cancel_abort_timeout_seconds: float = Field(
+        default=1.0,
+        alias="A2A_CANCEL_ABORT_TIMEOUT_SECONDS",
+    )
     a2a_interrupt_request_ttl_seconds: int = Field(
         default=3600,
         alias="A2A_INTERRUPT_REQUEST_TTL_SECONDS",
@@ -119,6 +123,13 @@ class Settings(BaseSettings):
             if scope:
                 scopes[scope] = ""
         return scopes
+
+    @field_validator("a2a_cancel_abort_timeout_seconds")
+    @classmethod
+    def validate_cancel_abort_timeout_seconds(cls, value: float) -> float:
+        if value < 0:
+            raise ValueError("A2A_CANCEL_ABORT_TIMEOUT_SECONDS must be >= 0")
+        return value
 
     @field_validator("a2a_interrupt_request_ttl_seconds")
     @classmethod

--- a/src/codex_a2a_server/extension_contracts.py
+++ b/src/codex_a2a_server/extension_contracts.py
@@ -547,6 +547,14 @@ def build_session_query_extension_params(
         "context_semantics": {
             "a2a_context_id_field": "contextId",
             "upstream_session_id_field": SHARED_SESSION_BINDING_FIELD,
+            "context_id_strategy": "equals_upstream_session_id",
+            "notes": [
+                (
+                    "session query projections currently set contextId equal to the "
+                    "upstream session_id"
+                ),
+                "metadata.shared.session.id carries the same upstream session identity explicitly",
+            ],
         },
     }
 

--- a/src/codex_a2a_server/jsonrpc_ext.py
+++ b/src/codex_a2a_server/jsonrpc_ext.py
@@ -49,6 +49,13 @@ ERR_INTERRUPT_EXPIRED = -32007
 ERR_INTERRUPT_TYPE_MISMATCH = -32008
 
 
+SESSION_CONTEXT_ID_STRATEGY = "equals_upstream_session_id"
+
+
+def _session_context_id(session_id: str) -> str:
+    return session_id
+
+
 def _interrupt_expected_type(method: str, *, permission_method: str) -> str:
     if method == permission_method:
         return "permission"
@@ -76,7 +83,7 @@ def _as_a2a_session_task(session: Any) -> dict[str, Any] | None:
         return None
     task = Task(
         id=session_id,
-        context_id=session_id,
+        context_id=_session_context_id(session_id),
         # Model Codex sessions as completed A2A Tasks for stable downstream rendering.
         status=TaskStatus(state=TaskState.completed),
         metadata={
@@ -112,7 +119,7 @@ def _as_a2a_message(session_id: str, item: Any) -> dict[str, Any] | None:
         message_id=message_id,
         role=role,
         parts=[TextPart(text=text)],
-        context_id=session_id,
+        context_id=_session_context_id(session_id),
         metadata={
             "shared": {"session": {"id": session_id}},
             "codex": {"raw": item},
@@ -193,6 +200,28 @@ class CodexSessionQueryJSONRPCApplication(A2AFastAPIApplication):
         self._session_claim_finalize = session_claim_finalize
         self._session_claim_release = session_claim_release
         self._session_owner_matcher = session_owner_matcher
+        self._validate_guard_hooks()
+
+    def _validate_guard_hooks(self) -> None:
+        missing_for_session_control: list[str] = []
+        if self._session_claim is None:
+            missing_for_session_control.append("session_claim")
+        if self._session_claim_finalize is None:
+            missing_for_session_control.append("session_claim_finalize")
+        if self._session_claim_release is None:
+            missing_for_session_control.append("session_claim_release")
+        if missing_for_session_control:
+            missing = ", ".join(missing_for_session_control)
+            raise ValueError(
+                "CodexSessionQueryJSONRPCApplication missing required session control hooks: "
+                f"{missing}"
+            )
+
+        if self._session_owner_matcher is None:
+            raise ValueError(
+                "CodexSessionQueryJSONRPCApplication missing required interrupt ownership "
+                "hook: session_owner_matcher"
+            )
 
     async def _handle_requests(self, request: Request) -> Response:
         # Fast path: sniff method first then either handle here or delegate.

--- a/tests/test_agent_card.py
+++ b/tests/test_agent_card.py
@@ -80,6 +80,13 @@ def test_agent_card_injects_deployment_context_into_extensions() -> None:
         session_query.params["context_semantics"]["upstream_session_id_field"]
         == "metadata.shared.session.id"
     )
+    assert session_query.params["context_semantics"]["context_id_strategy"] == (
+        "equals_upstream_session_id"
+    )
+    assert any(
+        "contextId equal to the upstream session_id" in note
+        for note in session_query.params["context_semantics"]["notes"]
+    )
     shell_contract = session_query.params["method_contracts"]["codex.sessions.shell"]
     assert shell_contract["execution_binding"] == "standalone_command_exec"
     assert shell_contract["session_binding"] == "ownership_attribution_only"

--- a/tests/test_cancellation.py
+++ b/tests/test_cancellation.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -89,3 +90,65 @@ async def test_cancel_does_not_block_with_real_event_queue() -> None:
     queue = EventQueue()
 
     await asyncio.wait_for(executor.cancel(context, queue), timeout=0.5)
+
+
+@pytest.mark.asyncio
+async def test_cancel_logs_abort_timeout_when_cleanup_does_not_finish(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    client = AsyncMock(spec=CodexClient)
+    send_started = asyncio.Event()
+    release_send = asyncio.Event()
+
+    async def send_message(
+        session_id,
+        _text,
+        *,
+        directory=None,  # noqa: ARG001
+        timeout_override=None,  # noqa: ARG001
+    ):
+        send_started.set()
+        try:
+            await asyncio.sleep(10)
+        except asyncio.CancelledError:
+            await release_send.wait()
+        response = MagicMock()
+        response.text = "Codex response"
+        response.session_id = session_id
+        response.message_id = "msg-1"
+        return response
+
+    client.create_session.return_value = "session-1"
+    client.send_message.side_effect = send_message
+    configure_mock_client_runtime(client)
+
+    executor = CodexAgentExecutor(
+        client,
+        streaming_enabled=False,
+        cancel_abort_timeout_seconds=0.01,
+    )
+
+    execute_context = make_request_context_mock(
+        task_id="task-timeout",
+        context_id="context-timeout",
+        identity="user-1",
+        user_input="hello",
+    )
+    execute_queue = AsyncMock(spec=EventQueue)
+    execute_task = asyncio.create_task(executor.execute(execute_context, execute_queue))
+    await asyncio.wait_for(send_started.wait(), timeout=1.0)
+
+    cancel_context = make_request_context_mock(
+        task_id="task-timeout",
+        context_id="context-timeout",
+        call_context_enabled=False,
+    )
+    cancel_queue = AsyncMock(spec=EventQueue)
+    caplog.set_level(logging.WARNING, logger="codex_a2a_server.agent")
+
+    await asyncio.wait_for(executor.cancel(cancel_context, cancel_queue), timeout=0.5)
+
+    assert any("Cancel abort timeout exceeded" in record.getMessage() for record in caplog.records)
+
+    release_send.set()
+    await asyncio.wait_for(execute_task, timeout=1.0)

--- a/tests/test_codex_session_extension.py
+++ b/tests/test_codex_session_extension.py
@@ -1,9 +1,18 @@
 import logging
+from unittest.mock import MagicMock
 
 import httpx
 import pytest
 
+from codex_a2a_server.app import build_agent_card
 from codex_a2a_server.config import Settings
+from codex_a2a_server.extension_contracts import (
+    INTERRUPT_CALLBACK_METHODS,
+    SESSION_CONTROL_METHODS,
+    SESSION_QUERY_METHODS,
+    build_supported_jsonrpc_methods,
+)
+from codex_a2a_server.jsonrpc_ext import CodexSessionQueryJSONRPCApplication
 from tests.helpers import DummySessionQueryCodexClient as DummyCodexClient
 from tests.helpers import make_settings
 
@@ -11,6 +20,61 @@ _BASE_SETTINGS = {
     "codex_timeout": 1.0,
     "a2a_log_level": "DEBUG",
 }
+
+
+def _build_extension_app(
+    *,
+    session_claim=None,
+    session_claim_finalize=None,
+    session_claim_release=None,
+    session_owner_matcher=None,
+) -> CodexSessionQueryJSONRPCApplication:
+    settings = make_settings(a2a_bearer_token="t-1", a2a_log_payloads=False, **_BASE_SETTINGS)
+    methods = {
+        **SESSION_QUERY_METHODS,
+        **SESSION_CONTROL_METHODS,
+        **INTERRUPT_CALLBACK_METHODS,
+    }
+    return CodexSessionQueryJSONRPCApplication(
+        agent_card=build_agent_card(settings),
+        http_handler=MagicMock(),
+        codex_client=DummyCodexClient(settings),
+        methods=methods,
+        protocol_version=settings.a2a_protocol_version,
+        supported_methods=build_supported_jsonrpc_methods(session_shell_enabled=True),
+        session_claim=session_claim,
+        session_claim_finalize=session_claim_finalize,
+        session_claim_release=session_claim_release,
+        session_owner_matcher=session_owner_matcher,
+    )
+
+
+def test_session_extension_fails_fast_when_session_control_hooks_are_missing() -> None:
+    async def owner_matcher(*, identity: str, session_id: str) -> bool:
+        del identity, session_id
+        return True
+
+    with pytest.raises(ValueError, match="missing required session control hooks"):
+        _build_extension_app(session_owner_matcher=owner_matcher)
+
+
+def test_session_extension_fails_fast_when_interrupt_owner_hook_is_missing() -> None:
+    async def claim(*, identity: str, session_id: str) -> bool:
+        del identity, session_id
+        return False
+
+    async def finalize(*, identity: str, session_id: str) -> None:
+        del identity, session_id
+
+    async def release(*, identity: str, session_id: str) -> None:
+        del identity, session_id
+
+    with pytest.raises(ValueError, match="missing required interrupt ownership hook"):
+        _build_extension_app(
+            session_claim=claim,
+            session_claim_finalize=finalize,
+            session_claim_release=release,
+        )
 
 
 @pytest.mark.asyncio
@@ -75,6 +139,7 @@ async def test_session_query_extension_returns_jsonrpc_result(monkeypatch):
         session = payload["result"]["items"][0]
         assert session["id"] == "s-1"
         assert session["contextId"] == "s-1"
+        assert session["contextId"] == session["metadata"]["shared"]["session"]["id"]
         assert session["metadata"]["shared"]["session"]["id"] == "s-1"
         assert session["metadata"]["shared"]["session"]["title"] == "Session s-1"
         assert session["metadata"]["codex"]["raw"]["id"] == "s-1"
@@ -98,6 +163,7 @@ async def test_session_query_extension_returns_jsonrpc_result(monkeypatch):
         assert "raw" not in payload["result"]
         message = payload["result"]["items"][0]
         assert message["contextId"] == "s-1"
+        assert message["contextId"] == message["metadata"]["shared"]["session"]["id"]
         assert message["parts"][0]["text"] == "SECRET_HISTORY"
         assert message["metadata"]["shared"]["session"]["id"] == "s-1"
         assert dummy.last_messages_params is not None

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -42,18 +42,31 @@ def test_parse_oauth_scopes():
         assert settings.a2a_oauth_scopes == {"scope1": "", "scope2": "", "scope3": ""}
 
 
-def test_settings_parse_ops_flags_and_interrupt_ttl():
+def test_settings_parse_ops_flags_and_timeouts():
     env = {
         "A2A_BEARER_TOKEN": "test",
         "A2A_ENABLE_HEALTH_ENDPOINT": "false",
         "A2A_ENABLE_SESSION_SHELL": "false",
+        "A2A_CANCEL_ABORT_TIMEOUT_SECONDS": "0.25",
         "A2A_INTERRUPT_REQUEST_TTL_SECONDS": "90",
     }
     with mock.patch.dict(os.environ, env, clear=True):
         settings = Settings()
         assert settings.a2a_enable_health_endpoint is False
         assert settings.a2a_enable_session_shell is False
+        assert settings.a2a_cancel_abort_timeout_seconds == 0.25
         assert settings.a2a_interrupt_request_ttl_seconds == 90
+
+
+def test_settings_reject_invalid_cancel_abort_timeout():
+    env = {
+        "A2A_BEARER_TOKEN": "test",
+        "A2A_CANCEL_ABORT_TIMEOUT_SECONDS": "-0.1",
+    }
+    with mock.patch.dict(os.environ, env, clear=True):
+        with pytest.raises(ValidationError) as excinfo:
+            Settings()
+    assert "A2A_CANCEL_ABORT_TIMEOUT_SECONDS" in str(excinfo.value)
 
 
 def test_settings_reject_invalid_interrupt_request_ttl():


### PR DESCRIPTION
## 关联
Closes #73
Closes #77
Closes #78

## 相关 commits
- `chore: tighten session guard and cancel semantics (#73, #77, #78)`

## 评估结论
- `#73` 仍然有效，但当前最佳实践是不扩大到新的 A2A 取消阶段语义，只补服务端 abort timeout 策略和日志。
- `#77` 仍然有效，但当前最佳实践不是立刻把 `contextId` 与 upstream `session_id` 脱钩，而是先把现状显式收敛成契约。
- `#78` 仍然有效，且应按 fail-fast 方式在构造期校验必需 hooks，而不是继续把 wiring 问题拖到运行期。
- 这三项都属于 session/cancel 边界治理的小步收敛，放在一个分支里仍然边界清晰；没有并入 `#63`、`#10` 等更大范围议题。

## 按模块说明
### 1. Cancel Abort Timeout
- 在 `src/codex_a2a_server/config.py` 新增 `A2A_CANCEL_ABORT_TIMEOUT_SECONDS`，默认 `1.0`，并要求 `>= 0`。
- 在 `src/codex_a2a_server/agent.py` 的 `cancel()` 中，将“发出取消”与“等待后台收口”拆开：
  - 先 `stop_event.set()` / `task.cancel()` / `inflight.cancel()`
  - 再按 `A2A_CANCEL_ABORT_TIMEOUT_SECONDS` 等待运行中的 request task 与 inflight session create 收口
  - 超时仅留下 warning，不改变当前对外 `canceled(final=true)` 语义
- `src/codex_a2a_server/app.py` 将该 timeout 接入默认 executor 组装路径。

### 2. Session Query Context Semantics
- 在 `src/codex_a2a_server/jsonrpc_ext.py` 引入 `_session_context_id(...)` helper，显式固定当前策略：`contextId == upstream session_id`。
- 在 `src/codex_a2a_server/extension_contracts.py` 的 `context_semantics` 中新增：
  - `context_id_strategy=equals_upstream_session_id`
  - 对 `contextId` 与 `metadata.shared.session.id` 等同关系的说明 notes
- 在 `docs/guide.md` 补英文说明，明确当前 deployment model 下二者等同是刻意行为，而不是偶然实现细节。

### 3. Guard Hooks Fail-Fast
- 在 `src/codex_a2a_server/jsonrpc_ext.py` 的 `CodexSessionQueryJSONRPCApplication.__init__()` 中增加构造期校验：
  - `session_claim`
  - `session_claim_finalize`
  - `session_claim_release`
  - `session_owner_matcher`
- 缺失时直接抛清晰 `ValueError`，避免实例带着空 ownership 保护进入运行期。

### 4. 测试
- `tests/test_settings.py`：新增 cancel abort timeout 配置解析与非法值校验
- `tests/test_cancellation.py`：新增 abort timeout 超时日志场景
- `tests/test_codex_session_extension.py`：新增 guard hooks fail-fast 断言，并锁住 `contextId == metadata.shared.session.id`
- `tests/test_agent_card.py`：新增 `context_id_strategy` 与 notes 的契约断言

## 风险与边界
- 本 PR 不尝试把 `contextId` 与 upstream `session_id` 真正脱钩；这会扩大到更大的兼容性与下游迁移问题，不适合当前范围。
- 本 PR 不把 cancel abort timeout 暴露到 Agent Card / deployment_context；当前把它保留为服务端运维配置更稳。
- guard hooks 现在是严格 fail-fast；这会阻止不完整 wiring 的自定义实例化路径继续“带病运行”，我认为这是预期收益，不是回归。

## 验证
- `uv run pre-commit run --all-files`
- `uv run pytest`
