### PR TITLE
fix: inject hashed bearer identity into request context

### DIFF
--- a/src/codex_a2a_server/app.py
+++ b/src/codex_a2a_server/app.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import secrets
@@ -357,6 +358,7 @@ def add_auth_middleware(app: FastAPI, settings: Settings) -> None:
         provided = auth_header.split(" ", 1)[1].strip()
         if not secrets.compare_digest(provided, token):
             return _unauthorized_response()
+        request.state.user_identity = f"bearer:{hashlib.sha256(provided.encode()).hexdigest()[:12]}"
 
         return await call_next(request)
 

--- a/tests/test_transport_contract.py
+++ b/tests/test_transport_contract.py
@@ -1,3 +1,4 @@
+import hashlib
 import logging
 import uuid
 
@@ -505,6 +506,7 @@ async def test_log_payloads_omits_oversized_request_body(monkeypatch, caplog) ->
 async def test_request_logs_reuse_supplied_correlation_id(monkeypatch, caplog) -> None:
     import codex_a2a_server.app as app_module
 
+    expected_identity = f"bearer:{hashlib.sha256(b'test-token').hexdigest()[:12]}"
     monkeypatch.setattr(app_module, "CodexClient", DummyChatCodexClient)
     app = app_module.create_app(make_settings(a2a_bearer_token="test-token"))
     transport = httpx.ASGITransport(app=app)
@@ -538,8 +540,12 @@ async def test_request_logs_reuse_supplied_correlation_id(monkeypatch, caplog) -
     assert any("A2A request started" in record.message for record in relevant)
     assert any("A2A request completed" in record.message for record in relevant)
     assert any("A2A message request started" in record.message for record in relevant)
-    assert any("Received message identity=" in record.message for record in relevant)
+    assert any(
+        f"Received message identity={expected_identity}" in record.message for record in relevant
+    )
     assert {record.correlation_id for record in relevant} == {"corr-user-supplied"}
+    assert "Bearer test-token" not in caplog.text
+    assert "test-token" not in caplog.text
 
 
 @pytest.mark.asyncio
@@ -549,6 +555,7 @@ async def test_request_logs_generate_correlation_id_for_stream_requests(
 ) -> None:
     import codex_a2a_server.app as app_module
 
+    expected_identity = f"bearer:{hashlib.sha256(b'test-token').hexdigest()[:12]}"
     monkeypatch.setattr(app_module, "CodexClient", DummyChatCodexClient)
     app = app_module.create_app(make_settings(a2a_bearer_token="test-token"))
     transport = httpx.ASGITransport(app=app)
@@ -576,10 +583,16 @@ async def test_request_logs_generate_correlation_id_for_stream_requests(
             "codex_a2a_server.app",
             "codex_a2a_server.request_handler",
             "codex_a2a_server.streaming",
+            "codex_a2a_server.agent",
         }
     ]
     assert relevant
     assert any("A2A request started" in record.message for record in relevant)
     assert any("A2A stream request started" in record.message for record in relevant)
     assert any("Codex event stream started" in record.message for record in relevant)
+    assert any(
+        f"Received message identity={expected_identity}" in record.message for record in relevant
+    )
     assert {record.correlation_id for record in relevant} == {generated}
+    assert "Bearer test-token" not in caplog.text
+    assert "test-token" not in caplog.text


### PR DESCRIPTION
## 关联
Closes #10

## 相关 commits
- `fix: inject hashed bearer identity into request context (#10)`

## 评估结论
- `#10` 仍然是当前真实运行路径上的缺口，而不是测试或设计层面的假问题。
- 当前最佳实践是不扩大到新的 caller identity source 设计，而是先把 Bearer 认证通过后的 identity 注入链路补完整。
- 本 PR 采用与参考仓库一致的最小正确方案：使用稳定且不可逆的 Bearer token hash 作为默认 `user_identity`。

## 按模块说明
### 1. 认证中间件
- 在 `src/codex_a2a_server/app.py` 的 `add_auth_middleware()` 中，Bearer 校验通过后设置：
  - `request.state.user_identity = "bearer:" + sha256(token)[:12]`
- 这样可以保证：
  - 同一个 Bearer token 多次请求 identity 稳定
  - 不在运行时上下文中继续传播原始 token
  - `IdentityAwareCallContextBuilder`、executor、session ownership / claim 能拿到真实主体，而不是继续退化到匿名路径

### 2. 真实请求路径测试
- 在 `tests/test_transport_contract.py` 增加真实 ASGI 请求路径断言，覆盖：
  - 常规 `message:send` 请求会在日志链路中携带稳定 hash identity
  - `message:stream` 请求也会通过同样的 identity 注入链路
  - 日志文本中不会出现原始 `Bearer test-token` 或裸 `test-token`
- 现有 `tests/test_call_context_builder.py` 和 ownership 相关测试继续保留，形成“builder + 真实请求路径”两层保护。

## 风险与边界
- 本 PR 只解决“认证通过后 identity 未注入”的问题，不扩展到更复杂的多 caller identity 设计。
- 当前 identity 粒度仍然是“一个 Bearer token 对应一个主体”。如果未来需要在同一个 service token 下区分多个逻辑调用方，再单独扩展到 header / OAuth subject 等更明确的 identity source。
- 采用 hash identity 的目的是稳定和不可逆；它不是面向最终用户展示的标识。

## 验证
- `uv run pre-commit run --all-files`
- `uv run pytest`
