### PR TITLE
fix: relax sudo readiness checks in init and uninstall scripts

### DIFF
--- a/scripts/init_system.sh
+++ b/scripts/init_system.sh
@@ -5,6 +5,10 @@
 # Optional env:
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/shell_helpers.sh"
+
 CODEX_CORE_DIR="/opt/.codex"
 CODEX_A2A_ROOT="/opt/codex-a2a"
 CODEX_A2A_RUNTIME_DIR="${CODEX_A2A_ROOT}/runtime"
@@ -83,7 +87,12 @@ if [[ "${EUID}" -ne 0 ]]; then
   fi
   SUDO="sudo"
   log_start "Checking sudo access..."
-  sudo -v
+  if ! ensure_sudo_ready \
+    "sudo requires a password or is not permitted (non-interactive). Refusing to continue." \
+    "Run in an interactive shell, or configure NOPASSWD for required commands."
+  then
+    die "sudo access is not ready."
+  fi
   log_done "Sudo access ready."
 fi
 

--- a/scripts/shell_helpers.sh
+++ b/scripts/shell_helpers.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+ensure_sudo_ready() {
+  local non_interactive_message="${1:-sudo requires a password or is not permitted (non-interactive). Refusing to continue.}"
+  local interactive_hint="${2:-Run in an interactive shell, or configure NOPASSWD for required commands.}"
+
+  if ! command -v sudo >/dev/null 2>&1; then
+    return 127
+  fi
+
+  if sudo -n true 2>/dev/null; then
+    return 0
+  fi
+
+  if [[ -t 0 ]]; then
+    sudo -v
+    return $?
+  fi
+
+  echo "$non_interactive_message" >&2
+  echo "$interactive_hint" >&2
+  return 1
+}

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -18,6 +18,10 @@
 #   ./scripts/uninstall.sh project=alpha confirm=UNINSTALL
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/shell_helpers.sh"
+
 PROJECT_NAME=""
 DATA_ROOT_INPUT=""
 CONFIRM_INPUT=""
@@ -257,16 +261,11 @@ if [[ "$APPLY" == "true" ]]; then
     echo "sudo not found; cannot apply uninstall." >&2
     exit 1
   fi
-  if [[ -t 0 ]]; then
-    # Interactive terminal: refresh credentials (may prompt).
-    sudo -v
-  else
-    # Non-interactive: require non-prompting sudo.
-    if ! sudo -n true 2>/dev/null; then
-      echo "sudo requires a password or is not permitted (non-interactive). Refusing to apply." >&2
-      echo "Run in an interactive shell, or configure NOPASSWD for required commands." >&2
-      exit 1
-    fi
+  if ! ensure_sudo_ready \
+    "sudo requires a password or is not permitted (non-interactive). Refusing to apply." \
+    "Run in an interactive shell, or configure NOPASSWD for required commands."
+  then
+    exit 1
   fi
 fi
 


### PR DESCRIPTION
## 关联关系

Closes #99

## 变更概览

本 PR 修复脚本层面对 `sudo -v` 的错误依赖，避免在部分 `NOPASSWD` / `verifypw` 组合下，实际 `sudo` 命令可执行但预检查先被阻塞的问题。

相关 commit:
- `4cf4cd3` `fix: relax sudo readiness checks in scripts (#99)`

## 按模块说明

### 1. 共享 shell helper

- 新增 `scripts/shell_helpers.sh`
- 抽出 `ensure_sudo_ready`
- 统一 sudo 就绪检查顺序：先尝试 `sudo -n true`，只有在无交互 sudo 不可用且存在交互终端时，才回退到 `sudo -v`
- 非交互场景保持严格约束：若 `sudo -n true` 不可用则直接失败，并输出操作提示

### 2. init_system

- `scripts/init_system.sh` 改为复用 `ensure_sudo_ready`
- 保持原有 `sudo not found` 错误路径不变
- 避免在交互式环境下仅因 `sudo -v` 与实际可执行 sudo 行为不一致而误阻塞初始化

### 3. uninstall

- `scripts/uninstall.sh` 的 `--apply` 路径改为复用 `ensure_sudo_ready`
- 保持原有 apply-only 检查范围不变
- 让交互与非交互场景的 sudo 就绪判定语义一致，不再出现脚本间漂移

### 4. 文档

- 本次未修改文档
- 当前变更仅涉及脚本执行语义收敛，不影响对外接口或部署参数说明

## 验证

已完成本地验证：
- `bash -n scripts/shell_helpers.sh scripts/init_system.sh scripts/uninstall.sh`
- `uv run pre-commit run --all-files`
- `uv run pytest`

## 风险与兼容性

- 行为变化是有意的：交互式执行时，不再默认优先依赖 `sudo -v`，而是先检查实际无交互 sudo 可执行性
- 若未来其它脚本也引入 sudo 预检查，应继续复用 `scripts/shell_helpers.sh`，避免重新出现判定分叉
- 当前未发现需要额外关联的 open issues；本 PR 直接关闭 `#99` 是准确的
