### PR TITLE
fix: move session-query method result contracts out of result_envelope

### DIFF
--- a/src/codex_a2a_server/extension_contracts.py
+++ b/src/codex_a2a_server/extension_contracts.py
@@ -515,7 +515,6 @@ def build_session_query_extension_params(
         if key in active_query_methods
     }
     method_contracts: dict[str, Any] = {}
-    result_envelope_by_method: dict[str, Any] = {}
     pagination_applies_to: list[str] = []
     pagination_behavior_by_method: dict[str, str] = {}
 
@@ -528,6 +527,8 @@ def build_session_query_extension_params(
         result_contract: dict[str, Any] = {"fields": list(method_contract.result_fields)}
         if method_contract.items_type:
             result_contract["items_type"] = method_contract.items_type
+        if method_contract.items_field:
+            result_contract["items_field"] = method_contract.items_field
 
         contract_doc: dict[str, Any] = {
             "params": params_contract,
@@ -548,11 +549,6 @@ def build_session_query_extension_params(
         if method_contract.notes:
             contract_doc["notes"] = list(method_contract.notes)
         method_contracts[method_contract.method] = contract_doc
-
-        envelope_doc: dict[str, Any] = {"fields": list(method_contract.result_fields)}
-        if method_contract.items_field:
-            envelope_doc["items_field"] = method_contract.items_field
-        result_envelope_by_method[method_contract.method] = envelope_doc
 
         if method_contract.pagination_mode == SESSION_QUERY_PAGINATION_MODE:
             pagination_applies_to.append(method_contract.method)
@@ -591,9 +587,7 @@ def build_session_query_extension_params(
             "error_data_fields": list(SESSION_QUERY_ERROR_DATA_FIELDS),
             "invalid_params_data_fields": list(SESSION_QUERY_INVALID_PARAMS_DATA_FIELDS),
         },
-        "result_envelope": {
-            "by_method": result_envelope_by_method,
-        },
+        "result_envelope": {},
         "context_semantics": {
             "a2a_context_id_field": "contextId",
             "upstream_session_id_field": SHARED_SESSION_BINDING_FIELD,

--- a/tests/test_agent_card.py
+++ b/tests/test_agent_card.py
@@ -99,6 +99,7 @@ def test_agent_card_injects_deployment_context_into_extensions() -> None:
         "codex.sessions.list": "upstream_passthrough",
         "codex.sessions.messages.list": "local_tail_slice",
     }
+    assert session_query.params["result_envelope"] == {}
     assert any(
         "forwards limit upstream" in note for note in session_query.params["pagination"]["notes"]
     )

--- a/tests/test_extension_contract_consistency.py
+++ b/tests/test_extension_contract_consistency.py
@@ -116,10 +116,8 @@ async def test_session_query_runtime_result_envelope_matches_declared_contract(
     settings = make_settings(a2a_bearer_token="t-1", a2a_log_payloads=False, codex_timeout=1.0)
     card = build_agent_card(settings)
     ext_by_uri = {ext.uri: ext for ext in card.capabilities.extensions or []}
-    envelope_by_method = ext_by_uri[SESSION_QUERY_EXTENSION_URI].params["result_envelope"][
-        "by_method"
-    ]
-    expected_envelope = envelope_by_method[method]
+    method_contracts = ext_by_uri[SESSION_QUERY_EXTENSION_URI].params["method_contracts"]
+    expected_result = method_contracts[method]["result"]
 
     dummy = DummyCodexClient(settings)
     monkeypatch.setattr(app_module, "CodexClient", lambda _settings: dummy)
@@ -135,11 +133,20 @@ async def test_session_query_runtime_result_envelope_matches_declared_contract(
 
     assert response.status_code == 200
     payload = response.json()
-    assert sorted(payload["result"].keys()) == sorted(expected_envelope["fields"])
+    assert sorted(payload["result"].keys()) == sorted(expected_result["fields"])
 
-    items_field = expected_envelope.get("items_field")
+    items_field = expected_result.get("items_field")
     if items_field is not None:
         assert isinstance(payload["result"][items_field], list)
+
+
+def test_session_query_result_envelope_omits_method_level_contracts() -> None:
+    settings = make_settings(a2a_bearer_token="test-token")
+    card = build_agent_card(settings)
+    ext_by_uri = {ext.uri: ext for ext in card.capabilities.extensions or []}
+    session_query = ext_by_uri[SESSION_QUERY_EXTENSION_URI]
+
+    assert session_query.params["result_envelope"] == {}
 
 
 def test_openapi_jsonrpc_contract_extension_matches_ssot() -> None:


### PR DESCRIPTION
## 关联关系

Closes #97

## 变更概览

本 PR 将 session-query 的方法级结果契约从统一 `result_envelope` 语义中迁出，避免 `result_envelope.by_method` 越出 query envelope 的既有边界，并与 `#97` 的目标保持一致。

相关 commit:
- `cfca141` `fix: move session-query method result contracts out of result_envelope (#97)`

## 按模块说明

### 1. session-query contract

- 更新 `src/codex_a2a_server/extension_contracts.py`
- 移除 `session_query.params.result_envelope.by_method`
- 将方法级结果结构说明统一收敛到 `method_contracts.<method>.result`
- 对 list 类方法保留 `items_field`，确保迁移后仍能表达结果列表所在字段
- `result_envelope` 不再承载方法级 contract，避免 consumer 将其误判为统一 envelope 声明区

### 2. Agent Card 与一致性测试

- 更新 `tests/test_agent_card.py`
- 显式断言 `session_query.params.result_envelope` 不再包含方法级 contract
- 更新 `tests/test_extension_contract_consistency.py`
- 运行时结果结构校验改为读取 `method_contracts.<method>.result`
- 补充断言，确保 `result_envelope` 已不再暴露方法级结果描述

### 3. 文档

- 本次未修改文档
- 当前仓库内没有面向用户的文档显式承诺 `result_envelope.by_method`，变更面主要集中在 Agent Card contract 与测试

## 验证

已完成本地验证：
- `uv run pre-commit run --all-files`
- `uv run pytest`

## 风险与兼容性

- 本次变更会影响依赖旧字段 `session_query.params.result_envelope.by_method` 的 consumer；这是 `#97` 期望的契约收敛，不是兼容旧字段的保守修复
- 方法级结果描述已迁入 `method_contracts.<method>.result`，因此功能信息未丢失
- 当前未发现需要一并关联的其它 open issues；本 PR 直接关闭 `#97` 是准确的
