### PR TITLE
chore: remove dead code

### DIFF
--- a/src/codex_a2a_server/codex_client.py
+++ b/src/codex_a2a_server/codex_client.py
@@ -201,7 +201,6 @@ class InterruptRequestBinding:
     interrupt_type: str
     session_id: str
     created_at: float
-    provider_method: str
 
 
 @dataclass
@@ -723,7 +722,6 @@ class CodexClient:
                     interrupt_type="permission",
                     session_id=session_id,
                     created_at=time.monotonic(),
-                    provider_method=method,
                 ),
                 rpc_request_id=request_id,
                 params=params,
@@ -751,7 +749,6 @@ class CodexClient:
                     interrupt_type="question",
                     session_id=session_id,
                     created_at=time.monotonic(),
-                    provider_method=method,
                 ),
                 rpc_request_id=request_id,
                 params=params,

--- a/src/codex_a2a_server/jsonrpc_ext.py
+++ b/src/codex_a2a_server/jsonrpc_ext.py
@@ -49,9 +49,6 @@ ERR_INTERRUPT_EXPIRED = -32007
 ERR_INTERRUPT_TYPE_MISMATCH = -32008
 
 
-SESSION_CONTEXT_ID_STRATEGY = "equals_upstream_session_id"
-
-
 def _session_context_id(session_id: str) -> str:
     return session_id
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -360,21 +360,12 @@ class DummySessionQueryCodexClient:
         interrupt_type: str,
         session_id: str = "ses-1",
         created_at: float = 0.0,
-        provider_method: str | None = None,
     ) -> None:
-        resolved_method = provider_method
-        if resolved_method is None:
-            resolved_method = (
-                "item/tool/requestUserInput"
-                if interrupt_type == "question"
-                else "item/commandExecution/requestApproval"
-            )
         self._interrupt_requests[request_id] = InterruptRequestBinding(
             request_id=request_id,
             interrupt_type=interrupt_type,
             session_id=session_id,
             created_at=created_at,
-            provider_method=resolved_method,
         )
 
     def resolve_interrupt_request(

--- a/tests/test_codex_client_params.py
+++ b/tests/test_codex_client_params.py
@@ -127,7 +127,6 @@ async def test_permission_reply_maps_to_codex_decision() -> None:
             interrupt_type="permission",
             session_id="thr-1",
             created_at=time.monotonic(),
-            provider_method="item/commandExecution/requestApproval",
         ),
         rpc_request_id=100,
         params={"threadId": "thr-1"},
@@ -163,7 +162,6 @@ async def test_question_reply_builds_answer_map() -> None:
             interrupt_type="question",
             session_id="thr-2",
             created_at=time.monotonic(),
-            provider_method="item/tool/requestUserInput",
         ),
         rpc_request_id=200,
         params={
@@ -215,7 +213,6 @@ def test_interrupt_request_status_uses_configured_ttl(monkeypatch) -> None:
             interrupt_type="permission",
             session_id="thr-1",
             created_at=10.0,
-            provider_method="item/commandExecution/requestApproval",
         ),
         rpc_request_id=1,
         params={"threadId": "thr-1"},


### PR DESCRIPTION
## 摘要
- 移除 `InterruptRequestBinding` 多余字段以及相关测试桩/单测引用
- 删除未使用的 `SESSION_CONTEXT_ID_STRATEGY` 常量，避免误导额外配置
- 验证死代码扫描结果，确保上述项不再出现

## 测试
- `uv run pre-commit run --all-files`
- `uv run pytest`
- `uv run --with vulture vulture src`

Closes #104
