### PR TITLE
refactor: converge interrupt asked details on shared metadata

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -281,15 +281,13 @@ described first in [README.md](../README.md) and above in this guide.
   to `TaskStatusUpdateEvent(final=false, state=working)` with
   `metadata.shared.interrupt.phase=resolved` and
   `metadata.shared.interrupt.resolution=replied|rejected`. Duplicate or unknown
-  resolved events are suppressed by `request_id`. Provider-private raw
-  interrupt payload is preserved under `metadata.codex.interrupt`.
-  For Codex app-server approval and `tool/requestUserInput` requests, shared
-  interrupt details are derived only from protocol-defined fields in the
-  vendored Codex schema: approval `reason` maps to shared
-  `details.display_message`, and `questions` is forwarded for
-  `tool/requestUserInput`. Undocumented or provider-private fields remain under
-  `metadata.codex.interrupt.metadata.raw` and are not promoted into shared
-  interrupt metadata.
+  resolved events are suppressed by `request_id`. For Codex app-server approval
+  and `tool/requestUserInput` requests, user-visible approval/question details
+  are normalized into `metadata.shared.interrupt.details`, including readable
+  `display_message`, resolved `patterns`, and `questions` when available.
+  Interrupt status events no longer mirror the asked payload under
+  `metadata.codex.interrupt`; downstream consumers should treat
+  `metadata.shared.interrupt` as the single interrupt rendering contract.
   Non-streaming requests return a `Task` directly.
 - `tool_call` payload contract:
 

--- a/src/codex_a2a_server/codex_client.py
+++ b/src/codex_a2a_server/codex_client.py
@@ -8,14 +8,13 @@ import os
 import shlex
 import shutil
 import time
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Mapping
 from dataclasses import dataclass, field
 from typing import Any
 
 from . import __version__
 from .config import Settings
 from .logging_context import bind_correlation_id, get_correlation_id, install_log_record_factory
-from .stream_interrupts import extract_interrupt_questions
 from .tool_call_payloads import (
     as_tool_call_payload,
     tool_call_output_delta_payload_from_notification,
@@ -49,6 +48,73 @@ def _first_string(payload: dict[str, Any], *keys: str) -> str | None:
     return None
 
 
+def _mapping_value(value: Any) -> Mapping[str, Any] | None:
+    if isinstance(value, Mapping):
+        return value
+    return None
+
+
+def _first_nested_string(payload: Mapping[str, Any], *paths: tuple[str, ...]) -> str | None:
+    for path in paths:
+        current: Any = payload
+        for key in path:
+            if not isinstance(current, Mapping):
+                break
+            current = current.get(key)
+        else:
+            value = _normalized_string(current)
+            if value is not None:
+                return value
+    return None
+
+
+def _extract_string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    values: list[str] = []
+    seen: set[str] = set()
+    for item in value:
+        normalized = _normalized_string(item)
+        if normalized is None or normalized in seen:
+            continue
+        seen.add(normalized)
+        values.append(normalized)
+    return values
+
+
+def _extract_permission_patterns(params: dict[str, Any]) -> list[str]:
+    patterns = _extract_string_list(params.get("patterns"))
+    if patterns:
+        return patterns
+
+    parsed_cmd = params.get("parsedCmd")
+    if not isinstance(parsed_cmd, list):
+        return []
+
+    resolved_patterns: list[str] = []
+    seen: set[str] = set()
+    for entry in parsed_cmd:
+        if not isinstance(entry, Mapping):
+            continue
+        path = _normalized_string(entry.get("path"))
+        if path is None or path in seen:
+            continue
+        seen.add(path)
+        resolved_patterns.append(path)
+    return resolved_patterns
+
+
+def _extract_question_properties_questions(params: dict[str, Any]) -> list[Any]:
+    questions = params.get("questions")
+    if isinstance(questions, list):
+        return questions
+
+    context = _mapping_value(params.get("context"))
+    if context is not None and isinstance(context.get("questions"), list):
+        return context["questions"]
+    return []
+
+
 def _build_codex_permission_interrupt_properties(
     *, request_key: str, session_id: str, method: str, params: dict[str, Any]
 ) -> dict[str, Any]:
@@ -57,22 +123,42 @@ def _build_codex_permission_interrupt_properties(
         "sessionID": session_id,
         "metadata": {"method": method, "raw": params},
     }
-    # Only map protocol-defined approval text into shared interrupt details.
-    display_message = _first_string(params, "reason")
+    display_message = _first_nested_string(
+        params,
+        ("request", "description"),
+        ("description",),
+        ("reason",),
+        ("request", "reason"),
+    )
     if display_message is not None:
         properties["display_message"] = display_message
+    patterns = _extract_permission_patterns(params)
+    if patterns:
+        properties["patterns"] = patterns
+    always = _extract_string_list(params.get("always"))
+    if always:
+        properties["always"] = always
     return properties
 
 
 def _build_codex_question_interrupt_properties(
     *, request_key: str, session_id: str, method: str, params: dict[str, Any]
 ) -> dict[str, Any]:
-    return {
+    properties = {
         "id": request_key,
         "sessionID": session_id,
-        "questions": extract_interrupt_questions(params),
+        "questions": _extract_question_properties_questions(params),
         "metadata": {"method": method, "raw": params},
     }
+    display_message = _first_nested_string(
+        params,
+        ("description",),
+        ("context", "description"),
+        ("prompt",),
+    )
+    if display_message is not None:
+        properties["display_message"] = display_message
+    return properties
 
 
 def _extract_tool_status(payload: dict[str, Any]) -> str | None:

--- a/src/codex_a2a_server/stream_interrupts.py
+++ b/src/codex_a2a_server/stream_interrupts.py
@@ -14,32 +14,116 @@ def _normalized_string(value: Any) -> str | None:
     return normalized or None
 
 
+def _mapping_value(value: Any) -> Mapping[str, Any] | None:
+    if isinstance(value, Mapping):
+        return value
+    return None
+
+
+def _nested_value(root: Mapping[str, Any], *path: str) -> Any:
+    current: Any = root
+    for key in path:
+        if not isinstance(current, Mapping):
+            return None
+        current = current.get(key)
+    return current
+
+
+def _first_nested_string(root: Mapping[str, Any], *paths: tuple[str, ...]) -> str | None:
+    for path in paths:
+        value = _normalized_string(_nested_value(root, *path))
+        if value is not None:
+            return value
+    return None
+
+
 def extract_string_list(value: Any) -> list[str]:
     if not isinstance(value, list):
         return []
     result: list[str] = []
+    seen: set[str] = set()
     for item in value:
         if not isinstance(item, str):
             continue
         normalized = item.strip()
-        if normalized:
+        if normalized and normalized not in seen:
+            seen.add(normalized)
             result.append(normalized)
     return result
 
 
 def extract_interrupt_text_details(props: Mapping[str, Any]) -> dict[str, Any]:
     details: dict[str, Any] = {}
-    display_message = _normalized_string(props.get("display_message"))
+    display_message = _first_nested_string(
+        props,
+        ("display_message",),
+        ("description",),
+        ("request", "description"),
+        ("context", "description"),
+        ("reason",),
+        ("request", "reason"),
+        ("metadata", "raw", "description"),
+        ("metadata", "raw", "request", "description"),
+        ("metadata", "raw", "context", "description"),
+        ("metadata", "raw", "prompt"),
+        ("metadata", "raw", "reason"),
+        ("metadata", "raw", "request", "reason"),
+    )
     if display_message is not None:
         details["display_message"] = display_message
     return details
 
 
 def extract_interrupt_questions(props: Mapping[str, Any]) -> list[Any]:
-    questions = props.get("questions")
+    questions = _nested_value(props, "questions")
     if isinstance(questions, list):
         return questions
+    nested_questions = _nested_value(props, "context", "questions")
+    if isinstance(nested_questions, list):
+        return nested_questions
+    raw_questions = _nested_value(props, "metadata", "raw", "questions")
+    if isinstance(raw_questions, list):
+        return raw_questions
+    raw_nested_questions = _nested_value(props, "metadata", "raw", "context", "questions")
+    if isinstance(raw_nested_questions, list):
+        return raw_nested_questions
     return []
+
+
+def extract_interrupt_patterns(props: Mapping[str, Any]) -> list[str]:
+    patterns = extract_string_list(_nested_value(props, "patterns"))
+    if patterns:
+        return patterns
+
+    raw_patterns = extract_string_list(_nested_value(props, "metadata", "raw", "patterns"))
+    if raw_patterns:
+        return raw_patterns
+
+    fallback_path = _first_nested_string(
+        props,
+        ("metadata", "path"),
+        ("path",),
+        ("metadata", "raw", "path"),
+    )
+    if fallback_path is not None:
+        return [fallback_path]
+
+    parsed_cmd = _nested_value(props, "metadata", "raw", "parsedCmd")
+    if not isinstance(parsed_cmd, list):
+        return []
+
+    resolved_patterns: list[str] = []
+    seen: set[str] = set()
+    for entry in parsed_cmd:
+        mapping = _mapping_value(entry)
+        if mapping is None:
+            continue
+        path = _normalized_string(mapping.get("path"))
+        if path is None or path in seen:
+            continue
+        seen.add(path)
+        resolved_patterns.append(path)
+    return resolved_patterns
 
 
 def diagnose_interrupt_event(event: Mapping[str, Any]) -> str | None:
@@ -82,38 +166,27 @@ def extract_interrupt_asked_event(event: Mapping[str, Any]) -> dict[str, Any] | 
         return None
     if event_type == "permission.asked":
         details: dict[str, Any] = {
-            "permission": props.get("permission"),
-            "patterns": extract_string_list(props.get("patterns")),
-            "always": extract_string_list(props.get("always")),
+            "permission": _first_nested_string(
+                props,
+                ("permission",),
+                ("metadata", "raw", "permission"),
+            ),
+            "patterns": extract_interrupt_patterns(props),
+            "always": extract_string_list(_nested_value(props, "always"))
+            or extract_string_list(_nested_value(props, "metadata", "raw", "always")),
         }
         details.update(extract_interrupt_text_details(props))
-        codex_private: dict[str, Any] = {}
-        metadata = props.get("metadata")
-        if isinstance(metadata, Mapping):
-            codex_private["metadata"] = dict(metadata)
-        tool = props.get("tool")
-        if isinstance(tool, Mapping):
-            codex_private["tool"] = dict(tool)
         return {
             "request_id": normalized_request_id,
             "interrupt_type": "permission",
             "details": details,
-            "codex_private": codex_private,
         }
     details = {"questions": extract_interrupt_questions(props)}
     details.update(extract_interrupt_text_details(props))
-    question_private: dict[str, Any] = {}
-    metadata = props.get("metadata")
-    if isinstance(metadata, Mapping):
-        question_private["metadata"] = dict(metadata)
-    tool = props.get("tool")
-    if isinstance(tool, Mapping):
-        question_private["tool"] = dict(tool)
     return {
         "request_id": normalized_request_id,
         "interrupt_type": "question",
         "details": details,
-        "codex_private": question_private,
     }
 
 

--- a/src/codex_a2a_server/streaming.py
+++ b/src/codex_a2a_server/streaming.py
@@ -259,7 +259,6 @@ async def consume_codex_stream(
         details: Mapping[str, Any],
         phase: str,
         resolution: str | None = None,
-        codex_private: Mapping[str, Any] | None = None,
     ) -> None:
         await flush_buffered_text_chunk()
         sequence = stream_state.next_sequence()
@@ -286,7 +285,6 @@ async def consume_codex_stream(
                         "sequence": sequence,
                     },
                     interrupt=interrupt_payload,
-                    codex_private=({"interrupt": dict(codex_private)} if codex_private else None),
                 ),
             )
         )
@@ -378,7 +376,6 @@ async def consume_codex_stream(
                                     interrupt_type=asked["interrupt_type"],
                                     details=asked["details"],
                                     phase="asked",
-                                    codex_private=asked.get("codex_private"),
                                 )
                         resolved = extract_interrupt_resolved_event(event)
                         if resolved is not None:

--- a/tests/test_codex_client_params.py
+++ b/tests/test_codex_client_params.py
@@ -690,7 +690,7 @@ async def test_unsupported_server_request_returns_jsonrpc_error() -> None:
 
 
 @pytest.mark.asyncio
-async def test_permission_request_emits_reason_as_display_message_only() -> None:
+async def test_permission_request_emits_shared_message_and_patterns() -> None:
     client = CodexClient(make_settings(a2a_bearer_token="t-1", codex_timeout=1.0))
     events: list[dict] = []
 
@@ -721,8 +721,8 @@ async def test_permission_request_emits_reason_as_display_message_only() -> None
     assert props["id"] == "301"
     assert props["sessionID"] == "thr-1"
     assert props["display_message"] == "The command needs confirmation before continuing."
+    assert props["patterns"] == ["/repo/.env"]
     assert "permission" not in props
-    assert "patterns" not in props
     assert "always" not in props
     assert "reason" not in props
     assert props["metadata"]["raw"]["parsedCmd"] == [
@@ -731,7 +731,7 @@ async def test_permission_request_emits_reason_as_display_message_only() -> None
 
 
 @pytest.mark.asyncio
-async def test_question_request_emits_protocol_questions_only() -> None:
+async def test_question_request_emits_shared_questions_and_display_message() -> None:
     client = CodexClient(make_settings(a2a_bearer_token="t-1", codex_timeout=1.0))
     events: list[dict] = []
 
@@ -764,7 +764,7 @@ async def test_question_request_emits_protocol_questions_only() -> None:
     assert len(events) == 1
     props = events[0]["properties"]
     assert props["id"] == "302"
-    assert "display_message" not in props
+    assert props["display_message"] == "Please confirm how the agent should continue."
     assert "description" not in props
     assert "prompt" not in props
     assert props["questions"] == [
@@ -774,7 +774,7 @@ async def test_question_request_emits_protocol_questions_only() -> None:
 
 
 @pytest.mark.asyncio
-async def test_permission_request_ignores_non_protocol_text_fields() -> None:
+async def test_permission_request_promotes_nested_request_message() -> None:
     client = CodexClient(make_settings(a2a_bearer_token="t-1", codex_timeout=1.0))
     events: list[dict] = []
 
@@ -805,7 +805,8 @@ async def test_permission_request_ignores_non_protocol_text_fields() -> None:
 
     assert len(events) == 1
     props = events[0]["properties"]
-    assert "display_message" not in props
+    assert props["display_message"] == "Agent wants to read the environment file."
+    assert props["patterns"] == ["/repo/.env"]
     assert "request" not in props
     assert props["metadata"]["raw"]["request"] == {
         "description": "Agent wants to read the environment file.",
@@ -814,7 +815,7 @@ async def test_permission_request_ignores_non_protocol_text_fields() -> None:
 
 
 @pytest.mark.asyncio
-async def test_question_request_ignores_nested_question_fallbacks() -> None:
+async def test_question_request_promotes_nested_context_details() -> None:
     client = CodexClient(make_settings(a2a_bearer_token="t-1", codex_timeout=1.0))
     events: list[dict] = []
 
@@ -841,8 +842,8 @@ async def test_question_request_ignores_nested_question_fallbacks() -> None:
 
     assert len(events) == 1
     props = events[0]["properties"]
-    assert "display_message" not in props
-    assert props["questions"] == []
+    assert props["display_message"] == "Please confirm how the agent should continue."
+    assert props["questions"] == [{"id": "q1", "question": "Proceed with deployment?"}]
     assert props["metadata"]["method"] == "item/tool/requestUserInput"
     assert props["metadata"]["raw"]["context"]["description"] == (
         "Please confirm how the agent should continue."

--- a/tests/test_stream_interrupts.py
+++ b/tests/test_stream_interrupts.py
@@ -19,7 +19,6 @@ def test_extract_permission_interrupt_keeps_explicit_display_message_only() -> N
             "always": [],
             "display_message": "Agent wants to read the environment file.",
         },
-        "codex_private": {},
     }
 
 
@@ -40,16 +39,20 @@ def test_extract_question_interrupt_keeps_explicit_display_message_only() -> Non
             "questions": [{"id": "q1", "question": "Proceed with deployment?"}],
             "display_message": "Please confirm how the agent should continue.",
         },
-        "codex_private": {},
     }
 
 
-def test_extract_permission_interrupt_does_not_guess_display_message_from_reason() -> None:
+def test_extract_permission_interrupt_promotes_reason_and_parsed_paths() -> None:
     event = {
         "type": "permission.asked",
         "properties": {
             "id": "perm-2",
-            "reason": "The command needs confirmation.",
+            "metadata": {
+                "raw": {
+                    "reason": "The command needs confirmation.",
+                    "parsedCmd": [{"path": "/repo/.env"}],
+                }
+            },
         },
     }
 
@@ -58,14 +61,14 @@ def test_extract_permission_interrupt_does_not_guess_display_message_from_reason
         "interrupt_type": "permission",
         "details": {
             "permission": None,
-            "patterns": [],
+            "patterns": ["/repo/.env"],
             "always": [],
+            "display_message": "The command needs confirmation.",
         },
-        "codex_private": {},
     }
 
 
-def test_extract_question_interrupt_does_not_guess_nested_questions() -> None:
+def test_extract_question_interrupt_promotes_nested_questions() -> None:
     event = {
         "type": "question.asked",
         "properties": {
@@ -78,6 +81,5 @@ def test_extract_question_interrupt_does_not_guess_nested_questions() -> None:
     assert extract_interrupt_asked_event(event) == {
         "request_id": "q-2",
         "interrupt_type": "question",
-        "details": {"questions": []},
-        "codex_private": {"metadata": {"method": "item/tool/requestUserInput"}},
+        "details": {"questions": [{"id": "q1", "question": "Proceed with deployment?"}]},
     }

--- a/tests/test_streaming_output_contract.py
+++ b/tests/test_streaming_output_contract.py
@@ -566,12 +566,7 @@ async def test_streaming_emits_interrupt_status_for_permission_asked_event() -> 
     assert interrupt["phase"] == "asked"
     assert "resolution" not in interrupt
     assert "/data/project/.env.secret" in interrupt["details"]["patterns"]
-    assert "metadata" not in interrupt["details"]
-    assert "tool" not in interrupt["details"]
-    assert (
-        interrupt_statuses[0].metadata["codex"]["interrupt"]["metadata"]["path"]
-        == "/data/project/.env.secret"
-    )
+    assert "codex" not in (interrupt_statuses[0].metadata or {})
     assert interrupt_statuses[0].status.state == TaskState.input_required
 
 
@@ -621,10 +616,10 @@ async def test_streaming_emits_interrupt_status_for_protocol_question_details() 
     assert interrupt["details"]["questions"] == [
         {"id": "q1", "question": "Proceed with deployment?"}
     ]
-    assert "display_message" not in interrupt["details"]
-    assert question_interrupts[0].metadata["codex"]["interrupt"]["metadata"]["method"] == (
-        "item/tool/requestUserInput"
+    assert (
+        interrupt["details"]["display_message"] == "Please confirm how the agent should continue."
     )
+    assert "codex" not in (question_interrupts[0].metadata or {})
     assert question_interrupts[0].status.state == TaskState.input_required
 
 


### PR DESCRIPTION
## 关联 issue

Closes #115
Relates to #98

## 变更概览

### codex_client
- 将 `requestApproval` / `requestUserInput` 的用户可见信息优先归一到 shared interrupt 属性
- 在 asked 事件组装阶段补齐 `display_message`、`patterns`、`questions`
- 对重复字符串列表做去重，避免 shared details 出现冗余路径

### stream_interrupts / streaming
- 扩展 interrupt asked 事件提取逻辑，从已知 upstream 结构中受控提取 message、path、questions
- asked 状态事件不再对外镜像 `metadata.codex.interrupt`
- 统一以 `metadata.shared.interrupt` 作为 interrupt 渲染入口

### tests
- 更新 `codex_client`、`stream_interrupts`、`streaming_output_contract` 的断言
- 覆盖 shared details 补齐后的行为与 shared-only contract

### docs
- 更新 guide 中对 interrupt metadata contract 的说明
- 明确下游应仅消费 `metadata.shared.interrupt`

## 变更影响

- 对下游来说，interrupt asked 的可见信息会更完整，shared-only 渲染路径可直接工作
- `metadata.codex.interrupt` 不再承载 asked 状态的对外并行语义，属于协议面收敛

## 验证

- `uv run pre-commit run --all-files`
- `uv run pytest`
