### PR TITLE
refactor: converge profile-based capability contracts

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -90,6 +90,13 @@ Current profile shape:
   - `interrupts.request_ttl_seconds=<int>`
   - `service_features.streaming.enabled=true`
   - `service_features.health_endpoint.enabled=true|false`
+- runtime context:
+  - `project=<optional>`
+  - `workspace_root=<optional>`
+  - `provider_id=<optional>`
+  - `model_id=<optional>`
+  - `agent=<optional>`
+  - `variant=<optional>`
 - core JSON-RPC methods:
   - `message/send`
   - `message/stream`
@@ -239,9 +246,8 @@ described first in [README.md](../README.md) and above in this guide.
 
 - `GET /health` is a lightweight authenticated status probe. It requires the
   same `Authorization: Bearer <token>` header as other protected endpoints and
-  returns service status plus a structured `profile` summary and compatibility-
-  relevant runtime flags such as streaming, session shell, and interrupt TTL; it
-  does not call upstream Codex.
+  returns service status plus a structured `profile` summary; it does not call
+  upstream Codex.
 - Requests require `Authorization: Bearer <token>`; otherwise `401` is
   returned. Agent Card endpoints are public.
 - Within one `codex-a2a-server` instance, all consumers share the same

--- a/src/codex_a2a_server/app.py
+++ b/src/codex_a2a_server/app.py
@@ -47,12 +47,12 @@ from .extension_contracts import (
     SESSION_QUERY_METHODS,
     STREAMING_EXTENSION_URI,
     WIRE_CONTRACT_EXTENSION_URI,
+    build_capability_snapshot,
     build_compatibility_profile_params,
     build_interrupt_callback_extension_params,
     build_session_binding_extension_params,
     build_session_query_extension_params,
     build_streaming_extension_params,
-    build_supported_jsonrpc_methods,
     build_wire_contract_extension_params,
 )
 from .jsonrpc_ext import CodexSessionQueryJSONRPCApplication
@@ -64,7 +64,7 @@ from .logging_context import (
     set_correlation_id,
 )
 from .openapi_contracts import patch_openapi_contract
-from .profile import build_runtime_profile
+from .profile import RuntimeProfile, build_runtime_profile
 from .request_handler import CodexRequestHandler
 
 logger = logging.getLogger(__name__)
@@ -140,25 +140,7 @@ def _build_sse_streaming_route(
     return route
 
 
-def _build_deployment_context(settings: Settings) -> dict[str, Any]:
-    runtime_profile = build_runtime_profile(settings)
-    context: dict[str, Any] = runtime_profile.deployment_context_dict()
-    if settings.a2a_project:
-        context["project"] = settings.a2a_project
-    if settings.codex_workspace_root:
-        context["workspace_root"] = settings.codex_workspace_root
-    if settings.codex_provider_id:
-        context["provider_id"] = settings.codex_provider_id
-    if settings.codex_model_id:
-        context["model_id"] = settings.codex_model_id
-    if settings.codex_agent:
-        context["agent"] = settings.codex_agent
-    if settings.codex_variant:
-        context["variant"] = settings.codex_variant
-    return context
-
-
-def _build_agent_card_description(settings: Settings, deployment_context: dict[str, Any]) -> str:
+def _build_agent_card_description(settings: Settings, runtime_profile: RuntimeProfile) -> str:
     base = (settings.a2a_description or "").strip() or "A2A wrapper service for Codex."
     summary = (
         "Supports HTTP+JSON and JSON-RPC transports, standard A2A messaging "
@@ -174,14 +156,15 @@ def _build_agent_card_description(settings: Settings, deployment_context: dict[s
         "underlying Codex workspace/environment."
     )
     parts.append("This server profile is intended for single-tenant, self-hosted coding workflows.")
-    project = deployment_context.get("project")
+    runtime_context = runtime_profile.runtime_context
+    project = runtime_context.project
     if isinstance(project, str) and project.strip():
         parts.append(f"Deployment project: {project}.")
-    workspace_root = deployment_context.get("workspace_root")
+    workspace_root = runtime_context.workspace_root
     if isinstance(workspace_root, str) and workspace_root.strip():
         parts.append(f"Workspace root: {workspace_root}.")
-    provider_id = deployment_context.get("provider_id")
-    model_id = deployment_context.get("model_id")
+    provider_id = runtime_context.provider_id
+    model_id = runtime_context.model_id
     if isinstance(provider_id, str) and isinstance(model_id, str):
         parts.append(f"Default upstream model: {provider_id}/{model_id}.")
     return " ".join(parts)
@@ -197,31 +180,29 @@ def _build_chat_examples(project: str | None) -> list[str]:
     return examples
 
 
-def build_agent_card(settings: Settings) -> AgentCard:
+def build_agent_card(
+    settings: Settings, *, runtime_profile: RuntimeProfile | None = None
+) -> AgentCard:
     public_url = settings.a2a_public_url.rstrip("/")
     base_url = public_url
-    deployment_context = _build_deployment_context(settings)
-    runtime_profile = deployment_context.get("profile")
+    runtime_profile = runtime_profile or build_runtime_profile(settings)
     session_binding_extension_params = build_session_binding_extension_params(
-        deployment_context=deployment_context,
-        directory_override_enabled=settings.a2a_allow_directory_override,
+        runtime_profile=runtime_profile,
     )
     streaming_extension_params = build_streaming_extension_params()
     session_query_extension_params = build_session_query_extension_params(
-        deployment_context=deployment_context,
-        session_shell_enabled=settings.a2a_enable_session_shell,
+        runtime_profile=runtime_profile,
     )
     interrupt_callback_extension_params = build_interrupt_callback_extension_params(
-        deployment_context=deployment_context
+        runtime_profile=runtime_profile
     )
     wire_contract_extension_params = build_wire_contract_extension_params(
         protocol_version=settings.a2a_protocol_version,
-        session_shell_enabled=settings.a2a_enable_session_shell,
+        runtime_profile=runtime_profile,
     )
     compatibility_profile_params = build_compatibility_profile_params(
         protocol_version=settings.a2a_protocol_version,
-        runtime_profile=runtime_profile if isinstance(runtime_profile, dict) else None,
-        session_shell_enabled=settings.a2a_enable_session_shell,
+        runtime_profile=runtime_profile,
     )
     security_schemes: dict[str, SecurityScheme] = {
         "bearerAuth": SecurityScheme(
@@ -236,7 +217,7 @@ def build_agent_card(settings: Settings) -> AgentCard:
 
     return AgentCard(
         name=settings.a2a_title,
-        description=_build_agent_card_description(settings, deployment_context),
+        description=_build_agent_card_description(settings, runtime_profile),
         url=base_url,
         documentation_url=settings.a2a_documentation_url,
         version=settings.a2a_version,
@@ -410,16 +391,16 @@ def create_app(settings: Settings) -> FastAPI:
         yield
         await client.close()
 
-    deployment_context = _build_deployment_context(settings)
     runtime_profile = build_runtime_profile(settings)
-    agent_card = build_agent_card(settings)
+    capability_snapshot = build_capability_snapshot(runtime_profile=runtime_profile)
+    agent_card = build_agent_card(settings, runtime_profile=runtime_profile)
     context_builder = IdentityAwareCallContextBuilder()
     jsonrpc_methods = {
         **SESSION_QUERY_METHODS,
         **SESSION_CONTROL_METHODS,
         **INTERRUPT_CALLBACK_METHODS,
     }
-    if not settings.a2a_enable_session_shell:
+    if "shell" not in capability_snapshot.session_query_method_keys:
         jsonrpc_methods.pop("shell", None)
 
     # Build JSON-RPC app (POST / by default) and attach REST endpoints (HTTP+JSON) to the same app.
@@ -430,9 +411,7 @@ def create_app(settings: Settings) -> FastAPI:
         codex_client=client,
         methods=jsonrpc_methods,
         protocol_version=settings.a2a_protocol_version,
-        supported_methods=build_supported_jsonrpc_methods(
-            session_shell_enabled=settings.a2a_enable_session_shell
-        ),
+        supported_methods=list(capability_snapshot.supported_jsonrpc_methods),
         directory_resolver=executor.resolve_directory,
         session_claim=executor.claim_session,
         session_claim_finalize=executor.finalize_session_claim,
@@ -706,10 +685,8 @@ def create_app(settings: Settings) -> FastAPI:
 
     patch_openapi_contract(
         app,
-        deployment_context=deployment_context,
-        directory_override_enabled=settings.a2a_allow_directory_override,
         protocol_version=settings.a2a_protocol_version,
-        session_shell_enabled=settings.a2a_enable_session_shell,
+        runtime_profile=runtime_profile,
     )
 
     app_status_cls: Any | None = None

--- a/src/codex_a2a_server/extension_contracts.py
+++ b/src/codex_a2a_server/extension_contracts.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
-from .profile import COMPATIBILITY_PROFILE_ID
+from .profile import RuntimeProfile
 
 COMPATIBILITY_PROFILE_EXTENSION_URI = "urn:codex-a2a:compatibility-profile/v1"
 WIRE_CONTRACT_EXTENSION_URI = "urn:codex-a2a:wire-contract/v1"
@@ -225,42 +225,58 @@ WIRE_CONTRACT_UNSUPPORTED_METHOD_DATA_FIELDS: tuple[str, ...] = (
 )
 
 
-def build_supported_jsonrpc_methods(*, session_shell_enabled: bool) -> list[str]:
-    methods = [
-        *CORE_JSONRPC_METHODS,
-        SESSION_QUERY_METHODS["list_sessions"],
-        SESSION_QUERY_METHODS["get_session_messages"],
-        SESSION_CONTROL_METHODS["prompt_async"],
-        SESSION_CONTROL_METHODS["command"],
-        *INTERRUPT_CALLBACK_METHODS.values(),
+@dataclass(frozen=True)
+class CapabilitySnapshot:
+    supported_jsonrpc_methods: tuple[str, ...]
+    extension_jsonrpc_methods: tuple[str, ...]
+    session_query_method_keys: tuple[str, ...]
+    session_query_methods: tuple[str, ...]
+    conditional_methods: dict[str, dict[str, str]]
+
+
+def build_capability_snapshot(*, runtime_profile: RuntimeProfile) -> CapabilitySnapshot:
+    session_query_method_keys = [
+        "list_sessions",
+        "get_session_messages",
+        "prompt_async",
+        "command",
     ]
-    if session_shell_enabled:
-        methods.append(SESSION_CONTROL_METHODS["shell"])
-    return methods
+    conditional_methods: dict[str, dict[str, str]] = {}
+    if runtime_profile.session_shell_enabled:
+        session_query_method_keys.append("shell")
+    else:
+        conditional_methods[SESSION_CONTROL_METHODS["shell"]] = {
+            "reason": "disabled_by_configuration",
+            "toggle": "A2A_ENABLE_SESSION_SHELL",
+        }
+    session_query_methods = tuple(SESSION_QUERY_METHODS[key] for key in session_query_method_keys)
+    extension_jsonrpc_methods = (
+        *session_query_methods,
+        *INTERRUPT_CALLBACK_METHODS.values(),
+    )
+    return CapabilitySnapshot(
+        supported_jsonrpc_methods=(
+            *CORE_JSONRPC_METHODS,
+            *extension_jsonrpc_methods,
+        ),
+        extension_jsonrpc_methods=extension_jsonrpc_methods,
+        session_query_method_keys=tuple(session_query_method_keys),
+        session_query_methods=session_query_methods,
+        conditional_methods=conditional_methods,
+    )
+
+
+def build_supported_jsonrpc_methods(*, runtime_profile: RuntimeProfile) -> list[str]:
+    snapshot = build_capability_snapshot(runtime_profile=runtime_profile)
+    return list(snapshot.supported_jsonrpc_methods)
 
 
 def build_wire_contract_extension_params(
     *,
     protocol_version: str,
-    session_shell_enabled: bool,
+    runtime_profile: RuntimeProfile,
 ) -> dict[str, Any]:
-    extension_jsonrpc_methods = [
-        SESSION_QUERY_METHODS["list_sessions"],
-        SESSION_QUERY_METHODS["get_session_messages"],
-        SESSION_CONTROL_METHODS["prompt_async"],
-        SESSION_CONTROL_METHODS["command"],
-        *INTERRUPT_CALLBACK_METHODS.values(),
-    ]
-    conditionally_available_methods: dict[str, dict[str, str]] = {}
-    if session_shell_enabled:
-        extension_jsonrpc_methods.append(SESSION_CONTROL_METHODS["shell"])
-    else:
-        conditionally_available_methods[SESSION_CONTROL_METHODS["shell"]] = {
-            "reason": "disabled_by_configuration",
-            "toggle": "A2A_ENABLE_SESSION_SHELL",
-        }
-
-    all_methods = build_supported_jsonrpc_methods(session_shell_enabled=session_shell_enabled)
+    snapshot = build_capability_snapshot(runtime_profile=runtime_profile)
     return {
         "protocol_version": protocol_version,
         "preferred_transport": "HTTP+JSON",
@@ -270,8 +286,8 @@ def build_wire_contract_extension_params(
             "http_endpoints": list(CORE_HTTP_ENDPOINTS),
         },
         "extensions": {
-            "jsonrpc_methods": extension_jsonrpc_methods,
-            "conditionally_available_methods": conditionally_available_methods,
+            "jsonrpc_methods": list(snapshot.extension_jsonrpc_methods),
+            "conditionally_available_methods": dict(snapshot.conditional_methods),
             "extension_uris": [
                 SESSION_BINDING_EXTENSION_URI,
                 STREAMING_EXTENSION_URI,
@@ -279,7 +295,7 @@ def build_wire_contract_extension_params(
                 INTERRUPT_CALLBACK_EXTENSION_URI,
             ],
         },
-        "all_jsonrpc_methods": all_methods,
+        "all_jsonrpc_methods": list(snapshot.supported_jsonrpc_methods),
         "unsupported_method_error": {
             "code": -32601,
             "type": "METHOD_NOT_SUPPORTED",
@@ -291,17 +307,9 @@ def build_wire_contract_extension_params(
 def build_compatibility_profile_params(
     *,
     protocol_version: str,
-    runtime_profile: dict[str, Any] | None = None,
-    session_shell_enabled: bool,
+    runtime_profile: RuntimeProfile,
 ) -> dict[str, Any]:
-    active_session_query_methods = [
-        SESSION_QUERY_METHODS["list_sessions"],
-        SESSION_QUERY_METHODS["get_session_messages"],
-        SESSION_CONTROL_METHODS["prompt_async"],
-        SESSION_CONTROL_METHODS["command"],
-    ]
-    if session_shell_enabled:
-        active_session_query_methods.append(SESSION_CONTROL_METHODS["shell"])
+    snapshot = build_capability_snapshot(runtime_profile=runtime_profile)
 
     method_retention: dict[str, dict[str, Any]] = {
         method: {
@@ -319,12 +327,12 @@ def build_compatibility_profile_params(
                 "retention": "stable",
                 "extension_uri": SESSION_QUERY_EXTENSION_URI,
             }
-            for method in active_session_query_methods
+            for method in snapshot.session_query_methods
         }
     )
     method_retention[SESSION_CONTROL_METHODS["shell"]] = {
         "surface": "extension",
-        "availability": "enabled" if session_shell_enabled else "disabled",
+        "availability": ("enabled" if runtime_profile.session_shell_enabled else "disabled"),
         "retention": "deployment-conditional",
         "extension_uri": SESSION_QUERY_EXTENSION_URI,
         "toggle": "A2A_ENABLE_SESSION_SHELL",
@@ -365,14 +373,10 @@ def build_compatibility_profile_params(
     }
 
     return {
-        "profile_id": COMPATIBILITY_PROFILE_ID,
+        "profile_id": runtime_profile.profile_id,
         "protocol_version": protocol_version,
-        "deployment_profile": {
-            "id": "single_tenant_shared_workspace",
-            "single_tenant": True,
-            "shared_workspace_across_consumers": True,
-            "tenant_isolation": "none",
-        },
+        "deployment": runtime_profile.deployment.as_dict(),
+        "runtime_features": runtime_profile.runtime_features_dict(),
         "core": {
             "jsonrpc_methods": list(CORE_JSONRPC_METHODS),
             "http_endpoints": list(CORE_HTTP_ENDPOINTS),
@@ -417,7 +421,6 @@ def build_compatibility_profile_params(
                 "declared profile and current extension contracts before calling it."
             ),
         ],
-        "runtime_profile": dict(runtime_profile) if runtime_profile else {},
     }
 
 
@@ -439,8 +442,7 @@ def _build_method_contract_params(
 
 def build_session_binding_extension_params(
     *,
-    deployment_context: dict[str, Any],
-    directory_override_enabled: bool,
+    runtime_profile: RuntimeProfile,
 ) -> dict[str, Any]:
     return {
         "metadata_field": SHARED_SESSION_BINDING_FIELD,
@@ -450,10 +452,7 @@ def build_session_binding_extension_params(
             "codex.directory",
         ],
         "provider_private_metadata": ["codex.directory"],
-        "directory_override_enabled": directory_override_enabled,
-        "shared_workspace_across_consumers": True,
-        "tenant_isolation": "none",
-        "deployment_context": deployment_context,
+        "profile": runtime_profile.summary_dict(),
         "notes": [
             (
                 "If metadata.shared.session.id is provided, the server will send the "
@@ -501,13 +500,13 @@ def build_streaming_extension_params() -> dict[str, Any]:
 
 def build_session_query_extension_params(
     *,
-    deployment_context: dict[str, Any],
-    session_shell_enabled: bool,
+    runtime_profile: RuntimeProfile,
 ) -> dict[str, Any]:
+    snapshot = build_capability_snapshot(runtime_profile=runtime_profile)
     active_method_contracts = {
         key: contract
         for key, contract in SESSION_QUERY_METHOD_CONTRACTS.items()
-        if session_shell_enabled or key != "shell"
+        if key in snapshot.session_query_method_keys
     }
     active_query_methods = {
         key: contract.method for key, contract in active_method_contracts.items()
@@ -563,9 +562,7 @@ def build_session_query_extension_params(
     return {
         "methods": active_query_methods,
         "control_methods": active_control_methods,
-        "shared_workspace_across_consumers": True,
-        "tenant_isolation": "none",
-        "deployment_context": deployment_context,
+        "profile": runtime_profile.summary_dict(),
         "supported_metadata": ["codex.directory"],
         "provider_private_metadata": ["codex.directory"],
         "pagination": {
@@ -608,7 +605,7 @@ def build_session_query_extension_params(
 
 def build_interrupt_callback_extension_params(
     *,
-    deployment_context: dict[str, Any],
+    runtime_profile: RuntimeProfile,
 ) -> dict[str, Any]:
     method_contracts: dict[str, Any] = {}
     for contract in INTERRUPT_CALLBACK_METHOD_CONTRACTS.values():
@@ -650,7 +647,5 @@ def build_interrupt_callback_extension_params(
             "error_data_fields": list(INTERRUPT_ERROR_DATA_FIELDS),
             "invalid_params_data_fields": list(INTERRUPT_INVALID_PARAMS_DATA_FIELDS),
         },
-        "shared_workspace_across_consumers": True,
-        "tenant_isolation": "none",
-        "deployment_context": deployment_context,
+        "profile": runtime_profile.summary_dict(),
     }

--- a/src/codex_a2a_server/openapi_contracts.py
+++ b/src/codex_a2a_server/openapi_contracts.py
@@ -16,6 +16,7 @@ from .extension_contracts import (
     build_streaming_extension_params,
     build_wire_contract_extension_params,
 )
+from .profile import RuntimeProfile
 
 
 def _build_jsonrpc_extension_openapi_description(*, session_shell_enabled: bool) -> str:
@@ -196,35 +197,26 @@ def _build_rest_message_openapi_examples() -> dict[str, Any]:
 def patch_openapi_contract(
     app: FastAPI,
     *,
-    deployment_context: dict[str, Any],
-    directory_override_enabled: bool,
     protocol_version: str,
-    session_shell_enabled: bool,
+    runtime_profile: RuntimeProfile,
 ) -> None:
     session_binding = build_session_binding_extension_params(
-        deployment_context=deployment_context,
-        directory_override_enabled=directory_override_enabled,
+        runtime_profile=runtime_profile,
     )
     streaming = build_streaming_extension_params()
     session_query = build_session_query_extension_params(
-        deployment_context=deployment_context,
-        session_shell_enabled=session_shell_enabled,
+        runtime_profile=runtime_profile,
     )
     interrupt_callback = build_interrupt_callback_extension_params(
-        deployment_context=deployment_context,
+        runtime_profile=runtime_profile,
     )
     wire_contract = build_wire_contract_extension_params(
         protocol_version=protocol_version,
-        session_shell_enabled=session_shell_enabled,
+        runtime_profile=runtime_profile,
     )
     compatibility_profile = build_compatibility_profile_params(
         protocol_version=protocol_version,
-        runtime_profile=(
-            deployment_context.get("profile")
-            if isinstance(deployment_context.get("profile"), dict)
-            else None
-        ),
-        session_shell_enabled=session_shell_enabled,
+        runtime_profile=runtime_profile,
     )
     original_openapi = app.openapi
 
@@ -241,7 +233,7 @@ def patch_openapi_contract(
                 if isinstance(post, dict):
                     post["summary"] = "Handle A2A JSON-RPC Requests"
                     post["description"] = _build_jsonrpc_extension_openapi_description(
-                        session_shell_enabled=session_shell_enabled
+                        session_shell_enabled=runtime_profile.session_shell_enabled
                     )
                     post["x-a2a-extension-contracts"] = {
                         "session_binding": session_binding,
@@ -259,7 +251,7 @@ def patch_openapi_contract(
                             app_json = content.setdefault("application/json", {})
                             if isinstance(app_json, dict):
                                 app_json["examples"] = _build_jsonrpc_extension_openapi_examples(
-                                    session_shell_enabled=session_shell_enabled
+                                    session_shell_enabled=runtime_profile.session_shell_enabled
                                 )
 
             rest_post_contracts: dict[str, dict[str, Any]] = {

--- a/src/codex_a2a_server/profile.py
+++ b/src/codex_a2a_server/profile.py
@@ -74,6 +74,32 @@ class ServiceFeaturesProfile:
 
 
 @dataclass(frozen=True)
+class RuntimeContext:
+    project: str | None = None
+    workspace_root: str | None = None
+    provider_id: str | None = None
+    model_id: str | None = None
+    agent: str | None = None
+    variant: str | None = None
+
+    def as_dict(self) -> dict[str, str]:
+        context: dict[str, str] = {}
+        if self.project:
+            context["project"] = self.project
+        if self.workspace_root:
+            context["workspace_root"] = self.workspace_root
+        if self.provider_id:
+            context["provider_id"] = self.provider_id
+        if self.model_id:
+            context["model_id"] = self.model_id
+        if self.agent:
+            context["agent"] = self.agent
+        if self.variant:
+            context["variant"] = self.variant
+        return context
+
+
+@dataclass(frozen=True)
 class RuntimeProfile:
     profile_id: str
     deployment: DeploymentProfile
@@ -81,6 +107,11 @@ class RuntimeProfile:
     session_shell: SessionShellProfile
     interrupts: InterruptProfile
     service_features: ServiceFeaturesProfile
+    runtime_context: RuntimeContext
+
+    @property
+    def session_shell_enabled(self) -> bool:
+        return self.session_shell.enabled
 
     def runtime_features_dict(self) -> dict[str, Any]:
         return {
@@ -91,29 +122,15 @@ class RuntimeProfile:
         }
 
     def summary_dict(self) -> dict[str, Any]:
-        return {
+        profile = {
             "profile_id": self.profile_id,
             "deployment": self.deployment.as_dict(),
             "runtime_features": self.runtime_features_dict(),
         }
-
-    def deployment_context_dict(self) -> dict[str, Any]:
-        deployment = self.deployment.as_dict()
-        runtime_features = self.runtime_features_dict()
-        return {
-            "profile": self.summary_dict(),
-            "profile_id": self.profile_id,
-            "deployment_profile": deployment["id"],
-            "allow_directory_override": self.directory_binding.allow_override,
-            "health_endpoint_enabled": self.service_features.health_endpoint["enabled"],
-            "interrupt_request_ttl_seconds": self.interrupts.request_ttl_seconds,
-            "session_shell_enabled": self.session_shell.enabled,
-            "single_tenant": deployment["single_tenant"],
-            "shared_workspace_across_consumers": deployment["shared_workspace_across_consumers"],
-            "streaming_enabled": self.service_features.streaming["enabled"],
-            "tenant_isolation": deployment["tenant_isolation"],
-            "runtime_features": runtime_features,
-        }
+        runtime_context = self.runtime_context.as_dict()
+        if runtime_context:
+            profile["runtime_context"] = runtime_context
+        return profile
 
     def health_payload(self, *, service: str, version: str) -> dict[str, Any]:
         return {
@@ -121,9 +138,6 @@ class RuntimeProfile:
             "service": service,
             "version": version,
             "profile": self.summary_dict(),
-            "streaming_enabled": self.service_features.streaming["enabled"],
-            "session_shell_enabled": self.session_shell.enabled,
-            "interrupt_request_ttl_seconds": self.interrupts.request_ttl_seconds,
         }
 
 
@@ -161,5 +175,13 @@ def build_runtime_profile(settings: Settings) -> RuntimeProfile:
                 "availability": ("enabled" if settings.a2a_enable_health_endpoint else "disabled"),
                 "toggle": "A2A_ENABLE_HEALTH_ENDPOINT",
             },
+        ),
+        runtime_context=RuntimeContext(
+            project=settings.a2a_project,
+            workspace_root=settings.codex_workspace_root,
+            provider_id=settings.codex_provider_id,
+            model_id=settings.codex_model_id,
+            agent=settings.codex_agent,
+            variant=settings.codex_variant,
         ),
     )

--- a/tests/test_agent_card.py
+++ b/tests/test_agent_card.py
@@ -33,7 +33,7 @@ def test_agent_card_declares_bearer_only_security() -> None:
     assert card.security == [{"bearerAuth": []}]
 
 
-def test_agent_card_injects_deployment_context_into_extensions() -> None:
+def test_agent_card_injects_profile_into_extensions() -> None:
     card = build_agent_card(
         make_settings(
             a2a_bearer_token="test-token",
@@ -49,50 +49,40 @@ def test_agent_card_injects_deployment_context_into_extensions() -> None:
     ext_by_uri = {ext.uri: ext for ext in card.capabilities.extensions or []}
 
     binding = ext_by_uri[SESSION_BINDING_EXTENSION_URI]
-    context = binding.params["deployment_context"]
-    assert context["project"] == "alpha"
-    assert context["workspace_root"] == "/srv/workspaces/alpha"
-    assert context["provider_id"] == "google"
-    assert context["model_id"] == "gemini-2.5-flash"
-    assert context["agent"] == "code-reviewer"
-    assert context["variant"] == "safe"
-    assert context["allow_directory_override"] is False
-    assert context["health_endpoint_enabled"] is True
-    assert context["interrupt_request_ttl_seconds"] == 3600
-    assert context["deployment_profile"] == "single_tenant_shared_workspace"
-    assert context["profile"]["profile_id"] == "codex-a2a-single-tenant-coding-v1"
-    assert context["profile"]["deployment"] == {
+    profile = binding.params["profile"]
+    assert profile["profile_id"] == "codex-a2a-single-tenant-coding-v1"
+    assert profile["deployment"] == {
         "id": "single_tenant_shared_workspace",
         "single_tenant": True,
         "shared_workspace_across_consumers": True,
         "tenant_isolation": "none",
     }
-    assert context["runtime_features"]["directory_binding"] == {
+    assert profile["runtime_context"] == {
+        "project": "alpha",
+        "workspace_root": "/srv/workspaces/alpha",
+        "provider_id": "google",
+        "model_id": "gemini-2.5-flash",
+        "agent": "code-reviewer",
+        "variant": "safe",
+    }
+    assert profile["runtime_features"]["directory_binding"] == {
         "allow_override": False,
         "scope": "workspace_root_only",
     }
-    assert context["runtime_features"]["session_shell"] == {
+    assert profile["runtime_features"]["session_shell"] == {
         "enabled": True,
         "availability": "enabled",
         "toggle": "A2A_ENABLE_SESSION_SHELL",
     }
-    assert context["runtime_features"]["interrupts"] == {
+    assert profile["runtime_features"]["interrupts"] == {
         "request_ttl_seconds": 3600,
     }
-    assert context["session_shell_enabled"] is True
-    assert context["single_tenant"] is True
-    assert context["shared_workspace_across_consumers"] is True
-    assert context["streaming_enabled"] is True
-    assert context["tenant_isolation"] == "none"
     assert binding.params["metadata_field"] == "metadata.shared.session.id"
     assert binding.params["supported_metadata"] == [
         "shared.session.id",
         "codex.directory",
     ]
     assert binding.params["provider_private_metadata"] == ["codex.directory"]
-    assert binding.params["directory_override_enabled"] is False
-    assert binding.params["shared_workspace_across_consumers"] is True
-    assert binding.params["tenant_isolation"] == "none"
 
     streaming = ext_by_uri[STREAMING_EXTENSION_URI]
     assert streaming.params["artifact_metadata_field"] == "metadata.shared.stream"
@@ -105,9 +95,7 @@ def test_agent_card_injects_deployment_context_into_extensions() -> None:
     )
 
     session_query = ext_by_uri[SESSION_QUERY_EXTENSION_URI]
-    assert session_query.params["deployment_context"]["project"] == "alpha"
-    assert session_query.params["shared_workspace_across_consumers"] is True
-    assert session_query.params["tenant_isolation"] == "none"
+    assert session_query.params["profile"] == profile
     assert session_query.params["supported_metadata"] == ["codex.directory"]
     assert session_query.params["provider_private_metadata"] == ["codex.directory"]
     assert session_query.params["pagination"]["mode"] == "limit"
@@ -140,9 +128,7 @@ def test_agent_card_injects_deployment_context_into_extensions() -> None:
     assert any("command/exec" in note for note in shell_contract["notes"])
 
     interrupt = ext_by_uri[INTERRUPT_CALLBACK_EXTENSION_URI]
-    assert interrupt.params["deployment_context"]["project"] == "alpha"
-    assert interrupt.params["shared_workspace_across_consumers"] is True
-    assert interrupt.params["tenant_isolation"] == "none"
+    assert interrupt.params["profile"] == profile
     assert interrupt.params["request_id_field"] == "metadata.shared.interrupt.request_id"
     assert interrupt.params["supported_metadata"] == ["codex.directory"]
     assert interrupt.params["provider_private_metadata"] == ["codex.directory"]
@@ -156,13 +142,14 @@ def test_agent_card_injects_deployment_context_into_extensions() -> None:
     compatibility = ext_by_uri[COMPATIBILITY_PROFILE_EXTENSION_URI]
     assert compatibility.params["profile_id"] == "codex-a2a-single-tenant-coding-v1"
     assert compatibility.params["protocol_version"] == "0.3.0"
-    assert compatibility.params["deployment_profile"] == {
+    assert compatibility.params["deployment"] == {
         "id": "single_tenant_shared_workspace",
         "single_tenant": True,
         "shared_workspace_across_consumers": True,
         "tenant_isolation": "none",
     }
-    assert compatibility.params["runtime_profile"] == context["profile"]
+    assert compatibility.params["deployment"] == profile["deployment"]
+    assert compatibility.params["runtime_features"] == profile["runtime_features"]
     assert compatibility.params["core"]["jsonrpc_methods"] == [
         "message/send",
         "message/stream",
@@ -229,12 +216,13 @@ def test_agent_card_omits_shell_method_when_disabled() -> None:
     assert "shell" not in session_query.params["methods"]
     assert "shell" not in session_query.params["control_methods"]
     assert "codex.sessions.shell" not in session_query.params["method_contracts"]
-    assert session_query.params["deployment_context"]["session_shell_enabled"] is False
-    assert session_query.params["deployment_context"]["interrupt_request_ttl_seconds"] == 45
-    assert session_query.params["deployment_context"]["runtime_features"]["session_shell"] == {
+    assert session_query.params["profile"]["runtime_features"]["session_shell"] == {
         "enabled": False,
         "availability": "disabled",
         "toggle": "A2A_ENABLE_SESSION_SHELL",
+    }
+    assert session_query.params["profile"]["runtime_features"]["interrupts"] == {
+        "request_ttl_seconds": 45
     }
     wire_contract = ext_by_uri[WIRE_CONTRACT_EXTENSION_URI]
     assert "codex.sessions.shell" not in wire_contract.params["all_jsonrpc_methods"]
@@ -247,7 +235,7 @@ def test_agent_card_omits_shell_method_when_disabled() -> None:
     compatibility = ext_by_uri[COMPATIBILITY_PROFILE_EXTENSION_URI]
     shell_policy = compatibility.params["method_retention"]["codex.sessions.shell"]
     assert shell_policy["availability"] == "disabled"
-    assert compatibility.params["runtime_profile"]["runtime_features"]["session_shell"] == {
+    assert compatibility.params["runtime_features"]["session_shell"] == {
         "enabled": False,
         "availability": "disabled",
         "toggle": "A2A_ENABLE_SESSION_SHELL",

--- a/tests/test_codex_session_extension.py
+++ b/tests/test_codex_session_extension.py
@@ -15,6 +15,7 @@ from codex_a2a_server.extension_contracts import (
     build_supported_jsonrpc_methods,
 )
 from codex_a2a_server.jsonrpc_ext import CodexSessionQueryJSONRPCApplication
+from codex_a2a_server.profile import build_runtime_profile
 from tests.helpers import DummySessionQueryCodexClient as DummyCodexClient
 from tests.helpers import make_settings
 
@@ -43,7 +44,9 @@ def _build_extension_app(
         codex_client=DummyCodexClient(settings),
         methods=methods,
         protocol_version=settings.a2a_protocol_version,
-        supported_methods=build_supported_jsonrpc_methods(session_shell_enabled=True),
+        supported_methods=build_supported_jsonrpc_methods(
+            runtime_profile=build_runtime_profile(settings)
+        ),
         session_claim=session_claim,
         session_claim_finalize=session_claim_finalize,
         session_claim_release=session_claim_release,

--- a/tests/test_extension_contract_consistency.py
+++ b/tests/test_extension_contract_consistency.py
@@ -14,6 +14,7 @@ from codex_a2a_server.app import (
 from codex_a2a_server.extension_contracts import (
     SESSION_QUERY_DEFAULT_LIMIT,
     SESSION_QUERY_MAX_LIMIT,
+    build_capability_snapshot,
     build_compatibility_profile_params,
     build_interrupt_callback_extension_params,
     build_session_binding_extension_params,
@@ -21,6 +22,7 @@ from codex_a2a_server.extension_contracts import (
     build_streaming_extension_params,
     build_wire_contract_extension_params,
 )
+from codex_a2a_server.profile import build_runtime_profile
 from tests.helpers import DummySessionQueryCodexClient as DummyCodexClient
 from tests.helpers import make_settings
 
@@ -34,16 +36,40 @@ def _example_params_include_field(payload: object, dotted_field: str) -> bool:
     return True
 
 
+def test_capability_snapshot_tracks_conditional_shell_surface() -> None:
+    runtime_profile = build_runtime_profile(
+        make_settings(
+            a2a_bearer_token="test-token",
+            a2a_enable_session_shell=False,
+        )
+    )
+
+    snapshot = build_capability_snapshot(runtime_profile=runtime_profile)
+
+    assert snapshot.session_query_method_keys == (
+        "list_sessions",
+        "get_session_messages",
+        "prompt_async",
+        "command",
+    )
+    assert "codex.sessions.shell" not in snapshot.supported_jsonrpc_methods
+    assert snapshot.conditional_methods == {
+        "codex.sessions.shell": {
+            "reason": "disabled_by_configuration",
+            "toggle": "A2A_ENABLE_SESSION_SHELL",
+        }
+    }
+
+
 def test_session_query_extension_ssot_matches_agent_card_contract() -> None:
     settings = make_settings(a2a_bearer_token="test-token")
+    runtime_profile = build_runtime_profile(settings)
     card = build_agent_card(settings)
     ext_by_uri = {ext.uri: ext for ext in card.capabilities.extensions or []}
 
     session_query = ext_by_uri[SESSION_QUERY_EXTENSION_URI]
-    deployment_context = session_query.params["deployment_context"]
     expected = build_session_query_extension_params(
-        deployment_context=deployment_context,
-        session_shell_enabled=settings.a2a_enable_session_shell,
+        runtime_profile=runtime_profile,
     )
 
     assert session_query.params == expected, (
@@ -59,14 +85,13 @@ def test_session_query_extension_ssot_matches_agent_card_contract_when_shell_dis
         a2a_bearer_token="test-token",
         a2a_enable_session_shell=False,
     )
+    runtime_profile = build_runtime_profile(settings)
     card = build_agent_card(settings)
     ext_by_uri = {ext.uri: ext for ext in card.capabilities.extensions or []}
 
     session_query = ext_by_uri[SESSION_QUERY_EXTENSION_URI]
-    deployment_context = session_query.params["deployment_context"]
     expected = build_session_query_extension_params(
-        deployment_context=deployment_context,
-        session_shell_enabled=settings.a2a_enable_session_shell,
+        runtime_profile=runtime_profile,
     )
 
     assert session_query.params == expected, (
@@ -151,6 +176,7 @@ def test_session_query_result_envelope_omits_method_level_contracts() -> None:
 
 def test_openapi_jsonrpc_contract_extension_matches_ssot() -> None:
     settings = make_settings(a2a_bearer_token="test-token")
+    runtime_profile = build_runtime_profile(settings)
     app = create_app(settings)
     openapi = app.openapi()
     post = openapi["paths"]["/"]["post"]
@@ -166,27 +192,23 @@ def test_openapi_jsonrpc_contract_extension_matches_ssot() -> None:
     interrupt_callback = contract["interrupt_callback"]
     wire_contract = contract["wire_contract"]
     compatibility_profile = contract["compatibility_profile"]
-    deployment_context = session_query["deployment_context"]
     expected_session_binding = build_session_binding_extension_params(
-        deployment_context=deployment_context,
-        directory_override_enabled=True,
+        runtime_profile=runtime_profile,
     )
     expected_streaming = build_streaming_extension_params()
     expected_session_query = build_session_query_extension_params(
-        deployment_context=deployment_context,
-        session_shell_enabled=settings.a2a_enable_session_shell,
+        runtime_profile=runtime_profile,
     )
     expected_interrupt_callback = build_interrupt_callback_extension_params(
-        deployment_context=deployment_context,
+        runtime_profile=runtime_profile,
     )
     expected_wire_contract = build_wire_contract_extension_params(
         protocol_version=settings.a2a_protocol_version,
-        session_shell_enabled=settings.a2a_enable_session_shell,
+        runtime_profile=runtime_profile,
     )
     expected_compatibility_profile = build_compatibility_profile_params(
         protocol_version=settings.a2a_protocol_version,
-        runtime_profile=deployment_context["profile"],
-        session_shell_enabled=settings.a2a_enable_session_shell,
+        runtime_profile=runtime_profile,
     )
 
     assert session_binding == expected_session_binding, (

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -6,10 +6,16 @@ def test_runtime_profile_splits_stable_deployment_and_runtime_features() -> None
     profile = build_runtime_profile(
         make_settings(
             a2a_bearer_token="test-token",
+            a2a_project="alpha",
             a2a_allow_directory_override=False,
             a2a_enable_session_shell=False,
             a2a_enable_health_endpoint=True,
             a2a_interrupt_request_ttl_seconds=90,
+            codex_workspace_root="/srv/workspaces/alpha",
+            codex_provider_id="google",
+            codex_model_id="gemini-2.5-flash",
+            codex_agent="code-reviewer",
+            codex_variant="safe",
         )
     )
 
@@ -45,3 +51,12 @@ def test_runtime_profile_splits_stable_deployment_and_runtime_features() -> None
             },
         },
     }
+    assert profile.runtime_context.as_dict() == {
+        "project": "alpha",
+        "workspace_root": "/srv/workspaces/alpha",
+        "provider_id": "google",
+        "model_id": "gemini-2.5-flash",
+        "agent": "code-reviewer",
+        "variant": "safe",
+    }
+    assert profile.summary_dict()["runtime_context"]["workspace_root"] == "/srv/workspaces/alpha"

--- a/tests/test_transport_contract.py
+++ b/tests/test_transport_contract.py
@@ -181,7 +181,7 @@ async def test_health_endpoint_requires_bearer_token(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_health_endpoint_with_bearer_token_reports_runtime_flags(monkeypatch) -> None:
+async def test_health_endpoint_with_bearer_token_reports_profile(monkeypatch) -> None:
     import codex_a2a_server.app as app_module
 
     settings = make_settings(
@@ -236,9 +236,6 @@ async def test_health_endpoint_with_bearer_token_reports_runtime_flags(monkeypat
                 },
             },
         },
-        "streaming_enabled": True,
-        "session_shell_enabled": False,
-        "interrupt_request_ttl_seconds": 90,
     }
 
 


### PR DESCRIPTION
## 关联

- Closes #125
- Relates #121
- Relates #123

## 改动概览

### Runtime Profile / Capability Snapshot
- 引入 `RuntimeContext`，将 project、workspace_root、provider_id、model_id、agent、variant 收敛到 `RuntimeProfile`。
- 新增最小 `CapabilitySnapshot`，统一 `session_shell` 的 deployment-conditional method availability。
- `create_app()`、wire contract、compatibility profile、session query contract 共享同一份 capability 判断来源。

### Public Contracts
- 扩展参数从原先的扁平 `deployment_context` 收敛为单一结构化 `profile`。
- compatibility profile 顶层收敛为 `profile_id + deployment + runtime_features`。
- `/health` 仅返回结构化 `profile`，不再重复返回扁平 runtime flags。

### OpenAPI / Docs
- OpenAPI contract patching 改为直接消费 `RuntimeProfile`。
- `docs/guide.md` 更新为新的 `profile` 结构，并同步 `/health` 返回语义。

### Tests
- 更新 Agent Card、OpenAPI contract、一致性校验与 health contract 测试。
- 新增 capability snapshot 条件能力测试。

## 验证

- `bash ./scripts/validate_baseline.sh`

## 说明

- 本 PR 有意移除一组兼容层公开字段，聚焦把公开 contract 收敛到结构化 `profile`。
