### PR TITLE
feat: declare execution environment boundaries in runtime profile

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -71,6 +71,11 @@ The compatibility surface distinguishes between:
 - runtime features such as directory binding policy, session shell availability,
   interrupt TTL, and health endpoint exposure
 
+Execution-environment boundary fields are also published through the runtime
+profile when configured. Those fields are declarative deployment metadata, not
+promises that every temporary approval, sandbox escalation, or host-side change
+will be reflected live per request.
+
 ## Extension Stability
 
 - Shared metadata and extension contracts should stay synchronized across Agent

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -90,6 +90,11 @@ Current profile shape:
   - `interrupts.request_ttl_seconds=<int>`
   - `service_features.streaming.enabled=true`
   - `service_features.health_endpoint.enabled=true|false`
+  - `execution_environment.sandbox.mode=unknown|read-only|workspace-write|danger-full-access`
+  - `execution_environment.sandbox.filesystem_scope=unknown|none|workspace_root|workspace_root_or_descendant|configured_roots|full_filesystem`
+  - `execution_environment.network.access=unknown|disabled|enabled|restricted`
+  - `execution_environment.approval.policy=unknown|never|on-request|on-failure|untrusted-only`
+  - `execution_environment.write_access.scope=unknown|none|workspace_root|workspace_root_or_descendant|configured_roots|full_filesystem`
 - runtime context:
   - `project=<optional>`
   - `workspace_root=<optional>`
@@ -123,6 +128,9 @@ Retention guidance:
   baseline capabilities.
 - Treat `codex.sessions.shell` as deployment-conditional. Discover it from the
   declared compatibility profile and extension contracts before calling it.
+- Treat `execution_environment.*` as deployment-configured discovery metadata.
+  It does not promise per-request snapshots of temporary approvals, escalations,
+  or host-side runtime mutations.
 
 Current implementation note:
 
@@ -177,6 +185,24 @@ Current implementation note:
   stream idle diagnostic log, default `60.0`
 - `A2A_INTERRUPT_REQUEST_TTL_SECONDS`: TTL for pending interrupt callbacks
   before they become expired, default `3600`
+- `A2A_EXECUTION_SANDBOX_MODE`: declarative sandbox mode for machine-readable
+  discovery, default `unknown`
+- `A2A_EXECUTION_SANDBOX_FILESYSTEM_SCOPE`: optional filesystem scope override
+  for machine-readable discovery
+- `A2A_EXECUTION_SANDBOX_WRITABLE_ROOTS`: optional comma-separated writable
+  root list for machine-readable discovery
+- `A2A_EXECUTION_NETWORK_ACCESS`: declarative network access policy for
+  machine-readable discovery, default `unknown`
+- `A2A_EXECUTION_NETWORK_ALLOWED_DOMAINS`: optional comma-separated allowlist
+  exposed only when safe to disclose
+- `A2A_EXECUTION_APPROVAL_POLICY`: declarative approval policy for
+  machine-readable discovery, default `unknown`
+- `A2A_EXECUTION_APPROVAL_ESCALATION_BEHAVIOR`: optional declarative approval
+  escalation behavior override
+- `A2A_EXECUTION_WRITE_ACCESS_SCOPE`: optional declarative write-access scope
+  override for machine-readable discovery
+- `A2A_EXECUTION_WRITE_OUTSIDE_WORKSPACE`: optional declarative override for
+  whether write access extends outside the workspace
 
 Configuration note:
 - The service configuration layer only accepts `CODEX_*` names for Codex-facing settings.

--- a/src/codex_a2a_server/config.py
+++ b/src/codex_a2a_server/config.py
@@ -1,11 +1,66 @@
 from __future__ import annotations
 
-from typing import cast
+from typing import Annotated, Any, cast
 
 from pydantic import Field, field_validator
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 
 from codex_a2a_server import __version__
+
+_SANDBOX_MODES = {
+    "unknown",
+    "read-only",
+    "workspace-write",
+    "danger-full-access",
+}
+_FILESYSTEM_SCOPES = {
+    "unknown",
+    "none",
+    "workspace_root",
+    "workspace_root_or_descendant",
+    "configured_roots",
+    "full_filesystem",
+}
+_NETWORK_ACCESS_MODES = {
+    "unknown",
+    "disabled",
+    "enabled",
+    "restricted",
+}
+_APPROVAL_POLICIES = {
+    "unknown",
+    "never",
+    "on-request",
+    "on-failure",
+    "untrusted-only",
+}
+_APPROVAL_ESCALATION_BEHAVIORS = {
+    "unknown",
+    "unavailable",
+    "per_request",
+    "fallback_only",
+    "restricted",
+}
+
+
+def _parse_str_list(value: Any) -> Any:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return []
+        return [item.strip() for item in stripped.split(",") if item.strip()]
+    if isinstance(value, tuple):
+        return list(value)
+    return value
+
+
+def _validate_choice(value: str, *, allowed: set[str], env_name: str) -> str:
+    if value not in allowed:
+        allowed_values = ", ".join(sorted(allowed))
+        raise ValueError(f"{env_name} must be one of: {allowed_values}")
+    return value
 
 
 class Settings(BaseSettings):
@@ -100,6 +155,42 @@ class Settings(BaseSettings):
         default=3600,
         alias="A2A_INTERRUPT_REQUEST_TTL_SECONDS",
     )
+    a2a_execution_sandbox_mode: str = Field(
+        default="unknown",
+        alias="A2A_EXECUTION_SANDBOX_MODE",
+    )
+    a2a_execution_sandbox_filesystem_scope: str | None = Field(
+        default=None,
+        alias="A2A_EXECUTION_SANDBOX_FILESYSTEM_SCOPE",
+    )
+    a2a_execution_sandbox_writable_roots: Annotated[list[str], NoDecode] = Field(
+        default_factory=list,
+        alias="A2A_EXECUTION_SANDBOX_WRITABLE_ROOTS",
+    )
+    a2a_execution_network_access: str = Field(
+        default="unknown",
+        alias="A2A_EXECUTION_NETWORK_ACCESS",
+    )
+    a2a_execution_network_allowed_domains: Annotated[list[str], NoDecode] = Field(
+        default_factory=list,
+        alias="A2A_EXECUTION_NETWORK_ALLOWED_DOMAINS",
+    )
+    a2a_execution_approval_policy: str = Field(
+        default="unknown",
+        alias="A2A_EXECUTION_APPROVAL_POLICY",
+    )
+    a2a_execution_approval_escalation_behavior: str | None = Field(
+        default=None,
+        alias="A2A_EXECUTION_APPROVAL_ESCALATION_BEHAVIOR",
+    )
+    a2a_execution_write_access_scope: str | None = Field(
+        default=None,
+        alias="A2A_EXECUTION_WRITE_ACCESS_SCOPE",
+    )
+    a2a_execution_write_outside_workspace: bool | None = Field(
+        default=None,
+        alias="A2A_EXECUTION_WRITE_OUTSIDE_WORKSPACE",
+    )
 
     @field_validator("a2a_cancel_abort_timeout_seconds")
     @classmethod
@@ -128,6 +219,75 @@ class Settings(BaseSettings):
         if value < 1:
             raise ValueError("A2A_INTERRUPT_REQUEST_TTL_SECONDS must be >= 1")
         return value
+
+    @field_validator(
+        "a2a_execution_sandbox_writable_roots",
+        "a2a_execution_network_allowed_domains",
+        mode="before",
+    )
+    @classmethod
+    def parse_execution_lists(cls, value: Any) -> Any:
+        return _parse_str_list(value)
+
+    @field_validator("a2a_execution_sandbox_mode")
+    @classmethod
+    def validate_execution_sandbox_mode(cls, value: str) -> str:
+        return _validate_choice(
+            value,
+            allowed=_SANDBOX_MODES,
+            env_name="A2A_EXECUTION_SANDBOX_MODE",
+        )
+
+    @field_validator("a2a_execution_sandbox_filesystem_scope")
+    @classmethod
+    def validate_execution_sandbox_filesystem_scope(cls, value: str | None) -> str | None:
+        if value is None:
+            return value
+        return _validate_choice(
+            value,
+            allowed=_FILESYSTEM_SCOPES,
+            env_name="A2A_EXECUTION_SANDBOX_FILESYSTEM_SCOPE",
+        )
+
+    @field_validator("a2a_execution_network_access")
+    @classmethod
+    def validate_execution_network_access(cls, value: str) -> str:
+        return _validate_choice(
+            value,
+            allowed=_NETWORK_ACCESS_MODES,
+            env_name="A2A_EXECUTION_NETWORK_ACCESS",
+        )
+
+    @field_validator("a2a_execution_approval_policy")
+    @classmethod
+    def validate_execution_approval_policy(cls, value: str) -> str:
+        return _validate_choice(
+            value,
+            allowed=_APPROVAL_POLICIES,
+            env_name="A2A_EXECUTION_APPROVAL_POLICY",
+        )
+
+    @field_validator("a2a_execution_approval_escalation_behavior")
+    @classmethod
+    def validate_execution_approval_escalation_behavior(cls, value: str | None) -> str | None:
+        if value is None:
+            return value
+        return _validate_choice(
+            value,
+            allowed=_APPROVAL_ESCALATION_BEHAVIORS,
+            env_name="A2A_EXECUTION_APPROVAL_ESCALATION_BEHAVIOR",
+        )
+
+    @field_validator("a2a_execution_write_access_scope")
+    @classmethod
+    def validate_execution_write_access_scope(cls, value: str | None) -> str | None:
+        if value is None:
+            return value
+        return _validate_choice(
+            value,
+            allowed=_FILESYSTEM_SCOPES,
+            env_name="A2A_EXECUTION_WRITE_ACCESS_SCOPE",
+        )
 
     @classmethod
     def from_env(cls) -> Settings:

--- a/src/codex_a2a_server/extension_contracts.py
+++ b/src/codex_a2a_server/extension_contracts.py
@@ -420,6 +420,11 @@ def build_compatibility_profile_params(
                 "codex.sessions.shell is deployment-conditional: discover it from the "
                 "declared profile and current extension contracts before calling it."
             ),
+            (
+                "Treat execution_environment fields as deployment-configured discovery "
+                "metadata rather than per-turn snapshots of temporary approvals or "
+                "runtime escalations."
+            ),
         ],
     }
 

--- a/src/codex_a2a_server/profile.py
+++ b/src/codex_a2a_server/profile.py
@@ -74,6 +74,80 @@ class ServiceFeaturesProfile:
 
 
 @dataclass(frozen=True)
+class SandboxProfile:
+    mode: str
+    filesystem_scope: str
+    writable_roots: tuple[str, ...] = ()
+
+    def as_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "mode": self.mode,
+            "filesystem_scope": self.filesystem_scope,
+        }
+        if self.writable_roots:
+            payload["writable_roots"] = list(self.writable_roots)
+        return payload
+
+
+@dataclass(frozen=True)
+class NetworkProfile:
+    access: str
+    allowed_domains: tuple[str, ...] = ()
+
+    def as_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "access": self.access,
+        }
+        if self.allowed_domains:
+            payload["allowed_domains"] = list(self.allowed_domains)
+        return payload
+
+
+@dataclass(frozen=True)
+class ApprovalProfile:
+    policy: str
+    escalation_behavior: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "policy": self.policy,
+        }
+        if self.escalation_behavior is not None:
+            payload["escalation_behavior"] = self.escalation_behavior
+        return payload
+
+
+@dataclass(frozen=True)
+class WriteAccessProfile:
+    scope: str
+    outside_workspace: bool | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "scope": self.scope,
+        }
+        if self.outside_workspace is not None:
+            payload["outside_workspace"] = self.outside_workspace
+        return payload
+
+
+@dataclass(frozen=True)
+class ExecutionEnvironmentProfile:
+    sandbox: SandboxProfile
+    network: NetworkProfile
+    approval: ApprovalProfile
+    write_access: WriteAccessProfile
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "sandbox": self.sandbox.as_dict(),
+            "network": self.network.as_dict(),
+            "approval": self.approval.as_dict(),
+            "write_access": self.write_access.as_dict(),
+        }
+
+
+@dataclass(frozen=True)
 class RuntimeContext:
     project: str | None = None
     workspace_root: str | None = None
@@ -107,6 +181,7 @@ class RuntimeProfile:
     session_shell: SessionShellProfile
     interrupts: InterruptProfile
     service_features: ServiceFeaturesProfile
+    execution_environment: ExecutionEnvironmentProfile
     runtime_context: RuntimeContext
 
     @property
@@ -119,6 +194,7 @@ class RuntimeProfile:
             "session_shell": self.session_shell.as_dict(),
             "interrupts": self.interrupts.as_dict(),
             "service_features": self.service_features.as_dict(),
+            "execution_environment": self.execution_environment.as_dict(),
         }
 
     def summary_dict(self) -> dict[str, Any]:
@@ -141,6 +217,52 @@ class RuntimeProfile:
         }
 
 
+def _default_filesystem_scope(*, sandbox_mode: str) -> str:
+    if sandbox_mode == "read-only":
+        return "none"
+    if sandbox_mode == "workspace-write":
+        return "workspace_root_or_descendant"
+    if sandbox_mode == "danger-full-access":
+        return "full_filesystem"
+    return "unknown"
+
+
+def _default_approval_escalation_behavior(*, policy: str) -> str | None:
+    if policy == "never":
+        return "unavailable"
+    if policy == "on-request":
+        return "per_request"
+    if policy == "on-failure":
+        return "fallback_only"
+    if policy == "untrusted-only":
+        return "restricted"
+    return None
+
+
+def _default_write_access_scope(*, sandbox_mode: str, filesystem_scope: str) -> str:
+    if sandbox_mode == "read-only":
+        return "none"
+    if sandbox_mode == "danger-full-access":
+        return "full_filesystem"
+    if filesystem_scope in {
+        "none",
+        "workspace_root",
+        "workspace_root_or_descendant",
+        "configured_roots",
+        "full_filesystem",
+    }:
+        return filesystem_scope
+    return "unknown"
+
+
+def _default_write_outside_workspace(*, write_access_scope: str) -> bool | None:
+    if write_access_scope == "full_filesystem":
+        return True
+    if write_access_scope in {"none", "workspace_root", "workspace_root_or_descendant"}:
+        return False
+    return None
+
+
 def build_runtime_profile(settings: Settings) -> RuntimeProfile:
     deployment = DeploymentProfile(
         id=DEPLOYMENT_PROFILE_ID,
@@ -152,6 +274,24 @@ def build_runtime_profile(settings: Settings) -> RuntimeProfile:
         "workspace_root_or_descendant"
         if settings.a2a_allow_directory_override
         else "workspace_root_only"
+    )
+    sandbox_filesystem_scope = (
+        settings.a2a_execution_sandbox_filesystem_scope
+        or _default_filesystem_scope(sandbox_mode=settings.a2a_execution_sandbox_mode)
+    )
+    approval_escalation_behavior = (
+        settings.a2a_execution_approval_escalation_behavior
+        if settings.a2a_execution_approval_escalation_behavior is not None
+        else _default_approval_escalation_behavior(policy=settings.a2a_execution_approval_policy)
+    )
+    write_access_scope = settings.a2a_execution_write_access_scope or _default_write_access_scope(
+        sandbox_mode=settings.a2a_execution_sandbox_mode,
+        filesystem_scope=sandbox_filesystem_scope,
+    )
+    write_outside_workspace = (
+        settings.a2a_execution_write_outside_workspace
+        if settings.a2a_execution_write_outside_workspace is not None
+        else _default_write_outside_workspace(write_access_scope=write_access_scope)
     )
     return RuntimeProfile(
         profile_id=COMPATIBILITY_PROFILE_ID,
@@ -175,6 +315,25 @@ def build_runtime_profile(settings: Settings) -> RuntimeProfile:
                 "availability": ("enabled" if settings.a2a_enable_health_endpoint else "disabled"),
                 "toggle": "A2A_ENABLE_HEALTH_ENDPOINT",
             },
+        ),
+        execution_environment=ExecutionEnvironmentProfile(
+            sandbox=SandboxProfile(
+                mode=settings.a2a_execution_sandbox_mode,
+                filesystem_scope=sandbox_filesystem_scope,
+                writable_roots=tuple(settings.a2a_execution_sandbox_writable_roots),
+            ),
+            network=NetworkProfile(
+                access=settings.a2a_execution_network_access,
+                allowed_domains=tuple(settings.a2a_execution_network_allowed_domains),
+            ),
+            approval=ApprovalProfile(
+                policy=settings.a2a_execution_approval_policy,
+                escalation_behavior=approval_escalation_behavior,
+            ),
+            write_access=WriteAccessProfile(
+                scope=write_access_scope,
+                outside_workspace=write_outside_workspace,
+            ),
         ),
         runtime_context=RuntimeContext(
             project=settings.a2a_project,

--- a/tests/test_agent_card.py
+++ b/tests/test_agent_card.py
@@ -44,6 +44,11 @@ def test_agent_card_injects_profile_into_extensions() -> None:
             codex_agent="code-reviewer",
             codex_variant="safe",
             a2a_allow_directory_override=False,
+            a2a_execution_sandbox_mode="workspace-write",
+            a2a_execution_network_access="restricted",
+            a2a_execution_network_allowed_domains=["api.openai.com"],
+            a2a_execution_approval_policy="on-request",
+            a2a_execution_write_access_scope="workspace_root_or_descendant",
         )
     )
     ext_by_uri = {ext.uri: ext for ext in card.capabilities.extensions or []}
@@ -76,6 +81,24 @@ def test_agent_card_injects_profile_into_extensions() -> None:
     }
     assert profile["runtime_features"]["interrupts"] == {
         "request_ttl_seconds": 3600,
+    }
+    assert profile["runtime_features"]["execution_environment"] == {
+        "sandbox": {
+            "mode": "workspace-write",
+            "filesystem_scope": "workspace_root_or_descendant",
+        },
+        "network": {
+            "access": "restricted",
+            "allowed_domains": ["api.openai.com"],
+        },
+        "approval": {
+            "policy": "on-request",
+            "escalation_behavior": "per_request",
+        },
+        "write_access": {
+            "scope": "workspace_root_or_descendant",
+            "outside_workspace": False,
+        },
     }
     assert binding.params["metadata_field"] == "metadata.shared.session.id"
     assert binding.params["supported_metadata"] == [
@@ -190,6 +213,9 @@ def test_agent_card_injects_profile_into_extensions() -> None:
         for note in compatibility.params["consumer_guidance"]
     )
     assert any("urn:a2a:*" in note for note in compatibility.params["consumer_guidance"])
+    assert any(
+        "execution_environment" in note for note in compatibility.params["consumer_guidance"]
+    )
     shell_policy = compatibility.params["method_retention"]["codex.sessions.shell"]
     assert shell_policy["availability"] == "enabled"
     assert shell_policy["retention"] == "deployment-conditional"
@@ -223,6 +249,21 @@ def test_agent_card_omits_shell_method_when_disabled() -> None:
     }
     assert session_query.params["profile"]["runtime_features"]["interrupts"] == {
         "request_ttl_seconds": 45
+    }
+    assert session_query.params["profile"]["runtime_features"]["execution_environment"] == {
+        "sandbox": {
+            "mode": "unknown",
+            "filesystem_scope": "unknown",
+        },
+        "network": {
+            "access": "unknown",
+        },
+        "approval": {
+            "policy": "unknown",
+        },
+        "write_access": {
+            "scope": "unknown",
+        },
     }
     wire_contract = ext_by_uri[WIRE_CONTRACT_EXTENSION_URI]
     assert "codex.sessions.shell" not in wire_contract.params["all_jsonrpc_methods"]

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -16,6 +16,13 @@ def test_runtime_profile_splits_stable_deployment_and_runtime_features() -> None
             codex_model_id="gemini-2.5-flash",
             codex_agent="code-reviewer",
             codex_variant="safe",
+            a2a_execution_sandbox_mode="workspace-write",
+            a2a_execution_sandbox_writable_roots=["/srv/workspaces/alpha", "/tmp/cache"],
+            a2a_execution_network_access="restricted",
+            a2a_execution_network_allowed_domains=["api.openai.com", "github.com"],
+            a2a_execution_approval_policy="on-request",
+            a2a_execution_write_access_scope="configured_roots",
+            a2a_execution_write_outside_workspace=True,
         )
     )
 
@@ -48,6 +55,25 @@ def test_runtime_profile_splits_stable_deployment_and_runtime_features() -> None
                 "enabled": True,
                 "availability": "enabled",
                 "toggle": "A2A_ENABLE_HEALTH_ENDPOINT",
+            },
+        },
+        "execution_environment": {
+            "sandbox": {
+                "mode": "workspace-write",
+                "filesystem_scope": "workspace_root_or_descendant",
+                "writable_roots": ["/srv/workspaces/alpha", "/tmp/cache"],
+            },
+            "network": {
+                "access": "restricted",
+                "allowed_domains": ["api.openai.com", "github.com"],
+            },
+            "approval": {
+                "policy": "on-request",
+                "escalation_behavior": "per_request",
+            },
+            "write_access": {
+                "scope": "configured_roots",
+                "outside_workspace": True,
             },
         },
     }

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -26,7 +26,7 @@ def test_settings_valid():
         "CODEX_WORKSPACE_ROOT": "/tmp/workspace",
     }
     with mock.patch.dict(os.environ, env, clear=True):
-        settings = Settings()
+        settings = Settings.from_env()
         assert settings.a2a_bearer_token == "test-token"
         assert settings.codex_timeout == 300.0
         assert settings.codex_model_reasoning_effort == "high"
@@ -45,13 +45,40 @@ def test_settings_parse_ops_flags_and_timeouts():
         "A2A_INTERRUPT_REQUEST_TTL_SECONDS": "90",
     }
     with mock.patch.dict(os.environ, env, clear=True):
-        settings = Settings()
+        settings = Settings.from_env()
         assert settings.a2a_enable_health_endpoint is False
         assert settings.a2a_enable_session_shell is False
         assert settings.a2a_cancel_abort_timeout_seconds == 0.25
         assert settings.a2a_stream_sse_ping_seconds == 8
         assert settings.a2a_stream_idle_diagnostic_seconds == 45
         assert settings.a2a_interrupt_request_ttl_seconds == 90
+
+
+def test_settings_parse_execution_environment_flags() -> None:
+    env = {
+        "A2A_BEARER_TOKEN": "test",
+        "A2A_EXECUTION_SANDBOX_MODE": "workspace-write",
+        "A2A_EXECUTION_SANDBOX_WRITABLE_ROOTS": "/workspace,/tmp/cache",
+        "A2A_EXECUTION_NETWORK_ACCESS": "restricted",
+        "A2A_EXECUTION_NETWORK_ALLOWED_DOMAINS": "api.openai.com,github.com",
+        "A2A_EXECUTION_APPROVAL_POLICY": "on-request",
+        "A2A_EXECUTION_APPROVAL_ESCALATION_BEHAVIOR": "per_request",
+        "A2A_EXECUTION_WRITE_ACCESS_SCOPE": "configured_roots",
+        "A2A_EXECUTION_WRITE_OUTSIDE_WORKSPACE": "true",
+    }
+    with mock.patch.dict(os.environ, env, clear=True):
+        settings = Settings.from_env()
+        assert settings.a2a_execution_sandbox_mode == "workspace-write"
+        assert settings.a2a_execution_sandbox_writable_roots == ["/workspace", "/tmp/cache"]
+        assert settings.a2a_execution_network_access == "restricted"
+        assert settings.a2a_execution_network_allowed_domains == [
+            "api.openai.com",
+            "github.com",
+        ]
+        assert settings.a2a_execution_approval_policy == "on-request"
+        assert settings.a2a_execution_approval_escalation_behavior == "per_request"
+        assert settings.a2a_execution_write_access_scope == "configured_roots"
+        assert settings.a2a_execution_write_outside_workspace is True
 
 
 def test_settings_reject_invalid_cancel_abort_timeout():
@@ -107,3 +134,14 @@ def test_settings_reject_invalid_stream_idle_diagnostic_seconds():
         with pytest.raises(ValidationError) as excinfo:
             Settings()
     assert "A2A_STREAM_IDLE_DIAGNOSTIC_SECONDS" in str(excinfo.value)
+
+
+def test_settings_reject_invalid_execution_sandbox_mode() -> None:
+    env = {
+        "A2A_BEARER_TOKEN": "test",
+        "A2A_EXECUTION_SANDBOX_MODE": "sandboxed",
+    }
+    with mock.patch.dict(os.environ, env, clear=True):
+        with pytest.raises(ValidationError) as excinfo:
+            Settings.from_env()
+    assert "A2A_EXECUTION_SANDBOX_MODE" in str(excinfo.value)

--- a/tests/test_transport_contract.py
+++ b/tests/test_transport_contract.py
@@ -234,6 +234,21 @@ async def test_health_endpoint_with_bearer_token_reports_profile(monkeypatch) ->
                         "toggle": "A2A_ENABLE_HEALTH_ENDPOINT",
                     },
                 },
+                "execution_environment": {
+                    "sandbox": {
+                        "mode": "unknown",
+                        "filesystem_scope": "unknown",
+                    },
+                    "network": {
+                        "access": "unknown",
+                    },
+                    "approval": {
+                        "policy": "unknown",
+                    },
+                    "write_access": {
+                        "scope": "unknown",
+                    },
+                },
             },
         },
     }


### PR DESCRIPTION
Closes #123
Relates #121

## Issue 关联

- `#123`：本 PR 直接实现该 issue 当前已确认的落地范围，因此使用 `Closes #123`。
- `#121`：本 PR 属于其下的兼容性/生态契合度子议题，因此保留 `Relates #121`，不关闭该 umbrella issue。
- `#124`：本 PR 不包含 runtime output contract layer 重构，因此不关联 `Closes`/`Relates`。

## 背景

本 PR 继续沿用当前仓库已经建立的 `RuntimeProfile -> compatibility profile -> Agent Card/OpenAPI/health` 发现链路，在现有 `runtime_features` 中补充 execution environment boundary 的机器可发现声明。

本次没有新增独立 extension URI，也没有把宿主运行中的瞬时授权状态包装成稳定协议承诺。

## 配置与模型

- 在 `Settings` 中新增 execution boundary 相关配置项。
- 为 sandbox mode、filesystem scope、network access、approval policy、write access scope 增加显式枚举校验。
- 对 list 型 env 增加逗号分隔解析，避免要求部署侧改为 JSON 书写。
- 在 `RuntimeProfile` 下新增 execution environment profile 与子模型：sandbox、network、approval、write_access。
- 对未配置字段保守声明为 `unknown`，并只对少数字段做有限默认推导。

## Contract 与发现面

- 将 `execution_environment` 纳入 `runtime_features_dict()`，因此自动进入：
  - Agent Card extension params
  - OpenAPI `x-a2a-extension-contracts`
  - `/health` profile payload
- 在 compatibility profile 的 consumer guidance 中补充语义说明：
  - 这些字段是 deployment-configured discovery metadata
  - 不是每次 turn / 审批 / 越权的实时快照

## 文档

- 更新 `docs/guide.md`：
  - profile shape
  - retention guidance
  - 新增 env 配置说明
- 更新 `docs/compatibility.md`：
  - 明确 execution-environment boundary 属于 declarative deployment metadata

## 测试与验证

- 更新 settings/profile/agent card/transport contract 相关测试。
- 新增 execution env 配置解析与非法值校验测试。
- 已本地通过：
  - `bash ./scripts/validate_baseline.sh`

## 范围说明

本 PR 未包含以下内容：

- 新增独立 `urn:codex-a2a:execution-environment/v1` 扩展
- 基于本机 `codex` CLI 的实时自省
- 与 #124 的 runtime output contract layer 重构绑定实施
