### PR TITLE
refactor: converge sdk transport assembly and service contracts

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -54,6 +54,12 @@ declared surfaces should not drift silently:
 Changes to those surfaces should be treated as compatibility-sensitive and
 should include corresponding test updates.
 
+Service-level behavior layered on top of those core methods should also be
+declared explicitly when this repository depends on it for interoperability.
+Current example: terminal `tasks/resubscribe` replay-once behavior is published
+as a service-level contract, not as a claim about generic A2A runtime
+semantics.
+
 ## Deployment Profile
 
 The current service profile is intentionally:

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -181,8 +181,6 @@ Current implementation note:
 - `A2A_CANCEL_ABORT_TIMEOUT_SECONDS`: how long `tasks/cancel` waits for
   in-flight execution/session-create cleanup after issuing cancellation,
   default `1.0`; `0` means best-effort cancel without waiting
-- `A2A_STREAM_SSE_PING_SECONDS`: transport-level SSE keepalive interval,
-  default `10` (integer seconds)
 - `A2A_STREAM_IDLE_DIAGNOSTIC_SECONDS`: threshold before the server emits a
   stream idle diagnostic log, default `60.0`
 - `A2A_INTERRUPT_REQUEST_TTL_SECONDS`: TTL for pending interrupt callbacks
@@ -300,6 +298,9 @@ described first in [README.md](../README.md) and above in this guide.
 - Non-streaming requests return a `Task` directly.
 - Non-streaming `message:send` responses may include normalized token usage at
   `Task.metadata.shared.usage` with the same field schema.
+- `tasks/resubscribe` remains part of the core A2A method baseline, but this
+  deployment's terminal-task replay-once policy is a declared service-level
+  behavior rather than a generic A2A guarantee.
 
 ### Streaming and Interrupt Contract
 
@@ -355,7 +356,8 @@ described first in [README.md](../README.md) and above in this guide.
   `metadata.shared.interrupt.details`, including readable `display_message`,
   resolved `patterns`, and `questions` when available.
 - HTTP streaming responses send transport-level SSE ping comments on a
-  configurable interval without adding synthetic A2A business events.
+  default keepalive interval from the underlying SDK / `sse-starlette`
+  response without adding synthetic A2A business events.
 - Interrupt status events no longer mirror the asked payload under
   `metadata.codex.interrupt`; downstream consumers should treat
   `metadata.shared.interrupt` as the single interrupt rendering contract.
@@ -572,7 +574,17 @@ curl -sS http://127.0.0.1:8000/ \
 
 ## Streaming Re-Subscription (`subscribe`)
 
-If an SSE connection drops, use `GET /v1/tasks/{task_id}:subscribe` to re-subscribe while the task is still non-terminal.
+If an SSE connection drops, use `GET /v1/tasks/{task_id}:subscribe` to
+re-subscribe while the task is still non-terminal.
+
+Terminal-task note:
+
+- While a task is non-terminal, the stream continues with live updates.
+- If the task is already terminal, this service replays one final task snapshot
+  and then closes the stream.
+- That replay-once terminal behavior is a service-level contract for this
+  deployment. It is published through the compatibility profile and wire
+  contract so clients do not mistake it for a generic A2A baseline rule.
 
 ## Development Setup
 

--- a/src/codex_a2a_server/app.py
+++ b/src/codex_a2a_server/app.py
@@ -1,22 +1,13 @@
 from __future__ import annotations
 
-import hashlib
-import json
 import logging
-import secrets
-import time
-from collections.abc import AsyncIterable, AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any
-from urllib.parse import unquote
 
 import uvicorn
+from a2a.server.apps.jsonrpc.fastapi_app import A2AFastAPI
 from a2a.server.apps.jsonrpc.jsonrpc_app import DefaultCallContextBuilder
-from a2a.server.apps.rest.rest_adapter import (
-    InvalidRequestError,
-    RESTAdapter,
-    ServerError,
-)
+from a2a.server.apps.rest.rest_adapter import RESTAdapter
 from a2a.server.tasks.inmemory_task_store import InMemoryTaskStore
 from a2a.types import (
     AgentCapabilities,
@@ -25,14 +16,10 @@ from a2a.types import (
     AgentInterface,
     AgentSkill,
     HTTPAuthSecurityScheme,
-    InternalError,
     SecurityScheme,
     TransportProtocol,
 )
 from fastapi import FastAPI, Request
-from fastapi.responses import JSONResponse
-from sse_starlette.sse import EventSourceResponse
-from starlette.responses import StreamingResponse
 
 from .agent import CodexAgentExecutor
 from .codex_client import CodexClient
@@ -55,19 +42,12 @@ from .extension_contracts import (
     build_streaming_extension_params,
     build_wire_contract_extension_params,
 )
+from .http_middlewares import install_http_middlewares
 from .jsonrpc_ext import CodexSessionQueryJSONRPCApplication
-from .logging_context import (
-    CORRELATION_ID_HEADER,
-    install_log_record_factory,
-    reset_correlation_id,
-    resolve_correlation_id,
-    set_correlation_id,
-)
+from .logging_context import install_log_record_factory
 from .openapi_contracts import patch_openapi_contract
 from .profile import RuntimeProfile, build_runtime_profile
 from .request_handler import CodexRequestHandler
-
-logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from a2a.server.context import ServerCallContext
@@ -100,46 +80,6 @@ class IdentityAwareCallContextBuilder(DefaultCallContextBuilder):
         return context
 
 
-def _build_sse_streaming_route(
-    *,
-    method: Callable[[Request, ServerCallContext], AsyncIterable[object]],
-    context_builder: DefaultCallContextBuilder,
-    sse_ping_seconds: int,
-) -> Callable[[Request], Awaitable[EventSourceResponse]]:
-    async def route(request: Request):
-        try:
-            await request.body()
-            call_context = context_builder.build(request)
-
-            async def event_generator(
-                stream: AsyncIterable[object],
-            ) -> AsyncIterator[dict[str, object]]:
-                async for item in stream:
-                    yield {"data": item}
-
-            return EventSourceResponse(
-                event_generator(method(request, call_context)),
-                ping=sse_ping_seconds,
-            )
-        except (ValueError, RuntimeError, OSError) as e:
-            raise ServerError(
-                error=InvalidRequestError(message=f"Failed to pre-consume request body: {e}")
-            ) from e
-        except ServerError as e:
-            error = e.error or InternalError(message="Internal error due to unknown reason")
-            log_level = logging.ERROR if isinstance(error, InternalError) else logging.WARNING
-            logger.log(
-                log_level,
-                "Request error: Code=%s, Message='%s'%s",
-                error.code,
-                error.message,
-                ", Data=" + str(error.data) if error.data else "",
-            )
-            raise
-
-    return route
-
-
 def _build_agent_card_description(settings: Settings, runtime_profile: RuntimeProfile) -> str:
     base = (settings.a2a_description or "").strip() or "A2A wrapper service for Codex."
     summary = (
@@ -154,6 +94,10 @@ def _build_agent_card_description(settings: Settings, runtime_profile: RuntimePr
     parts.append(
         "Within one codex-a2a-server instance, all consumers share the same "
         "underlying Codex workspace/environment."
+    )
+    parts.append(
+        "Terminal tasks/resubscribe replay-once behavior is declared as a "
+        "service-level contract for this deployment."
     )
     parts.append("This server profile is intended for single-tenant, self-hosted coding workflows.")
     runtime_context = runtime_profile.runtime_context
@@ -335,37 +279,6 @@ def build_agent_card(
     )
 
 
-def add_auth_middleware(app: FastAPI, settings: Settings) -> None:
-    token = settings.a2a_bearer_token
-
-    def _unauthorized_response() -> JSONResponse:
-        return JSONResponse(
-            {"error": "Unauthorized"},
-            status_code=401,
-            headers={"WWW-Authenticate": "Bearer"},
-        )
-
-    public_paths = {
-        "/.well-known/agent-card.json",
-        "/.well-known/agent.json",
-    }
-
-    @app.middleware("http")
-    async def bearer_auth(request: Request, call_next):
-        if request.method == "OPTIONS" or request.url.path in public_paths:
-            return await call_next(request)
-
-        auth_header = request.headers.get("authorization", "")
-        if not auth_header.lower().startswith("bearer "):
-            return _unauthorized_response()
-        provided = auth_header.split(" ", 1)[1].strip()
-        if not secrets.compare_digest(provided, token):
-            return _unauthorized_response()
-        request.state.user_identity = f"bearer:{hashlib.sha256(provided.encode()).hexdigest()[:12]}"
-
-        return await call_next(request)
-
-
 def create_app(settings: Settings) -> FastAPI:
     install_log_record_factory()
     client = CodexClient(settings)
@@ -403,8 +316,8 @@ def create_app(settings: Settings) -> FastAPI:
     if "shell" not in capability_snapshot.session_query_method_keys:
         jsonrpc_methods.pop("shell", None)
 
-    # Build JSON-RPC app (POST / by default) and attach REST endpoints (HTTP+JSON) to the same app.
-    app = CodexSessionQueryJSONRPCApplication(
+    # Compose the shared FastAPI app from the SDK JSON-RPC and REST application wrappers.
+    jsonrpc_app = CodexSessionQueryJSONRPCApplication(
         agent_card=agent_card,
         http_handler=handler,
         context_builder=context_builder,
@@ -417,7 +330,13 @@ def create_app(settings: Settings) -> FastAPI:
         session_claim_finalize=executor.finalize_session_claim,
         session_claim_release=executor.release_session_claim,
         session_owner_matcher=executor.session_owner_matches,
-    ).build(title=settings.a2a_title, version=settings.a2a_version, lifespan=lifespan)
+    )
+    app = A2AFastAPI(
+        title=settings.a2a_title,
+        version=settings.a2a_version,
+        lifespan=lifespan,
+    )
+    jsonrpc_app.add_routes_to_app(app)
     app.state.codex_client = client
     app.state.codex_executor = executor
 
@@ -426,18 +345,7 @@ def create_app(settings: Settings) -> FastAPI:
         http_handler=handler,
         context_builder=context_builder,
     )
-    rest_routes = rest_adapter.routes()
-    rest_routes[("/v1/message:stream", "POST")] = _build_sse_streaming_route(
-        method=rest_adapter.handler.on_message_send_stream,
-        context_builder=context_builder,
-        sse_ping_seconds=settings.a2a_stream_sse_ping_seconds,
-    )
-    rest_routes[("/v1/tasks/{id}:subscribe", "GET")] = _build_sse_streaming_route(
-        method=rest_adapter.handler.on_resubscribe_to_task,
-        context_builder=context_builder,
-        sse_ping_seconds=settings.a2a_stream_sse_ping_seconds,
-    )
-    for route, callback in rest_routes.items():
+    for route, callback in rest_adapter.routes().items():
         app.add_api_route(route[0], callback, methods=[route[1]])
 
     if settings.a2a_enable_health_endpoint:
@@ -449,239 +357,11 @@ def create_app(settings: Settings) -> FastAPI:
                 version=settings.a2a_version,
             )
 
-    def _parse_json_body(body_bytes: bytes) -> dict | None:
-        try:
-            payload = json.loads(body_bytes.decode("utf-8", errors="replace"))
-        except Exception:
-            return None
-        return payload if isinstance(payload, dict) else None
-
-    def _detect_codex_extension_method(payload: dict | None) -> str | None:
-        if payload is None:
-            return None
-        method = payload.get("method")
-        if not isinstance(method, str):
-            return None
-        if method.startswith("codex."):
-            return method
-        return None
-
-    def _parse_content_length(value: str | None) -> int | None:
-        if value is None:
-            return None
-        try:
-            parsed = int(value)
-        except ValueError:
-            return None
-        return parsed if parsed >= 0 else None
-
-    def _normalize_content_type(value: str | None) -> str:
-        if not value:
-            return ""
-        return value.split(";", 1)[0].strip().lower()
-
-    def _is_json_content_type(content_type: str) -> bool:
-        if not content_type:
-            return False
-        return content_type == "application/json" or content_type.endswith("+json")
-
-    def _decode_payload_preview(body: bytes, *, limit: int) -> str:
-        text = body.decode("utf-8", errors="replace")
-        if limit > 0 and len(text) > limit:
-            return f"{text[:limit]}...[truncated]"
-        return text
-
-    async def _get_request_body(request: Request) -> bytes:
-        body = await request.body()
-        request._body = body  # allow downstream to read again
-        return body
-
-    def _looks_like_jsonrpc_message_payload(payload: dict | None) -> bool:
-        if payload is None:
-            return False
-        message = payload.get("message")
-        if not isinstance(message, dict):
-            return False
-        if "parts" in message:
-            return True
-        role = message.get("role")
-        return isinstance(role, str) and role in {"user", "agent"}
-
-    def _looks_like_jsonrpc_envelope(payload: dict | None) -> bool:
-        if payload is None:
-            return False
-        method = payload.get("method")
-        version = payload.get("jsonrpc")
-        return isinstance(method, str) and isinstance(version, str)
-
-    @app.middleware("http")
-    async def guard_rest_payload_shape(request: Request, call_next):
-        if request.method != "POST" or request.url.path not in {
-            "/v1/message:send",
-            "/v1/message:stream",
-        }:
-            return await call_next(request)
-
-        body = await _get_request_body(request)
-        payload = _parse_json_body(body)
-        if _looks_like_jsonrpc_envelope(payload) or _looks_like_jsonrpc_message_payload(payload):
-            return JSONResponse(
-                {
-                    "error": (
-                        "Invalid HTTP+JSON payload for REST endpoint. "
-                        "Use message.content with ROLE_* role values, or call "
-                        "POST / with method=message/send or method=message/stream."
-                    )
-                },
-                status_code=400,
-            )
-        return await call_next(request)
-
-    @app.middleware("http")
-    async def guard_missing_subscribe_task(request: Request, call_next):
-        path = request.url.path
-        if not path.startswith("/v1/tasks/") or not path.endswith(":subscribe"):
-            return await call_next(request)
-
-        encoded_task_id = path.removeprefix("/v1/tasks/").removesuffix(":subscribe")
-        task_id = unquote(encoded_task_id).strip()
-        if not task_id:
-            return JSONResponse({"error": "Task not found"}, status_code=404)
-
-        task = await task_store.get(task_id)
-        if task is None:
-            return JSONResponse({"error": "Task not found", "task_id": task_id}, status_code=404)
-        return await call_next(request)
-
-    @app.middleware("http")
-    async def log_payloads(request: Request, call_next):
-        if not settings.a2a_log_payloads:
-            return await call_next(request)
-
-        path = request.url.path
-        limit = settings.a2a_log_body_limit
-        content_type = _normalize_content_type(request.headers.get("content-type"))
-        content_length = _parse_content_length(request.headers.get("content-length"))
-
-        sensitive_method: str | None = None
-        request_omit_reason: str | None = None
-
-        if not _is_json_content_type(content_type):
-            request_omit_reason = f"non-json content-type={content_type or 'unknown'}"
-        elif limit > 0 and content_length is None:
-            request_omit_reason = f"missing content-length with limit={limit}"
-        elif limit > 0 and content_length is not None and content_length > limit:
-            request_omit_reason = f"content-length={content_length} exceeds limit={limit}"
-        else:
-            body = await _get_request_body(request)
-            payload = _parse_json_body(body)
-            sensitive_method = _detect_codex_extension_method(payload)
-
-            if sensitive_method:
-                logger.debug("A2A request %s %s method=%s", request.method, path, sensitive_method)
-            else:
-                logger.debug(
-                    "A2A request %s %s body=%s",
-                    request.method,
-                    path,
-                    _decode_payload_preview(body, limit=limit),
-                )
-
-        if request_omit_reason:
-            logger.debug(
-                "A2A request %s %s body=[omitted %s]",
-                request.method,
-                path,
-                request_omit_reason,
-            )
-
-        response = await call_next(request)
-        if isinstance(response, StreamingResponse):
-            status_code = getattr(response, "status_code", 200)
-            if request_omit_reason:
-                logger.debug(
-                    "A2A response %s status=%s body=[omitted request_%s]",
-                    path,
-                    status_code,
-                    request_omit_reason,
-                )
-            elif sensitive_method:
-                logger.debug("A2A response %s streaming method=%s", path, sensitive_method)
-            else:
-                logger.debug("A2A response %s streaming", path)
-            return response
-
-        response_body = getattr(response, "body", b"") or b""
-        if sensitive_method:
-            logger.debug(
-                "A2A response %s status=%s bytes=%s method=%s",
-                path,
-                response.status_code,
-                len(response_body),
-                sensitive_method,
-            )
-            return response
-
-        if request_omit_reason:
-            logger.debug(
-                "A2A response %s status=%s bytes=%s body=[omitted request_%s]",
-                path,
-                response.status_code,
-                len(response_body),
-                request_omit_reason,
-            )
-            return response
-
-        response_content_type = _normalize_content_type(response.headers.get("content-type"))
-        if not _is_json_content_type(response_content_type):
-            logger.debug(
-                "A2A response %s status=%s bytes=%s body=[omitted non-json content-type=%s]",
-                path,
-                response.status_code,
-                len(response_body),
-                response_content_type or "unknown",
-            )
-            return response
-
-        logger.debug(
-            "A2A response %s status=%s body=%s",
-            path,
-            response.status_code,
-            _decode_payload_preview(response_body, limit=limit),
-        )
-        return response
-
-    add_auth_middleware(app, settings)
-
-    @app.middleware("http")
-    async def correlation_id_middleware(request: Request, call_next):
-        correlation_id = resolve_correlation_id(request.headers.get("x-request-id"))
-        request.state.correlation_id = correlation_id
-        token = set_correlation_id(correlation_id)
-        started_at = time.perf_counter()
-        path = request.url.path
-        logger.info("A2A request started method=%s path=%s", request.method, path)
-        try:
-            response = await call_next(request)
-            response.headers[CORRELATION_ID_HEADER] = correlation_id
-            logger.info(
-                "A2A request completed method=%s path=%s status=%s duration_ms=%.2f",
-                request.method,
-                path,
-                response.status_code,
-                (time.perf_counter() - started_at) * 1000.0,
-            )
-            return response
-        except Exception:
-            logger.exception(
-                "A2A request failed method=%s path=%s duration_ms=%.2f",
-                request.method,
-                path,
-                (time.perf_counter() - started_at) * 1000.0,
-            )
-            raise
-        finally:
-            reset_correlation_id(token)
+    install_http_middlewares(
+        app,
+        settings=settings,
+        task_store=task_store,
+    )
 
     patch_openapi_contract(
         app,

--- a/src/codex_a2a_server/config.py
+++ b/src/codex_a2a_server/config.py
@@ -143,10 +143,6 @@ class Settings(BaseSettings):
         default=1.0,
         alias="A2A_CANCEL_ABORT_TIMEOUT_SECONDS",
     )
-    a2a_stream_sse_ping_seconds: int = Field(
-        default=10,
-        alias="A2A_STREAM_SSE_PING_SECONDS",
-    )
     a2a_stream_idle_diagnostic_seconds: float = Field(
         default=60.0,
         alias="A2A_STREAM_IDLE_DIAGNOSTIC_SECONDS",
@@ -197,13 +193,6 @@ class Settings(BaseSettings):
     def validate_cancel_abort_timeout_seconds(cls, value: float) -> float:
         if value < 0:
             raise ValueError("A2A_CANCEL_ABORT_TIMEOUT_SECONDS must be >= 0")
-        return value
-
-    @field_validator("a2a_stream_sse_ping_seconds")
-    @classmethod
-    def validate_stream_sse_ping_seconds(cls, value: int) -> int:
-        if value <= 0:
-            raise ValueError("A2A_STREAM_SSE_PING_SECONDS must be > 0")
         return value
 
     @field_validator("a2a_stream_idle_diagnostic_seconds")

--- a/src/codex_a2a_server/extension_contracts.py
+++ b/src/codex_a2a_server/extension_contracts.py
@@ -20,6 +20,9 @@ STREAMING_EXTENSION_URI = "urn:a2a:stream-hints/v1"
 SESSION_QUERY_EXTENSION_URI = "urn:codex-a2a:codex-session-query/v1"
 INTERRUPT_CALLBACK_EXTENSION_URI = "urn:a2a:interactive-interrupt/v1"
 
+TASKS_RESUBSCRIBE_METHOD = "tasks/resubscribe"
+TASKS_SUBSCRIBE_HTTP_ENDPOINT = "/v1/tasks/{id}:subscribe"
+
 SHARED_SESSION_BINDING_FIELD = "metadata.shared.session.id"
 SHARED_SESSION_METADATA_FIELD = "metadata.shared.session"
 SHARED_STREAM_METADATA_FIELD = "metadata.shared.stream"
@@ -217,12 +220,12 @@ CORE_JSONRPC_METHODS: tuple[str, ...] = (
     "message/stream",
     "tasks/get",
     "tasks/cancel",
-    "tasks/resubscribe",
+    TASKS_RESUBSCRIBE_METHOD,
 )
 CORE_HTTP_ENDPOINTS: tuple[str, ...] = (
     "/v1/message:send",
     "/v1/message:stream",
-    "/v1/tasks/{id}:subscribe",
+    TASKS_SUBSCRIBE_HTTP_ENDPOINT,
 )
 WIRE_CONTRACT_UNSUPPORTED_METHOD_DATA_FIELDS: tuple[str, ...] = (
     "type",
@@ -284,6 +287,23 @@ def build_wire_contract_extension_params(
     runtime_profile: RuntimeProfile,
 ) -> dict[str, Any]:
     snapshot = build_capability_snapshot(runtime_profile=runtime_profile)
+    resubscribe_behavior = {
+        "scope": "service-level",
+        "jsonrpc_method": TASKS_RESUBSCRIBE_METHOD,
+        "http_endpoint": TASKS_SUBSCRIBE_HTTP_ENDPOINT,
+        "non_terminal_behavior": "stream_live_updates",
+        "terminal_behavior": "replay_once_then_close",
+        "notes": [
+            (
+                "tasks/resubscribe remains part of the core A2A method baseline, but this "
+                "deployment's terminal-task replay behavior is a service-level contract."
+            ),
+            (
+                "When the task is already terminal, this service replays one final task "
+                "snapshot and then closes the stream."
+            ),
+        ],
+    }
     return {
         "protocol_version": protocol_version,
         "preferred_transport": "HTTP+JSON",
@@ -308,6 +328,9 @@ def build_wire_contract_extension_params(
             "type": "METHOD_NOT_SUPPORTED",
             "data_fields": list(WIRE_CONTRACT_UNSUPPORTED_METHOD_DATA_FIELDS),
         },
+        "service_behaviors": {
+            TASKS_RESUBSCRIBE_METHOD: resubscribe_behavior,
+        },
     }
 
 
@@ -317,6 +340,23 @@ def build_compatibility_profile_params(
     runtime_profile: RuntimeProfile,
 ) -> dict[str, Any]:
     snapshot = build_capability_snapshot(runtime_profile=runtime_profile)
+    resubscribe_behavior = {
+        "scope": "service-level",
+        "jsonrpc_method": TASKS_RESUBSCRIBE_METHOD,
+        "http_endpoint": TASKS_SUBSCRIBE_HTTP_ENDPOINT,
+        "non_terminal_behavior": "stream_live_updates",
+        "terminal_behavior": "replay_once_then_close",
+        "notes": [
+            (
+                "tasks/resubscribe itself is part of the core interoperability baseline, but "
+                "the terminal replay-once policy is deployment-specific service behavior."
+            ),
+            (
+                "Consumers should not assume replay-once terminal delivery is guaranteed by "
+                "generic A2A runtimes unless it is declared explicitly."
+            ),
+        ],
+    }
 
     method_retention: dict[str, dict[str, Any]] = {
         method: {
@@ -388,6 +428,9 @@ def build_compatibility_profile_params(
             "jsonrpc_methods": list(CORE_JSONRPC_METHODS),
             "http_endpoints": list(CORE_HTTP_ENDPOINTS),
         },
+        "service_behaviors": {
+            TASKS_RESUBSCRIBE_METHOD: resubscribe_behavior,
+        },
         "extension_taxonomy": {
             "shared_extensions": [
                 SESSION_BINDING_EXTENSION_URI,
@@ -431,6 +474,10 @@ def build_compatibility_profile_params(
                 "Treat execution_environment fields as deployment-configured discovery "
                 "metadata rather than per-turn snapshots of temporary approvals or "
                 "runtime escalations."
+            ),
+            (
+                "Treat this service's terminal tasks/resubscribe replay-once behavior as a "
+                "declared service-level contract rather than a generic A2A baseline promise."
             ),
         ],
     }

--- a/src/codex_a2a_server/http_middlewares.py
+++ b/src/codex_a2a_server/http_middlewares.py
@@ -1,0 +1,299 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import secrets
+import time
+from urllib.parse import unquote
+
+from a2a.server.tasks.task_store import TaskStore
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from starlette.responses import StreamingResponse
+
+from .config import Settings
+from .logging_context import (
+    CORRELATION_ID_HEADER,
+    reset_correlation_id,
+    resolve_correlation_id,
+    set_correlation_id,
+)
+
+logger = logging.getLogger(__name__)
+
+_PUBLIC_AGENT_CARD_PATHS = {
+    "/.well-known/agent-card.json",
+    "/.well-known/agent.json",
+}
+_REST_MESSAGE_PATHS = {
+    "/v1/message:send",
+    "/v1/message:stream",
+}
+
+
+def _parse_json_body(body_bytes: bytes) -> dict | None:
+    try:
+        payload = json.loads(body_bytes.decode("utf-8", errors="replace"))
+    except Exception:
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _detect_codex_extension_method(payload: dict | None) -> str | None:
+    if payload is None:
+        return None
+    method = payload.get("method")
+    if not isinstance(method, str):
+        return None
+    if method.startswith("codex."):
+        return method
+    return None
+
+
+def _parse_content_length(value: str | None) -> int | None:
+    if value is None:
+        return None
+    try:
+        parsed = int(value)
+    except ValueError:
+        return None
+    return parsed if parsed >= 0 else None
+
+
+def _normalize_content_type(value: str | None) -> str:
+    if not value:
+        return ""
+    return value.split(";", 1)[0].strip().lower()
+
+
+def _is_json_content_type(content_type: str) -> bool:
+    if not content_type:
+        return False
+    return content_type == "application/json" or content_type.endswith("+json")
+
+
+def _decode_payload_preview(body: bytes, *, limit: int) -> str:
+    text = body.decode("utf-8", errors="replace")
+    if limit > 0 and len(text) > limit:
+        return f"{text[:limit]}...[truncated]"
+    return text
+
+
+async def _get_request_body(request: Request) -> bytes:
+    body = await request.body()
+    request._body = body  # allow downstream to read again
+    return body
+
+
+def _looks_like_jsonrpc_message_payload(payload: dict | None) -> bool:
+    if payload is None:
+        return False
+    message = payload.get("message")
+    if not isinstance(message, dict):
+        return False
+    if "parts" in message:
+        return True
+    role = message.get("role")
+    return isinstance(role, str) and role in {"user", "agent"}
+
+
+def _looks_like_jsonrpc_envelope(payload: dict | None) -> bool:
+    if payload is None:
+        return False
+    method = payload.get("method")
+    version = payload.get("jsonrpc")
+    return isinstance(method, str) and isinstance(version, str)
+
+
+def install_http_middlewares(
+    app: FastAPI,
+    *,
+    settings: Settings,
+    task_store: TaskStore,
+) -> None:
+    def _unauthorized_response() -> JSONResponse:
+        return JSONResponse(
+            {"error": "Unauthorized"},
+            status_code=401,
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    @app.middleware("http")
+    async def guard_rest_payload_shape(request: Request, call_next):
+        if request.method != "POST" or request.url.path not in _REST_MESSAGE_PATHS:
+            return await call_next(request)
+
+        body = await _get_request_body(request)
+        payload = _parse_json_body(body)
+        if _looks_like_jsonrpc_envelope(payload) or _looks_like_jsonrpc_message_payload(payload):
+            return JSONResponse(
+                {
+                    "error": (
+                        "Invalid HTTP+JSON payload for REST endpoint. "
+                        "Use message.content with ROLE_* role values, or call "
+                        "POST / with method=message/send or method=message/stream."
+                    )
+                },
+                status_code=400,
+            )
+        return await call_next(request)
+
+    @app.middleware("http")
+    async def guard_missing_subscribe_task(request: Request, call_next):
+        path = request.url.path
+        if not path.startswith("/v1/tasks/") or not path.endswith(":subscribe"):
+            return await call_next(request)
+
+        encoded_task_id = path.removeprefix("/v1/tasks/").removesuffix(":subscribe")
+        task_id = unquote(encoded_task_id).strip()
+        if not task_id:
+            return JSONResponse({"error": "Task not found"}, status_code=404)
+
+        task = await task_store.get(task_id)
+        if task is None:
+            return JSONResponse({"error": "Task not found", "task_id": task_id}, status_code=404)
+        return await call_next(request)
+
+    @app.middleware("http")
+    async def log_payloads(request: Request, call_next):
+        if not settings.a2a_log_payloads:
+            return await call_next(request)
+
+        path = request.url.path
+        limit = settings.a2a_log_body_limit
+        content_type = _normalize_content_type(request.headers.get("content-type"))
+        content_length = _parse_content_length(request.headers.get("content-length"))
+
+        sensitive_method: str | None = None
+        request_omit_reason: str | None = None
+
+        if not _is_json_content_type(content_type):
+            request_omit_reason = f"non-json content-type={content_type or 'unknown'}"
+        elif limit > 0 and content_length is None:
+            request_omit_reason = f"missing content-length with limit={limit}"
+        elif limit > 0 and content_length is not None and content_length > limit:
+            request_omit_reason = f"content-length={content_length} exceeds limit={limit}"
+        else:
+            body = await _get_request_body(request)
+            payload = _parse_json_body(body)
+            sensitive_method = _detect_codex_extension_method(payload)
+
+            if sensitive_method:
+                logger.debug("A2A request %s %s method=%s", request.method, path, sensitive_method)
+            else:
+                logger.debug(
+                    "A2A request %s %s body=%s",
+                    request.method,
+                    path,
+                    _decode_payload_preview(body, limit=limit),
+                )
+
+        if request_omit_reason:
+            logger.debug(
+                "A2A request %s %s body=[omitted %s]",
+                request.method,
+                path,
+                request_omit_reason,
+            )
+
+        response = await call_next(request)
+        if isinstance(response, StreamingResponse):
+            status_code = getattr(response, "status_code", 200)
+            if request_omit_reason:
+                logger.debug(
+                    "A2A response %s status=%s body=[omitted request_%s]",
+                    path,
+                    status_code,
+                    request_omit_reason,
+                )
+            elif sensitive_method:
+                logger.debug("A2A response %s streaming method=%s", path, sensitive_method)
+            else:
+                logger.debug("A2A response %s streaming", path)
+            return response
+
+        response_body = getattr(response, "body", b"") or b""
+        if sensitive_method:
+            logger.debug(
+                "A2A response %s status=%s bytes=%s method=%s",
+                path,
+                response.status_code,
+                len(response_body),
+                sensitive_method,
+            )
+            return response
+
+        if request_omit_reason:
+            logger.debug(
+                "A2A response %s status=%s bytes=%s body=[omitted request_%s]",
+                path,
+                response.status_code,
+                len(response_body),
+                request_omit_reason,
+            )
+            return response
+
+        response_content_type = _normalize_content_type(response.headers.get("content-type"))
+        if not _is_json_content_type(response_content_type):
+            logger.debug(
+                "A2A response %s status=%s bytes=%s body=[omitted non-json content-type=%s]",
+                path,
+                response.status_code,
+                len(response_body),
+                response_content_type or "unknown",
+            )
+            return response
+
+        logger.debug(
+            "A2A response %s status=%s body=%s",
+            path,
+            response.status_code,
+            _decode_payload_preview(response_body, limit=limit),
+        )
+        return response
+
+    @app.middleware("http")
+    async def bearer_auth(request: Request, call_next):
+        if request.method == "OPTIONS" or request.url.path in _PUBLIC_AGENT_CARD_PATHS:
+            return await call_next(request)
+
+        auth_header = request.headers.get("authorization", "")
+        if not auth_header.lower().startswith("bearer "):
+            return _unauthorized_response()
+        provided = auth_header.split(" ", 1)[1].strip()
+        if not secrets.compare_digest(provided, settings.a2a_bearer_token):
+            return _unauthorized_response()
+        request.state.user_identity = f"bearer:{hashlib.sha256(provided.encode()).hexdigest()[:12]}"
+
+        return await call_next(request)
+
+    @app.middleware("http")
+    async def correlation_id_middleware(request: Request, call_next):
+        correlation_id = resolve_correlation_id(request.headers.get("x-request-id"))
+        request.state.correlation_id = correlation_id
+        token = set_correlation_id(correlation_id)
+        started_at = time.perf_counter()
+        path = request.url.path
+        logger.info("A2A request started method=%s path=%s", request.method, path)
+        try:
+            response = await call_next(request)
+            response.headers[CORRELATION_ID_HEADER] = correlation_id
+            logger.info(
+                "A2A request completed method=%s path=%s status=%s duration_ms=%.2f",
+                request.method,
+                path,
+                response.status_code,
+                (time.perf_counter() - started_at) * 1000.0,
+            )
+            return response
+        except Exception:
+            logger.exception(
+                "A2A request failed method=%s path=%s duration_ms=%.2f",
+                request.method,
+                path,
+                (time.perf_counter() - started_at) * 1000.0,
+            )
+            raise
+        finally:
+            reset_correlation_id(token)

--- a/tests/test_agent_card.py
+++ b/tests/test_agent_card.py
@@ -220,6 +220,23 @@ def test_agent_card_injects_profile_into_extensions() -> None:
         "tasks/cancel",
         "tasks/resubscribe",
     ]
+    assert compatibility.params["service_behaviors"]["tasks/resubscribe"] == {
+        "scope": "service-level",
+        "jsonrpc_method": "tasks/resubscribe",
+        "http_endpoint": "/v1/tasks/{id}:subscribe",
+        "non_terminal_behavior": "stream_live_updates",
+        "terminal_behavior": "replay_once_then_close",
+        "notes": [
+            (
+                "tasks/resubscribe itself is part of the core interoperability baseline, but "
+                "the terminal replay-once policy is deployment-specific service behavior."
+            ),
+            (
+                "Consumers should not assume replay-once terminal delivery is guaranteed by "
+                "generic A2A runtimes unless it is declared explicitly."
+            ),
+        ],
+    }
     assert compatibility.params["extension_taxonomy"]["shared_extensions"] == [
         "urn:a2a:session-binding/v1",
         "urn:a2a:stream-hints/v1",
@@ -240,6 +257,23 @@ def test_agent_card_injects_profile_into_extensions() -> None:
         "tasks/cancel",
         "tasks/resubscribe",
     ]
+    assert wire_contract.params["service_behaviors"]["tasks/resubscribe"] == {
+        "scope": "service-level",
+        "jsonrpc_method": "tasks/resubscribe",
+        "http_endpoint": "/v1/tasks/{id}:subscribe",
+        "non_terminal_behavior": "stream_live_updates",
+        "terminal_behavior": "replay_once_then_close",
+        "notes": [
+            (
+                "tasks/resubscribe remains part of the core A2A method baseline, but this "
+                "deployment's terminal-task replay behavior is a service-level contract."
+            ),
+            (
+                "When the task is already terminal, this service replays one final task "
+                "snapshot and then closes the stream."
+            ),
+        ],
+    }
     assert "codex.sessions.shell" in wire_contract.params["all_jsonrpc_methods"]
     assert wire_contract.params["unsupported_method_error"]["code"] == -32601
     assert wire_contract.params["unsupported_method_error"]["data_fields"] == [
@@ -255,6 +289,10 @@ def test_agent_card_injects_profile_into_extensions() -> None:
     assert any("urn:a2a:*" in note for note in compatibility.params["consumer_guidance"])
     assert any(
         "execution_environment" in note for note in compatibility.params["consumer_guidance"]
+    )
+    assert any(
+        "terminal tasks/resubscribe replay-once behavior" in note
+        for note in compatibility.params["consumer_guidance"]
     )
     shell_policy = compatibility.params["method_retention"]["codex.sessions.shell"]
     assert shell_policy["availability"] == "enabled"

--- a/tests/test_codex_session_extension.py
+++ b/tests/test_codex_session_extension.py
@@ -535,7 +535,7 @@ async def test_session_query_extension_does_not_log_response_bodies(monkeypatch,
     import codex_a2a_server.app as app_module
 
     monkeypatch.setattr(app_module, "CodexClient", DummyCodexClient)
-    caplog.set_level(logging.DEBUG, logger="codex_a2a_server.app")
+    caplog.set_level(logging.DEBUG, logger="codex_a2a_server.http_middlewares")
 
     app = app_module.create_app(
         make_settings(a2a_bearer_token="t-1", a2a_log_payloads=True, **_BASE_SETTINGS)

--- a/tests/test_extension_contract_consistency.py
+++ b/tests/test_extension_contract_consistency.py
@@ -288,6 +288,21 @@ def test_guide_mentions_declared_streaming_contract_fields() -> None:
         )
 
 
+def test_guide_mentions_resubscribe_service_level_behavior() -> None:
+    guide_text = Path("docs/guide.md").read_text()
+    compatibility_text = Path("docs/compatibility.md").read_text()
+    wire_contract = build_wire_contract_extension_params(
+        protocol_version="0.3.0",
+        runtime_profile=build_runtime_profile(make_settings(a2a_bearer_token="test-token")),
+    )
+    assert "tasks/resubscribe" in wire_contract["service_behaviors"]
+
+    assert "replay-once" in guide_text
+    assert "one final task snapshot" in guide_text
+    assert "service-level" in guide_text
+    assert "terminal `tasks/resubscribe` replay-once behavior" in compatibility_text
+
+
 def test_guide_environment_variables_match_settings_aliases() -> None:
     import re
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -40,7 +40,6 @@ def test_settings_parse_ops_flags_and_timeouts():
         "A2A_ENABLE_HEALTH_ENDPOINT": "false",
         "A2A_ENABLE_SESSION_SHELL": "false",
         "A2A_CANCEL_ABORT_TIMEOUT_SECONDS": "0.25",
-        "A2A_STREAM_SSE_PING_SECONDS": "8",
         "A2A_STREAM_IDLE_DIAGNOSTIC_SECONDS": "45",
         "A2A_INTERRUPT_REQUEST_TTL_SECONDS": "90",
     }
@@ -49,7 +48,6 @@ def test_settings_parse_ops_flags_and_timeouts():
         assert settings.a2a_enable_health_endpoint is False
         assert settings.a2a_enable_session_shell is False
         assert settings.a2a_cancel_abort_timeout_seconds == 0.25
-        assert settings.a2a_stream_sse_ping_seconds == 8
         assert settings.a2a_stream_idle_diagnostic_seconds == 45
         assert settings.a2a_interrupt_request_ttl_seconds == 90
 
@@ -101,28 +99,6 @@ def test_settings_reject_invalid_interrupt_request_ttl():
         with pytest.raises(ValidationError) as excinfo:
             Settings()
     assert "A2A_INTERRUPT_REQUEST_TTL_SECONDS" in str(excinfo.value)
-
-
-def test_settings_reject_invalid_stream_ping_seconds():
-    env = {
-        "A2A_BEARER_TOKEN": "test",
-        "A2A_STREAM_SSE_PING_SECONDS": "0",
-    }
-    with mock.patch.dict(os.environ, env, clear=True):
-        with pytest.raises(ValidationError) as excinfo:
-            Settings()
-    assert "A2A_STREAM_SSE_PING_SECONDS" in str(excinfo.value)
-
-
-def test_settings_reject_non_integer_stream_ping_seconds():
-    env = {
-        "A2A_BEARER_TOKEN": "test",
-        "A2A_STREAM_SSE_PING_SECONDS": "8.5",
-    }
-    with mock.patch.dict(os.environ, env, clear=True):
-        with pytest.raises(ValidationError) as excinfo:
-            Settings()
-    assert "A2A_STREAM_SSE_PING_SECONDS" in str(excinfo.value)
 
 
 def test_settings_reject_invalid_stream_idle_diagnostic_seconds():

--- a/tests/test_transport_contract.py
+++ b/tests/test_transport_contract.py
@@ -6,10 +6,12 @@ from unittest.mock import MagicMock
 
 import httpx
 import pytest
+from a2a.server.apps.rest.rest_adapter import RESTAdapter
 from a2a.types import TransportProtocol
+from sse_starlette.sse import EventSourceResponse
 from starlette.requests import Request
 
-from codex_a2a_server.app import _build_sse_streaming_route, build_agent_card, create_app
+from codex_a2a_server.app import build_agent_card, create_app
 from tests.helpers import DummyChatCodexClient, make_settings
 
 
@@ -67,7 +69,8 @@ def test_create_app_resets_sse_app_status() -> None:
 
 
 @pytest.mark.asyncio
-async def test_streaming_route_uses_configured_sse_ping_interval() -> None:
+async def test_streaming_route_uses_sdk_default_sse_keepalive() -> None:
+    settings = make_settings(a2a_bearer_token="test-token")
     context_builder = MagicMock()
     context_builder.build.return_value = MagicMock()
 
@@ -94,14 +97,14 @@ async def test_streaming_route_uses_configured_sse_ping_interval() -> None:
         async for item in _empty_async_stream():
             yield item
 
-    route = _build_sse_streaming_route(
-        method=stream_method,
+    adapter = RESTAdapter(
+        agent_card=build_agent_card(settings),
+        http_handler=MagicMock(),
         context_builder=context_builder,
-        sse_ping_seconds=8,
     )
-    response = await route(request)
+    response = await adapter._handle_streaming_request(stream_method, request)
 
-    assert response.ping_interval == 8
+    assert response.ping_interval == EventSourceResponse.DEFAULT_PING_INTERVAL
 
 
 def test_create_app_propagates_stream_idle_diagnostic_setting(monkeypatch) -> None:
@@ -494,7 +497,7 @@ async def test_log_payloads_keeps_body_for_rest_handler(monkeypatch, caplog) -> 
     transport = httpx.ASGITransport(app=app)
     headers = {"Authorization": "Bearer test-token"}
 
-    with caplog.at_level(logging.DEBUG, logger="codex_a2a_server.app"):
+    with caplog.at_level(logging.DEBUG, logger="codex_a2a_server.http_middlewares"):
         async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
             resp = await client.post(
                 "/v1/message:send",
@@ -518,7 +521,7 @@ async def test_log_payloads_streaming_response_path(monkeypatch, caplog) -> None
     transport = httpx.ASGITransport(app=app)
     headers = {"Authorization": "Bearer test-token"}
 
-    with caplog.at_level(logging.DEBUG, logger="codex_a2a_server.app"):
+    with caplog.at_level(logging.DEBUG, logger="codex_a2a_server.http_middlewares"):
         async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
             async with client.stream(
                 "POST", "/v1/message:stream", headers=headers, json=_rest_message_payload()
@@ -548,7 +551,7 @@ async def test_log_payloads_omits_non_json_request_body(monkeypatch, caplog) -> 
         "Content-Type": "application/octet-stream",
     }
 
-    with caplog.at_level(logging.DEBUG, logger="codex_a2a_server.app"):
+    with caplog.at_level(logging.DEBUG, logger="codex_a2a_server.http_middlewares"):
         async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
             resp = await client.post("/", headers=headers, content=b"\x00\x01\x02\x03")
             assert resp.status_code < 500
@@ -576,7 +579,7 @@ async def test_log_payloads_omits_text_plain_request_body(monkeypatch, caplog) -
         '{"messageId":"m","role":"user","parts":[{"kind":"text","text":"secret"}]}}}'
     )
 
-    with caplog.at_level(logging.DEBUG, logger="codex_a2a_server.app"):
+    with caplog.at_level(logging.DEBUG, logger="codex_a2a_server.http_middlewares"):
         async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
             resp = await client.post("/", headers=headers, content=body)
             assert resp.status_code < 500
@@ -613,7 +616,7 @@ async def test_log_payloads_omits_when_content_length_missing(monkeypatch, caplo
     async def _body_stream():
         yield body
 
-    with caplog.at_level(logging.DEBUG, logger="codex_a2a_server.app"):
+    with caplog.at_level(logging.DEBUG, logger="codex_a2a_server.http_middlewares"):
         async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
             resp = await client.post(
                 "/",
@@ -649,7 +652,7 @@ async def test_log_payloads_omits_oversized_request_body(monkeypatch, caplog) ->
     headers = {"Authorization": "Bearer test-token"}
     oversized_text = "x" * 512
 
-    with caplog.at_level(logging.DEBUG, logger="codex_a2a_server.app"):
+    with caplog.at_level(logging.DEBUG, logger="codex_a2a_server.http_middlewares"):
         async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
             resp = await client.post(
                 "/",
@@ -694,7 +697,7 @@ async def test_request_logs_reuse_supplied_correlation_id(monkeypatch, caplog) -
         for record in caplog.records
         if record.name
         in {
-            "codex_a2a_server.app",
+            "codex_a2a_server.http_middlewares",
             "codex_a2a_server.request_handler",
             "codex_a2a_server.agent",
         }
@@ -743,7 +746,7 @@ async def test_request_logs_generate_correlation_id_for_stream_requests(
         for record in caplog.records
         if record.name
         in {
-            "codex_a2a_server.app",
+            "codex_a2a_server.http_middlewares",
             "codex_a2a_server.request_handler",
             "codex_a2a_server.streaming",
             "codex_a2a_server.agent",


### PR DESCRIPTION
## 概要

本 PR 聚焦 `#132` 当前已经推进的协议层收敛项，不关闭母单；重点是把 transport/app 装配进一步向 `a2a-sdk` 现有实现收敛，并把已存在的服务级行为声明补齐到机器可读 contract 与文档。

## 模块一：App 装配与 transport 收敛

- `create_app()` 改为显式创建共享 `A2AFastAPI`，再分别挂载 JSON-RPC 与 REST 路由，减少主流程里的手工拼装逻辑。
- 删除本地 REST SSE wrapper，REST streaming 直接复用 `a2a-sdk` / `sse-starlette` 默认 keepalive 行为。
- 新增 `src/codex_a2a_server/http_middlewares.py`，把 REST payload guard、subscribe task guard、payload logging、bearer auth、correlation id middleware 从 `create_app()` 中抽离。
- middleware 模块不再保留历史 logger 兼容名，直接使用模块自身 logger `codex_a2a_server.http_middlewares`。

## 模块二：服务级 contract 收敛

- 将 terminal `tasks/resubscribe` replay-once 行为明确声明为 service-level behavior，而不是泛化为 A2A baseline 保证。
- 在 `wire_contract` 与 `compatibility_profile` 中同步发布 `service_behaviors.tasks/resubscribe`。
- 在 AgentCard 描述中补充该部署级行为说明。

## 模块三：配置、文档与测试同步

- 删除 `A2A_STREAM_SSE_PING_SECONDS` 配置与对应校验，避免保留已经不再使用的本地 transport 配置面。
- 更新 `docs/guide.md` 与 `docs/compatibility.md`，说明 SDK 默认 SSE keepalive 与 `tasks/resubscribe` 的 service-level contract 边界。
- 更新相关测试，覆盖：
  - SDK 默认 SSE keepalive 行为
  - `service_behaviors.tasks/resubscribe` 声明
  - middleware 新 logger 名称
  - 移除 SSE ping 配置后的 settings 行为

## 验证

- `uv run pytest --no-cov tests/test_transport_contract.py tests/test_codex_session_extension.py`
- `bash ./scripts/validate_baseline.sh`

基线脚本末尾仍会输出若干 `curl: (7) Failed to connect ...`，但脚本退出码为 `0`，与仓库当前基线行为一致。

## 关联

- Relates to #132
- Relates to #121
- Relates to #98
- 后续剩余项跟踪：#133、#134、#135、#136
