### PR TITLE
ops: upgrade workflows to node24-compatible actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,15 +15,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
 
@@ -42,15 +42,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,11 @@ on:
     tags:
       - "v*"
   workflow_dispatch:
+    inputs:
+      tag_name:
+        description: "Existing tag to publish"
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -16,19 +21,26 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag_name || github.ref_name }}
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
+
+      - name: Resolve release tag
+        id: release_tag
+        run: echo "tag=${RELEASE_TAG}" >> "$GITHUB_OUTPUT"
+        env:
+          RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag_name || github.ref_name }}
 
       - name: Build package artifacts
         run: uv build --no-sources
@@ -53,12 +65,13 @@ jobs:
 
           wheel = pathlib.Path(os.environ["WHEEL_PATH"]).name
           version = wheel.removeprefix("codex_a2a-").split("-py3", 1)[0]
-          tag = os.environ["GITHUB_REF_NAME"].removeprefix("v")
+          tag = os.environ["RELEASE_TAG"].removeprefix("v")
           if version != tag:
               raise SystemExit(f"Wheel version {version!r} does not match tag {tag!r}")
           print(f"Validated release version: {version}")
           PY
         env:
+          RELEASE_TAG: ${{ steps.release_tag.outputs.tag }}
           WHEEL_PATH: ${{ steps.wheel.outputs.wheel_path }}
 
       - name: Smoke test wheel install
@@ -70,9 +83,12 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          generate_release_notes: true
-          files: |
-            dist/*.tar.gz
-            dist/*.whl
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.release_tag.outputs.tag }}
+        run: |
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            gh release upload "$RELEASE_TAG" dist/*.tar.gz dist/*.whl --clobber
+          else
+            gh release create "$RELEASE_TAG" dist/*.tar.gz dist/*.whl --generate-notes --verify-tag
+          fi


### PR DESCRIPTION
## 背景

本 PR 对应 `#156`，目标是消除仓库当前 workflow 中实际存在的 Node 20 action runtime，避免后续受 GitHub Actions runner 默认 Node 24 切换影响。

相关提交：
- `7fb6df1` `ops: upgrade workflows to node24-compatible actions (#156)`

## CI Workflow

- 升级 `actions/checkout@v4 -> @v5`
- 升级 `actions/setup-python@v5 -> @v6`
- 升级 `astral-sh/setup-uv@v4 -> @v7`
- 保持现有 baseline / runtime matrix 执行路径不变，仅做 Node 24 兼容 action major 升级

## Publish Workflow

- 同步升级 `checkout` / `setup-python` / `setup-uv` 到 Node 24 兼容 major
- 删除仍基于 Node 20 的 `softprops/action-gh-release@v2`
- 改为使用 `gh release` CLI 完成 release 创建 / 资产上传，避免继续依赖 Node 20 JS action
- 为 `workflow_dispatch` 增加必填 `tag_name` 输入，并统一用解析后的 release tag 做 checkout、wheel 版本校验和 release 创建

## 范围说明

- `pypa/gh-action-pypi-publish@release/v1` 当前是 composite action，不属于这次 Node 20 runtime 升级问题的核心对象，因此本轮未改
- `softprops/action-gh-release@v2` 虽然不在 issue 原正文列举范围内，但它同样是 `publish.yml` 中实际存在的 Node 20 action，因此纳入本次一起收口

## 验证

- `bash ./scripts/validate_baseline.sh`
- 结果：`283 passed`，coverage `80.28%`

## Issue 关联

Closes #156
