### PR TITLE
docs clarify alpha contract surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@
 auth, streaming, session continuity, interrupt handling, a built-in
 outbound A2A client, and a clear deployment boundary.
 
+This repository currently ships as an alpha project. Within that alpha line,
+the intended stable interoperability surface is the declared A2A core method
+set plus the machine-readable extension contracts published through Agent Card
+and OpenAPI metadata.
+
 ## What This Is
 
 - An A2A adapter service for the local Codex runtime, with inbound runtime

--- a/src/codex_a2a/server/agent_card.py
+++ b/src/codex_a2a/server/agent_card.py
@@ -41,6 +41,11 @@ def _build_agent_card_description(settings: Settings, runtime_profile: RuntimePr
     )
     parts: list[str] = [base, summary]
     parts.append(
+        "This repository currently ships as an alpha project; treat the declared "
+        "machine-readable A2A contract surfaces as compatibility-sensitive rather "
+        "than the full internal implementation."
+    )
+    parts.append(
         "Within one codex-a2a instance, all consumers share the same "
         "underlying Codex workspace/environment."
     )

--- a/tests/server/test_agent_card.py
+++ b/tests/server/test_agent_card.py
@@ -20,6 +20,8 @@ def test_agent_card_description_reflects_actual_transport_capabilities() -> None
     assert "tasks/get, tasks/cancel" in card.description
     assert "machine-readable wire contract" in card.description
     assert "machine-readable compatibility profile" in card.description
+    assert "alpha project" in card.description
+    assert "compatibility-sensitive" in card.description
     assert "all consumers share the same underlying Codex workspace/environment" in card.description
     assert "single-tenant, self-hosted coding workflows" in card.description
 


### PR DESCRIPTION
## 背景
`#121` 当前剩余的有效缺口，主要是公开信号层面对外没有足够明确地说明两件事：
- 仓库当前仍处于 alpha 阶段
- 当前应被视为稳定互操作承诺的 surface，是已声明的 A2A core methods 与 machine-readable extension contracts，而不是全部内部实现细节

本 PR 只收敛这一个残余缺口，不改动 runtime profile、wire contract 或其它 machine-readable contract 的结构。

## 模块变更
### README
- 在仓库首页概览中补充 alpha 状态说明
- 明确当前 intended stable interoperability surface 的边界，避免概览页对外信号过宽

### Server / Agent Card
- 在 Agent Card description 中补充同样的 contract 边界说明
- 让 machine-readable 发现面与 README 概览文案保持一致，减少外部集成方误读

### Tests
- 为 Agent Card description 补充断言
- 防止后续调整文案时再次丢失 alpha / compatibility-sensitive 信号

## PR 审查结论
- 本 PR 的实现方式合理，范围控制得当
- 改动没有偏离 `#121` 想解决的问题，也没有引入新的 contract 语义
- `Closes #121` 是准确的：在本 PR 合并后，`#121` 里仍有价值的残余公开信号缺口已完成收口
- 不建议把 `#132`、`#143`、`#152`、`#98`、`#136` 等 issue 挂成 closes；它们虽然相关，但不是本 PR 直接解决的事项

## 关联问题
Closes #121

## 验证
- `bash ./scripts/validate_baseline.sh`
- GitHub Actions `quality-gate`
- GitHub Actions `runtime-matrix (3.11)`
- GitHub Actions `runtime-matrix (3.12)`
