### PR TITLE
enhance: Add interrupt request tombstones and persisted context

### DIFF
--- a/src/codex_a2a/config.py
+++ b/src/codex_a2a/config.py
@@ -6,7 +6,6 @@ from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 
 from codex_a2a import __version__
-from codex_a2a.client.auth import validate_basic_auth
 
 _SANDBOX_MODES = {
     "unknown",
@@ -350,6 +349,8 @@ class Settings(BaseSettings):
     def validate_a2a_client_basic_auth(cls, value: str | None) -> str | None:
         if value is None:
             return value
+        from codex_a2a.client.auth import validate_basic_auth
+
         validate_basic_auth(value)
         return value
 

--- a/src/codex_a2a/execution/executor.py
+++ b/src/codex_a2a/execution/executor.py
@@ -175,6 +175,14 @@ class CodexAgentExecutor(AgentExecutor):
             )
             session_lock = await self._session_runtime.get_session_lock(session_id)
             await session_lock.acquire()
+            bind_interrupt_context = getattr(self._client, "bind_interrupt_context", None)
+            if callable(bind_interrupt_context):
+                bind_interrupt_context(
+                    session_id=session_id,
+                    identity=identity,
+                    task_id=task_id,
+                    context_id=context_id,
+                )
             await event_queue.enqueue_event(
                 TaskStatusUpdateEvent(
                     task_id=task_id,
@@ -290,6 +298,9 @@ class CodexAgentExecutor(AgentExecutor):
                 stream_task.cancel()
                 with suppress(asyncio.CancelledError):
                     await stream_task
+            release_interrupt_context = getattr(self._client, "release_interrupt_context", None)
+            if callable(release_interrupt_context) and session_id:
+                release_interrupt_context(session_id=session_id)
             if session_lock and session_lock.locked():
                 session_lock.release()
             await self._session_runtime.untrack_running_request(

--- a/src/codex_a2a/server/runtime_state.py
+++ b/src/codex_a2a/server/runtime_state.py
@@ -15,6 +15,7 @@ from sqlalchemy import (
     and_,
     delete,
     insert,
+    inspect,
     select,
     update,
 )
@@ -25,7 +26,10 @@ from sqlalchemy.ext.asyncio import (
 )
 
 from codex_a2a.config import Settings
-from codex_a2a.upstream.interrupts import InterruptRequestBinding
+from codex_a2a.upstream.interrupts import (
+    INTERRUPT_REQUEST_TOMBSTONE_TTL_SECONDS,
+    InterruptRequestBinding,
+)
 
 from .database import build_database_engine
 
@@ -60,10 +64,23 @@ _PENDING_INTERRUPT_REQUESTS = Table(
     Column("request_id", String, primary_key=True),
     Column("interrupt_type", String, nullable=False),
     Column("session_id", String, nullable=False),
+    Column("identity", String, nullable=True),
+    Column("task_id", String, nullable=True),
+    Column("context_id", String, nullable=True),
     Column("created_at", Float, nullable=False),
+    Column("expires_at", Float, nullable=True),
+    Column("tombstone_expires_at", Float, nullable=True),
     Column("rpc_request_id", JSON, nullable=False),
     Column("params", JSON, nullable=False),
 )
+
+_INTERRUPT_REQUEST_SCHEMA_UPDATES = {
+    "identity": "TEXT",
+    "task_id": "TEXT",
+    "context_id": "TEXT",
+    "expires_at": "FLOAT",
+    "tombstone_expires_at": "FLOAT",
+}
 
 
 @dataclass(frozen=True, slots=True)
@@ -116,18 +133,26 @@ class InterruptRequestRepository(Protocol):
         request_id: str,
         interrupt_type: str,
         session_id: str,
+        identity: str | None,
+        task_id: str | None,
+        context_id: str | None,
         created_at: float,
+        expires_at: float,
         rpc_request_id: str | int,
         params: dict[str, Any],
     ) -> None: ...
 
-    async def delete_interrupt_request(self, *, request_id: str) -> None: ...
+    async def expire_interrupt_request(self, *, request_id: str) -> None: ...
 
-    async def load_interrupt_requests(
+    async def resolve_interrupt_request(
         self,
         *,
-        interrupt_request_ttl_seconds: int,
-    ) -> list[PersistedInterruptRequest]: ...
+        request_id: str,
+    ) -> tuple[str, PersistedInterruptRequest | None]: ...
+
+    async def delete_interrupt_request(self, *, request_id: str) -> None: ...
+
+    async def load_interrupt_requests(self) -> list[PersistedInterruptRequest]: ...
 
 
 @dataclass(slots=True)
@@ -142,9 +167,17 @@ async def _noop() -> None:
 
 
 class RuntimeStateStore:
-    def __init__(self, engine: AsyncEngine) -> None:
+    def __init__(
+        self,
+        engine: AsyncEngine,
+        *,
+        interrupt_request_tombstone_ttl_seconds: float = INTERRUPT_REQUEST_TOMBSTONE_TTL_SECONDS,
+    ) -> None:
         self._engine = engine
         self._session_maker = async_sessionmaker(self._engine, expire_on_commit=False)
+        self._interrupt_request_tombstone_ttl_seconds = float(
+            interrupt_request_tombstone_ttl_seconds
+        )
         self._initialized = False
 
     async def initialize(self) -> None:
@@ -152,6 +185,7 @@ class RuntimeStateStore:
             return
         async with self._engine.begin() as conn:
             await conn.run_sync(_STATE_METADATA.create_all)
+            await conn.run_sync(self._upgrade_interrupt_request_schema)
         self._initialized = True
 
     async def dispose(self) -> None:
@@ -165,10 +199,84 @@ class RuntimeStateStore:
     def _expires_at(*, ttl_seconds: int) -> float:
         return time.time() + float(ttl_seconds)
 
+    @staticmethod
+    def _upgrade_interrupt_request_schema(sync_conn: Any) -> None:
+        inspector = inspect(sync_conn)
+        existing_columns = {
+            column["name"] for column in inspector.get_columns(_PENDING_INTERRUPT_REQUESTS.name)
+        }
+        for column_name, sql_type in _INTERRUPT_REQUEST_SCHEMA_UPDATES.items():
+            if column_name in existing_columns:
+                continue
+            sync_conn.exec_driver_sql(
+                f"ALTER TABLE {_PENDING_INTERRUPT_REQUESTS.name} "
+                f"ADD COLUMN {column_name} {sql_type}"
+            )
+
+    def _interrupt_request_tombstone_expires_at(self, *, now: float) -> float | None:
+        ttl_seconds = self._interrupt_request_tombstone_ttl_seconds
+        if ttl_seconds <= 0:
+            return None
+        return now + ttl_seconds
+
     async def _purge_expired_pending_claims(self, session: AsyncSession) -> None:
         now = time.time()
         await session.execute(
             delete(_PENDING_SESSION_CLAIMS).where(_PENDING_SESSION_CLAIMS.c.expires_at <= now)
+        )
+
+    async def _purge_expired_interrupt_tombstones(
+        self, session: AsyncSession, *, now: float
+    ) -> None:
+        await session.execute(
+            delete(_PENDING_INTERRUPT_REQUESTS).where(
+                and_(
+                    _PENDING_INTERRUPT_REQUESTS.c.tombstone_expires_at.is_not(None),
+                    _PENDING_INTERRUPT_REQUESTS.c.tombstone_expires_at <= now,
+                )
+            )
+        )
+
+    async def _set_interrupt_request_tombstone(
+        self,
+        session: AsyncSession,
+        *,
+        request_id: str,
+        now: float,
+    ) -> None:
+        tombstone_expires_at = self._interrupt_request_tombstone_expires_at(now=now)
+        if tombstone_expires_at is None:
+            await session.execute(
+                delete(_PENDING_INTERRUPT_REQUESTS).where(
+                    _PENDING_INTERRUPT_REQUESTS.c.request_id == request_id
+                )
+            )
+            return
+        await session.execute(
+            update(_PENDING_INTERRUPT_REQUESTS)
+            .where(_PENDING_INTERRUPT_REQUESTS.c.request_id == request_id)
+            .values(tombstone_expires_at=tombstone_expires_at)
+        )
+
+    @staticmethod
+    def _persisted_interrupt_request_from_row(row: Any) -> PersistedInterruptRequest:
+        expires_at = row.get("expires_at")
+        if expires_at is None:
+            expires_at = row["created_at"]
+        return PersistedInterruptRequest(
+            request_id=row["request_id"],
+            binding=InterruptRequestBinding(
+                request_id=row["request_id"],
+                interrupt_type=row["interrupt_type"],
+                session_id=row["session_id"],
+                created_at=row["created_at"],
+                expires_at=expires_at,
+                identity=row.get("identity"),
+                task_id=row.get("task_id"),
+                context_id=row.get("context_id"),
+            ),
+            rpc_request_id=row["rpc_request_id"],
+            params=dict(row["params"]),
         )
 
     async def load_session_binding(self, *, identity: str, context_id: str) -> str | None:
@@ -322,7 +430,11 @@ class RuntimeStateStore:
         request_id: str,
         interrupt_type: str,
         session_id: str,
+        identity: str | None,
+        task_id: str | None,
+        context_id: str | None,
         created_at: float,
+        expires_at: float,
         rpc_request_id: str | int,
         params: dict[str, Any],
     ) -> None:
@@ -331,7 +443,12 @@ class RuntimeStateStore:
             "request_id": request_id,
             "interrupt_type": interrupt_type,
             "session_id": session_id,
+            "identity": identity,
+            "task_id": task_id,
+            "context_id": context_id,
             "created_at": created_at,
+            "expires_at": expires_at,
+            "tombstone_expires_at": None,
             "rpc_request_id": rpc_request_id,
             "params": params,
         }
@@ -350,6 +467,46 @@ class RuntimeStateStore:
                     .values(**values)
                 )
 
+    async def expire_interrupt_request(self, *, request_id: str) -> None:
+        await self._ensure_initialized()
+        now = time.time()
+        async with self._session_maker.begin() as session:
+            await self._purge_expired_interrupt_tombstones(session, now=now)
+            await self._set_interrupt_request_tombstone(session, request_id=request_id, now=now)
+
+    async def resolve_interrupt_request(
+        self,
+        *,
+        request_id: str,
+    ) -> tuple[str, PersistedInterruptRequest | None]:
+        await self._ensure_initialized()
+        now = time.time()
+        async with self._session_maker.begin() as session:
+            await self._purge_expired_interrupt_tombstones(session, now=now)
+            row = (
+                (
+                    await session.execute(
+                        select(_PENDING_INTERRUPT_REQUESTS).where(
+                            _PENDING_INTERRUPT_REQUESTS.c.request_id == request_id
+                        )
+                    )
+                )
+                .mappings()
+                .one_or_none()
+            )
+            if row is None:
+                return "missing", None
+            tombstone_expires_at = row.get("tombstone_expires_at")
+            if isinstance(tombstone_expires_at, (float, int)) and tombstone_expires_at > now:
+                return "expired", None
+            expires_at = row.get("expires_at")
+            if expires_at is None:
+                expires_at = row["created_at"]
+            if expires_at <= now:
+                await self._set_interrupt_request_tombstone(session, request_id=request_id, now=now)
+                return "expired", None
+            return "active", self._persisted_interrupt_request_from_row(row)
+
     async def delete_interrupt_request(self, *, request_id: str) -> None:
         await self._ensure_initialized()
         async with self._session_maker.begin() as session:
@@ -359,35 +516,30 @@ class RuntimeStateStore:
                 )
             )
 
-    async def load_interrupt_requests(
-        self,
-        *,
-        interrupt_request_ttl_seconds: int,
-    ) -> list[PersistedInterruptRequest]:
+    async def load_interrupt_requests(self) -> list[PersistedInterruptRequest]:
         await self._ensure_initialized()
-        cutoff = time.time() - float(interrupt_request_ttl_seconds)
+        now = time.time()
         async with self._session_maker.begin() as session:
-            await session.execute(
-                delete(_PENDING_INTERRUPT_REQUESTS).where(
-                    _PENDING_INTERRUPT_REQUESTS.c.created_at <= cutoff
-                )
-            )
+            await self._purge_expired_interrupt_tombstones(session, now=now)
             rows = (await session.execute(select(_PENDING_INTERRUPT_REQUESTS))).mappings().all()
 
-        return [
-            PersistedInterruptRequest(
-                request_id=row["request_id"],
-                binding=InterruptRequestBinding(
-                    request_id=row["request_id"],
-                    interrupt_type=row["interrupt_type"],
-                    session_id=row["session_id"],
-                    created_at=row["created_at"],
-                ),
-                rpc_request_id=row["rpc_request_id"],
-                params=dict(row["params"]),
-            )
-            for row in rows
-        ]
+            restored: list[PersistedInterruptRequest] = []
+            for row in rows:
+                tombstone_expires_at = row.get("tombstone_expires_at")
+                if isinstance(tombstone_expires_at, (float, int)) and tombstone_expires_at > now:
+                    continue
+                expires_at = row.get("expires_at")
+                if expires_at is None:
+                    expires_at = row["created_at"]
+                if expires_at <= now:
+                    await self._set_interrupt_request_tombstone(
+                        session,
+                        request_id=row["request_id"],
+                        now=now,
+                    )
+                    continue
+                restored.append(self._persisted_interrupt_request_from_row(row))
+            return restored
 
 
 def build_runtime_state_runtime(

--- a/src/codex_a2a/upstream/client.py
+++ b/src/codex_a2a/upstream/client.py
@@ -8,6 +8,7 @@ import os
 import shutil
 import time
 from collections.abc import AsyncIterator
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from codex_a2a import __version__
@@ -18,8 +19,10 @@ from codex_a2a.logging_context import (
     install_log_record_factory,
 )
 from codex_a2a.upstream.interrupts import (
+    INTERRUPT_REQUEST_TOMBSTONE_TTL_SECONDS,
     InterruptRequestBinding,
     InterruptRequestError,
+    InterruptRequestTombstone,
     _PendingInterruptRequest,
     build_codex_permission_interrupt_properties,
     build_codex_question_interrupt_properties,
@@ -59,6 +62,13 @@ _DEFAULT_CLIENT_TITLE = "Codex A2A"
 _EVENT_QUEUE_MAXSIZE = 2048
 
 
+@dataclass(frozen=True)
+class _InterruptExecutionContext:
+    identity: str | None
+    task_id: str | None
+    context_id: str | None
+
+
 class CodexClient:
     """Codex app-server client adapter (stdio JSON-RPC)."""
 
@@ -79,6 +89,7 @@ class CodexClient:
         self._default_model = settings.codex_model
         self._model_reasoning_effort = settings.codex_model_reasoning_effort
         self._interrupt_request_ttl_seconds = settings.a2a_interrupt_request_ttl_seconds
+        self._interrupt_request_tombstone_ttl_seconds = INTERRUPT_REQUEST_TOMBSTONE_TTL_SECONDS
         self._log_payloads = settings.a2a_log_payloads
         self._interrupt_request_store = interrupt_request_store
 
@@ -95,21 +106,97 @@ class CodexClient:
         self._next_request_id = 1
         self._pending_requests: dict[str, _PendingRpcRequest] = {}
         self._pending_server_requests: dict[str, _PendingInterruptRequest] = {}
+        self._expired_server_requests: dict[str, InterruptRequestTombstone] = {}
+        self._active_interrupt_contexts: dict[str, _InterruptExecutionContext] = {}
         self._event_subscribers: set[asyncio.Queue[dict[str, Any]]] = set()
         self._turn_trackers: dict[tuple[str, str], _TurnTracker] = {}
 
     async def restore_persisted_interrupt_requests(self) -> None:
         if self._interrupt_request_store is None:
             return
-        restored = await self._interrupt_request_store.load_interrupt_requests(
-            interrupt_request_ttl_seconds=self._interrupt_request_ttl_seconds
-        )
+        restored = await self._interrupt_request_store.load_interrupt_requests()
         for entry in restored:
             self._pending_server_requests[entry.request_id] = _PendingInterruptRequest(
                 binding=entry.binding,
                 rpc_request_id=entry.rpc_request_id,
                 params=entry.params,
             )
+
+    @staticmethod
+    def _optional_string(value: Any) -> str | None:
+        if not isinstance(value, str):
+            return None
+        normalized = value.strip()
+        return normalized or None
+
+    def bind_interrupt_context(
+        self,
+        *,
+        session_id: str,
+        identity: str | None,
+        task_id: str | None,
+        context_id: str | None,
+    ) -> None:
+        normalized_session_id = session_id.strip()
+        if not normalized_session_id:
+            return
+        self._active_interrupt_contexts[normalized_session_id] = _InterruptExecutionContext(
+            identity=self._optional_string(identity),
+            task_id=self._optional_string(task_id),
+            context_id=self._optional_string(context_id),
+        )
+
+    def release_interrupt_context(self, *, session_id: str) -> None:
+        normalized_session_id = session_id.strip()
+        if not normalized_session_id:
+            return
+        self._active_interrupt_contexts.pop(normalized_session_id, None)
+
+    def _resolve_interrupt_context(
+        self,
+        *,
+        session_id: str,
+        params: dict[str, Any],
+    ) -> _InterruptExecutionContext:
+        active_context = self._active_interrupt_contexts.get(session_id)
+        return _InterruptExecutionContext(
+            identity=(
+                self._optional_string(params.get("identity"))
+                or self._optional_string(params.get("userIdentity"))
+                or (active_context.identity if active_context is not None else None)
+            ),
+            task_id=(
+                self._optional_string(params.get("task_id"))
+                or self._optional_string(params.get("taskId"))
+                or (active_context.task_id if active_context is not None else None)
+            ),
+            context_id=(
+                self._optional_string(params.get("context_id"))
+                or self._optional_string(params.get("contextId"))
+                or (active_context.context_id if active_context is not None else None)
+            ),
+        )
+
+    def _purge_expired_interrupt_tombstones(self) -> None:
+        now = time.time()
+        expired = [
+            request_id
+            for request_id, tombstone in self._expired_server_requests.items()
+            if tombstone.expires_at <= now
+        ]
+        for request_id in expired:
+            self._expired_server_requests.pop(request_id, None)
+
+    def _remember_interrupt_tombstone(self, request_id: str) -> None:
+        ttl_seconds = self._interrupt_request_tombstone_ttl_seconds
+        self._pending_server_requests.pop(request_id, None)
+        if ttl_seconds <= 0:
+            self._expired_server_requests.pop(request_id, None)
+            return
+        self._expired_server_requests[request_id] = InterruptRequestTombstone(
+            request_id=request_id,
+            expires_at=time.time() + ttl_seconds,
+        )
 
     async def close(self) -> None:
         self._closed = True
@@ -605,24 +692,37 @@ class CodexClient:
             "execCommandApproval",
         }:
             session_id = str(params.get("threadId") or params.get("conversationId") or "").strip()
+            interrupt_context = self._resolve_interrupt_context(
+                session_id=session_id, params=params
+            )
             rpc_request_id = request_id if isinstance(request_id, str | int) else request_key
+            created_at = time.time()
             self._pending_server_requests[request_key] = _PendingInterruptRequest(
                 binding=InterruptRequestBinding(
                     request_id=request_key,
                     interrupt_type="permission",
                     session_id=session_id,
-                    created_at=time.time(),
+                    created_at=created_at,
+                    expires_at=created_at + float(self._interrupt_request_ttl_seconds),
+                    identity=interrupt_context.identity,
+                    task_id=interrupt_context.task_id,
+                    context_id=interrupt_context.context_id,
                 ),
                 rpc_request_id=rpc_request_id,
                 params=params,
             )
+            self._expired_server_requests.pop(request_key, None)
             if self._interrupt_request_store is not None:
                 binding = self._pending_server_requests[request_key].binding
                 await self._interrupt_request_store.save_interrupt_request(
                     request_id=request_key,
                     interrupt_type=binding.interrupt_type,
                     session_id=binding.session_id,
+                    identity=binding.identity,
+                    task_id=binding.task_id,
+                    context_id=binding.context_id,
                     created_at=binding.created_at,
+                    expires_at=binding.expires_at or binding.created_at,
                     rpc_request_id=rpc_request_id,
                     params=params,
                 )
@@ -641,24 +741,37 @@ class CodexClient:
 
         if method == "item/tool/requestUserInput":
             session_id = str(params.get("threadId") or params.get("conversationId") or "").strip()
+            interrupt_context = self._resolve_interrupt_context(
+                session_id=session_id, params=params
+            )
             rpc_request_id = request_id if isinstance(request_id, str | int) else request_key
+            created_at = time.time()
             self._pending_server_requests[request_key] = _PendingInterruptRequest(
                 binding=InterruptRequestBinding(
                     request_id=request_key,
                     interrupt_type="question",
                     session_id=session_id,
-                    created_at=time.time(),
+                    created_at=created_at,
+                    expires_at=created_at + float(self._interrupt_request_ttl_seconds),
+                    identity=interrupt_context.identity,
+                    task_id=interrupt_context.task_id,
+                    context_id=interrupt_context.context_id,
                 ),
                 rpc_request_id=rpc_request_id,
                 params=params,
             )
+            self._expired_server_requests.pop(request_key, None)
             if self._interrupt_request_store is not None:
                 binding = self._pending_server_requests[request_key].binding
                 await self._interrupt_request_store.save_interrupt_request(
                     request_id=request_key,
                     interrupt_type=binding.interrupt_type,
                     session_id=binding.session_id,
+                    identity=binding.identity,
+                    task_id=binding.task_id,
+                    context_id=binding.context_id,
                     created_at=binding.created_at,
+                    expires_at=binding.expires_at or binding.created_at,
                     rpc_request_id=rpc_request_id,
                     params=params,
                 )
@@ -958,18 +1071,44 @@ class CodexClient:
         self, request_id: str
     ) -> tuple[str, InterruptRequestBinding | None]:
         request_key = request_id.strip()
-        pending = self._pending_server_requests.get(request_key)
-        if pending is None:
+        if not request_key:
             return "missing", None
-        status = self._interrupt_request_status(pending.binding)
-        if status == "expired":
-            await self.discard_interrupt_request(request_key)
+        self._purge_expired_interrupt_tombstones()
+        pending = self._pending_server_requests.get(request_key)
+        if pending is not None:
+            status = self._interrupt_request_status(pending.binding)
+            if status == "expired":
+                self._remember_interrupt_tombstone(request_key)
+                if self._interrupt_request_store is not None:
+                    await self._interrupt_request_store.expire_interrupt_request(
+                        request_id=request_key
+                    )
+                return "expired", None
             return status, pending.binding
-        return status, pending.binding
+        if request_key in self._expired_server_requests:
+            return "expired", None
+        if self._interrupt_request_store is None:
+            return "missing", None
+        status, persisted = await self._interrupt_request_store.resolve_interrupt_request(
+            request_id=request_key
+        )
+        if status == "active" and persisted is not None:
+            pending = _PendingInterruptRequest(
+                binding=persisted.binding,
+                rpc_request_id=persisted.rpc_request_id,
+                params=persisted.params,
+            )
+            self._pending_server_requests[request_key] = pending
+            return "active", pending.binding
+        if status == "expired":
+            self._remember_interrupt_tombstone(request_key)
+            return "expired", None
+        return "missing", None
 
     async def discard_interrupt_request(self, request_id: str) -> None:
         request_key = request_id.strip()
         self._pending_server_requests.pop(request_key, None)
+        self._expired_server_requests.pop(request_key, None)
         if self._interrupt_request_store is not None:
             await self._interrupt_request_store.delete_interrupt_request(request_id=request_key)
 

--- a/src/codex_a2a/upstream/interrupts.py
+++ b/src/codex_a2a/upstream/interrupts.py
@@ -96,12 +96,25 @@ class InterruptRequestError(RuntimeError):
         self.actual_interrupt_type = actual_interrupt_type
 
 
+INTERRUPT_REQUEST_TOMBSTONE_TTL_SECONDS = 600.0
+
+
 @dataclass(frozen=True)
 class InterruptRequestBinding:
     request_id: str
     interrupt_type: str
     session_id: str
     created_at: float
+    expires_at: float | None = None
+    identity: str | None = None
+    task_id: str | None = None
+    context_id: str | None = None
+
+
+@dataclass(frozen=True)
+class InterruptRequestTombstone:
+    request_id: str
+    expires_at: float
 
 
 @dataclass
@@ -162,7 +175,9 @@ def interrupt_request_status(
     *,
     interrupt_request_ttl_seconds: int,
 ) -> str:
-    expires_at = binding.created_at + float(interrupt_request_ttl_seconds)
+    expires_at = binding.expires_at
+    if expires_at is None:
+        expires_at = binding.created_at + float(interrupt_request_ttl_seconds)
     if expires_at <= time.time():
         return "expired"
     return "active"

--- a/tests/jsonrpc/test_codex_session_extension.py
+++ b/tests/jsonrpc/test_codex_session_extension.py
@@ -1115,7 +1115,7 @@ async def test_interrupt_callback_extension_returns_expired_for_stale_request(mo
         payload = resp.json()
         assert payload["error"]["code"] == -32007
         assert payload["error"]["data"]["type"] == "INTERRUPT_REQUEST_EXPIRED"
-        assert (await dummy.resolve_interrupt_request("perm-expired"))[0] == "missing"
+        assert (await dummy.resolve_interrupt_request("perm-expired"))[0] == "expired"
 
 
 @pytest.mark.asyncio

--- a/tests/server/test_database_app_persistence.py
+++ b/tests/server/test_database_app_persistence.py
@@ -43,7 +43,7 @@ async def test_database_backend_persists_task_session_and_interrupt_state_across
             self.directory = settings.codex_workspace_root
             self.stream_timeout = None
             self._interrupt_request_store = interrupt_request_store
-            self._pending_request_ids: set[str] = set()
+            self._pending_requests: dict[str, object] = {}
 
         async def close(self) -> None:
             return None
@@ -54,10 +54,8 @@ async def test_database_backend_persists_task_session_and_interrupt_state_across
         async def restore_persisted_interrupt_requests(self) -> None:
             if self._interrupt_request_store is None:
                 return
-            restored = await self._interrupt_request_store.load_interrupt_requests(
-                interrupt_request_ttl_seconds=self.settings.a2a_interrupt_request_ttl_seconds
-            )
-            self._pending_request_ids = {entry.request_id for entry in restored}
+            restored = await self._interrupt_request_store.load_interrupt_requests()
+            self._pending_requests = {entry.request_id: entry.binding for entry in restored}
 
         async def create_session(
             self,
@@ -98,47 +96,55 @@ async def test_database_backend_persists_task_session_and_interrupt_state_across
             identity: str | None = None,
             ttl_seconds: float | None = None,
         ) -> None:
-            del ttl_seconds
             assert self._interrupt_request_store is not None
             from codex_a2a.upstream.interrupts import InterruptRequestBinding
 
+            created_at = time.time()
+            resolved_ttl_seconds = (
+                float(ttl_seconds)
+                if ttl_seconds is not None
+                else float(self.settings.a2a_interrupt_request_ttl_seconds)
+            )
             binding = InterruptRequestBinding(
                 request_id=request_id,
                 interrupt_type=interrupt_type,
                 session_id=session_id,
-                created_at=time.time(),
+                created_at=created_at,
+                expires_at=created_at + resolved_ttl_seconds,
+                identity=identity,
+                task_id=task_id,
+                context_id=context_id,
             )
             await self._interrupt_request_store.save_interrupt_request(
                 request_id=request_id,
                 interrupt_type=interrupt_type,
                 session_id=session_id,
+                identity=identity,
+                task_id=task_id,
+                context_id=context_id,
                 created_at=binding.created_at,
+                expires_at=binding.expires_at or binding.created_at,
                 rpc_request_id=request_id,
-                params={
-                    "task_id": task_id,
-                    "context_id": context_id,
-                    "identity": identity,
-                },
+                params={},
             )
-            self._pending_request_ids.add(request_id)
+            self._pending_requests[request_id] = binding
 
         async def resolve_interrupt_request(self, request_id: str):
-            if request_id not in self._pending_request_ids:
-                return "missing", None
-            from codex_a2a.upstream.interrupts import InterruptRequestBinding
-
-            return (
-                "active",
-                InterruptRequestBinding(
-                    request_id=request_id,
-                    interrupt_type="permission",
-                    session_id="ses-1",
-                    created_at=0.0,
-                ),
+            if self._interrupt_request_store is None:
+                binding = self._pending_requests.get(request_id)
+                if binding is None:
+                    return "missing", None
+                return "active", binding
+            status, persisted = await self._interrupt_request_store.resolve_interrupt_request(
+                request_id=request_id
             )
+            if status != "active" or persisted is None:
+                return status, None
+            self._pending_requests[request_id] = persisted.binding
+            return "active", persisted.binding
 
         async def discard_interrupt_request(self, request_id: str) -> None:
-            self._pending_request_ids.discard(request_id)
+            self._pending_requests.pop(request_id, None)
 
         async def permission_reply(
             self,
@@ -218,6 +224,15 @@ async def test_database_backend_persists_task_session_and_interrupt_state_across
         assert pending is False
         assert restored_session_id == "ses-1"
         assert PersistentStateDummyClient.created_sessions == 1
+        (
+            interrupt_status,
+            interrupt_binding,
+        ) = await app2.state.codex_client.resolve_interrupt_request("perm-1")
+        assert interrupt_status == "active"
+        assert interrupt_binding is not None
+        assert interrupt_binding.task_id == "task-1"
+        assert interrupt_binding.context_id == "ctx-1"
+        assert interrupt_binding.identity is None
 
         transport = httpx.ASGITransport(app=app2)
         async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:

--- a/tests/support/dummy_clients.py
+++ b/tests/support/dummy_clients.py
@@ -80,6 +80,7 @@ class DummySessionQueryCodexClient:
         self.question_reply_calls: list[dict[str, Any]] = []
         self.question_reject_calls: list[dict[str, Any]] = []
         self._interrupt_requests: dict[str, InterruptRequestBinding] = {}
+        self._expired_interrupt_requests: set[str] = set()
 
     async def close(self) -> None:
         return None
@@ -181,6 +182,7 @@ class DummySessionQueryCodexClient:
 
     async def discard_interrupt_request(self, request_id: str) -> None:
         self._interrupt_requests.pop(request_id, None)
+        self._expired_interrupt_requests.discard(request_id)
 
     def prime_interrupt_request(
         self,
@@ -189,22 +191,32 @@ class DummySessionQueryCodexClient:
         interrupt_type: str,
         session_id: str = "ses-1",
         created_at: float = 0.0,
+        identity: str | None = None,
+        task_id: str | None = None,
+        context_id: str | None = None,
     ) -> None:
         self._interrupt_requests[request_id] = InterruptRequestBinding(
             request_id=request_id,
             interrupt_type=interrupt_type,
             session_id=session_id,
             created_at=created_at,
+            identity=identity,
+            task_id=task_id,
+            context_id=context_id,
         )
+        self._expired_interrupt_requests.discard(request_id)
 
     async def resolve_interrupt_request(
         self,
         request_id: str,
     ) -> tuple[str, InterruptRequestBinding | None]:
+        if request_id in self._expired_interrupt_requests:
+            return "expired", None
         binding = self._interrupt_requests.get(request_id)
         if binding is None:
             return "missing", None
         if binding.created_at == 0.0:
             return "active", binding
         self._interrupt_requests.pop(request_id, None)
-        return "expired", binding
+        self._expired_interrupt_requests.add(request_id)
+        return "expired", None

--- a/tests/upstream/test_codex_client_params.py
+++ b/tests/upstream/test_codex_client_params.py
@@ -222,11 +222,17 @@ async def test_interrupt_request_status_uses_configured_ttl(monkeypatch) -> None
         params={"threadId": "thr-1"},
     )
 
+    monkeypatch.setattr("codex_a2a.upstream.client.time.time", lambda: 14.0)
     monkeypatch.setattr("codex_a2a.upstream.interrupts.time.time", lambda: 14.0)
     assert (await client.resolve_interrupt_request("req-1"))[0] == "active"
 
+    monkeypatch.setattr("codex_a2a.upstream.client.time.time", lambda: 15.0)
     monkeypatch.setattr("codex_a2a.upstream.interrupts.time.time", lambda: 15.0)
     assert (await client.resolve_interrupt_request("req-1"))[0] == "expired"
+    assert (await client.resolve_interrupt_request("req-1"))[0] == "expired"
+
+    monkeypatch.setattr("codex_a2a.upstream.client.time.time", lambda: 616.0)
+    monkeypatch.setattr("codex_a2a.upstream.interrupts.time.time", lambda: 616.0)
     assert (await client.resolve_interrupt_request("req-1"))[0] == "missing"
     assert "req-1" not in client._pending_server_requests
 

--- a/tests/upstream/test_interrupt_persistence.py
+++ b/tests/upstream/test_interrupt_persistence.py
@@ -20,6 +20,12 @@ async def test_interrupt_requests_restore_after_client_rebuild(tmp_path) -> None
     await runtime_state.startup()
     try:
         client_1 = CodexClient(settings, interrupt_request_store=runtime_state.state_store)
+        client_1.bind_interrupt_context(
+            session_id="thr-1",
+            identity="user-1",
+            task_id="task-1",
+            context_id="ctx-1",
+        )
         await client_1._handle_server_request(
             {
                 "id": 100,
@@ -46,6 +52,9 @@ async def test_interrupt_requests_restore_after_client_rebuild(tmp_path) -> None
     assert status == "active"
     assert binding is not None
     assert binding.session_id == "thr-1"
+    assert binding.identity == "user-1"
+    assert binding.task_id == "task-1"
+    assert binding.context_id == "ctx-1"
     assert missing_status == "missing"
     assert missing_binding is None
 
@@ -72,12 +81,24 @@ async def test_expired_interrupt_requests_are_not_restored(tmp_path, monkeypatch
         )
 
         monkeypatch.setattr("codex_a2a.server.runtime_state.time.time", lambda: 16.0)
+        monkeypatch.setattr("codex_a2a.upstream.client.time.time", lambda: 16.0)
         monkeypatch.setattr("codex_a2a.upstream.interrupts.time.time", lambda: 16.0)
         client_2 = CodexClient(settings, interrupt_request_store=runtime_state.state_store)
         await client_2.restore_persisted_interrupt_requests()
         status, binding = await client_2.resolve_interrupt_request("200")
+        repeated_status, repeated_binding = await client_2.resolve_interrupt_request("200")
+
+        monkeypatch.setattr("codex_a2a.server.runtime_state.time.time", lambda: 617.0)
+        monkeypatch.setattr("codex_a2a.upstream.client.time.time", lambda: 617.0)
+        monkeypatch.setattr("codex_a2a.upstream.interrupts.time.time", lambda: 617.0)
+        missing_status, missing_binding = await client_2.resolve_interrupt_request("200")
     finally:
         await runtime_state.shutdown()
 
-    assert status == "missing"
+    assert status == "expired"
     assert binding is None
+    assert repeated_status == "expired"
+    assert repeated_binding is None
+    assert missing_status == "missing"
+    assert binding is None
+    assert missing_binding is None


### PR DESCRIPTION
## 关联 Issues
- Closes #157
- 未关联 #158：本 PR 没有开放新的 TTL 配置面，只收敛 interrupt request lifecycle 与持久化语义。

## 模块变更
### upstream
- 为 interrupt request 增加 tombstone 生命周期语义，统一 `active / expired / missing` 行为。
- 为 interrupt binding 增加内部持久化上下文字段：`identity`、`task_id`、`context_id`、`expires_at`。
- 保持与 Codex 上游现有 interrupt callback 协议一致，没有新增对上游 request payload 的强依赖；上下文字段仅做服务端内部尽力采集与持久化。

### execution
- 在任务执行生命周期内绑定/释放 session 对应的 interrupt context，便于收到 Codex 上游 interrupt 时补全当前执行上下文。
- 未改变现有 session owner guard 设计，interrupt callback 授权仍然基于 `session_owner_matcher(session_id)`。

### server/runtime_state
- 扩展 interrupt 持久化表结构，增加 `identity`、`task_id`、`context_id`、`expires_at`、`tombstone_expires_at`。
- 新增 repository 级 `resolve/expire/load` 语义，避免过期 request 在首次解析或重启恢复后直接退化成 `missing`。
- 为已有 SQLite 数据库增加轻量 schema upgrade，保证旧库在升级后启动时可自动补齐新增列。

### tests
- 更新 interrupt persistence、Codex client params、JSON-RPC callback、database persistence 与 dummy client 回归测试。
- 覆盖重启恢复、expired tombstone 保留窗口、上下文字段恢复，以及旧数据库升级后的启动路径。

## 代码审查结论
### 需求匹配
- 本 PR 基本完整覆盖了 #157 的目标范围：补齐 tombstone 语义，并把可借鉴的上下文字段纳入内部持久化。
- 与 `~/opencode-a2a-serve` 相比，本 PR 只借鉴了 repository 级 lifecycle 与 tombstone 方案，没有照搬其基于 `binding.identity` 的授权路径，避免与当前主干的 session owner guard 形成双重真相源。

### 风险与注意事项
- tombstone TTL 当前仍为内部常量，未对外暴露配置；这与本次 PR 的收敛范围一致。
- 历史数据库升级采用增量补列方式，当前覆盖 SQLite 路径；后续如引入更正式 migration 机制，可再统一收口。

## 验证
- `bash ./scripts/validate_baseline.sh`
