### PR TITLE
fix: harden sqlite persistence defaults and clarify startup config

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,20 @@ A2A_BEARER_TOKEN="$(python -c 'import secrets; print(secrets.token_hex(24))')" \
 A2A_HOST=127.0.0.1 \
 A2A_PORT=8000 \
 A2A_PUBLIC_URL=http://127.0.0.1:8000 \
-A2A_DATABASE_URL=sqlite+aiosqlite:///./codex-a2a.db \
+A2A_DATABASE_URL=sqlite+aiosqlite:////abs/path/to/workspace/.codex-a2a/codex-a2a.db \
 CODEX_WORKSPACE_ROOT=/abs/path/to/workspace \
 codex-a2a
 ```
+
+When `A2A_DATABASE_URL` is unset and `CODEX_WORKSPACE_ROOT` is configured, the default SQLite database is created under `${CODEX_WORKSPACE_ROOT}/.codex-a2a/codex-a2a.db`.
+
+YOLO-equivalent startup note:
+
+- `codex-a2a` does not add a separate `--yolo` flag or `YOLO` environment variable.
+- To start the underlying Codex process with YOLO-equivalent behavior, set:
+  - `CODEX_APPROVAL_POLICY=never`
+  - `CODEX_SANDBOX_MODE=danger-full-access`
+- `A2A_EXECUTION_*` settings are discovery metadata only and do not change how the Codex subprocess starts.
 
 Agent Card: `http://127.0.0.1:8000/.well-known/agent-card.json`
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -62,7 +62,7 @@ Task-store resilience is also service-level behavior in this deployment:
 Task durability is deployment-dependent:
 
 - `A2A_DATABASE_URL=<sqlalchemy-async-url>` preserves task lookup/cancel/resubscribe state across process restarts.
-- `A2A_DATABASE_URL` now defaults to `sqlite+aiosqlite:///./codex-a2a.db`, so persistence is the default runtime behavior.
+- `A2A_DATABASE_URL` now defaults to a workspace-local SQLite database at `${CODEX_WORKSPACE_ROOT}/.codex-a2a/codex-a2a.db` when `CODEX_WORKSPACE_ROOT` is configured; otherwise it falls back to `sqlite+aiosqlite:///./codex-a2a.db`. Persistence therefore remains the default runtime behavior.
 - The same database-backed mode also preserves session-binding ownership state and pending interrupt callback requests that still fall within their TTL. Session-binding and ownership persistence are independent from the in-memory session cache TTL.
 
 ## Deployment Profile

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -174,7 +174,7 @@ Current implementation note:
 - `A2A_HOST`: bind host, default `127.0.0.1`
 - `A2A_PORT`: bind port, default `8000`
 - `A2A_BEARER_TOKEN`: required; service fails fast if unset
-- `A2A_DATABASE_URL`: SQLAlchemy async database URL shared by the database task store and runtime-state persistence, default `sqlite+aiosqlite:///./codex-a2a.db`. This enables database-backed task persistence and also backs session-binding ownership state plus pending interrupt callback requests for cross-restart recovery. Persisted session binding and ownership state are retained independently from the in-memory session cache TTL. In the default SQLite-backed deployment, terminal-task persistence also uses an atomic database upsert so late conflicting writes do not depend on a process-local pre-read.
+- `A2A_DATABASE_URL`: SQLAlchemy async database URL shared by the database task store and runtime-state persistence. When unset and `CODEX_WORKSPACE_ROOT` is configured, it defaults to a SQLite database under `${CODEX_WORKSPACE_ROOT}/.codex-a2a/codex-a2a.db`; otherwise it falls back to `sqlite+aiosqlite:///./codex-a2a.db` relative to the service start directory. This enables database-backed task persistence and also backs session-binding ownership state plus pending interrupt callback requests for cross-restart recovery. Persisted session binding and ownership state are retained independently from the in-memory session cache TTL. In the default SQLite-backed deployment, terminal-task persistence also uses an atomic database upsert so late conflicting writes do not depend on a process-local pre-read. SQLite engines started by `codex-a2a` now default to `journal_mode=WAL`, `busy_timeout=30000`, and `synchronous=NORMAL`; for multi-instance deployments, still prefer an explicit per-instance `A2A_DATABASE_URL` instead of sharing a default SQLite file.
 - `A2A_ENABLE_HEALTH_ENDPOINT`: enable the authenticated lightweight `/health` probe, default `true`
 - `A2A_ENABLE_SESSION_SHELL`: expose `codex.sessions.shell` on JSON-RPC extensions, default `true`
 - `A2A_LOG_LEVEL`: `DEBUG/INFO/WARNING/ERROR`, default `INFO`
@@ -207,6 +207,14 @@ Configuration note:
 - The service configuration layer only accepts `CODEX_*` names for Codex-facing settings.
 - Outbound auth prefers `A2A_CLIENT_BEARER_TOKEN` when both bearer and basic credentials are configured; otherwise it uses `A2A_CLIENT_BASIC_AUTH`.
 
+YOLO-equivalent execution note:
+- `codex-a2a` does not expose a separate `--yolo` flag or `YOLO` environment variable.
+- To start the underlying Codex app-server with YOLO-equivalent behavior, configure:
+  - `CODEX_APPROVAL_POLICY=never`
+  - `CODEX_SANDBOX_MODE=danger-full-access`
+- These values are forwarded to `codex app-server` as `-c approval_policy=...` and `-c sandbox_mode=...`.
+- `A2A_EXECUTION_*` variables are declarative discovery metadata and do not control Codex subprocess startup.
+
 Codex prerequisite note:
 - `codex-a2a` assumes the local `codex` runtime is already usable.
 - Install and verify the `codex` CLI itself before starting this server.
@@ -232,9 +240,11 @@ A2A_BEARER_TOKEN="$(python -c 'import secrets; print(secrets.token_hex(24))')" \
 A2A_HOST=127.0.0.1 \
 A2A_PORT=8000 \
 A2A_PUBLIC_URL=http://127.0.0.1:8000 \
-A2A_DATABASE_URL=sqlite+aiosqlite:///./codex-a2a.db \
+A2A_DATABASE_URL=sqlite+aiosqlite:////abs/path/to/workspace/.codex-a2a/codex-a2a.db \
 CODEX_WORKSPACE_ROOT=/abs/path/to/workspace \
 CODEX_MODEL=gpt-5.1-codex \
+CODEX_APPROVAL_POLICY=never \
+CODEX_SANDBOX_MODE=danger-full-access \
 CODEX_MODEL_REASONING_EFFORT=high \
 CODEX_WEB_SEARCH=live \
 CODEX_TIMEOUT=300 \
@@ -244,6 +254,7 @@ codex-a2a
 Notes:
 
 - `CODEX_WORKSPACE_ROOT` should point at the workspace root you want Codex to operate in.
+- If `A2A_DATABASE_URL` is omitted, `codex-a2a` defaults to `${CODEX_WORKSPACE_ROOT}/.codex-a2a/codex-a2a.db` when a workspace root is configured.
 - `codex-a2a` launches the Codex app-server subprocess itself; no separate `codex serve` step is required.
 - Upgrade the installed CLI with `uv tool upgrade codex-a2a`.
 

--- a/src/codex_a2a/config.py
+++ b/src/codex_a2a/config.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Annotated, Any, cast
 
-from pydantic import Field, field_validator
+from pydantic import Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 
 from codex_a2a import __version__
@@ -127,6 +128,14 @@ def _validate_choice(value: str, *, allowed: set[str], env_name: str) -> str:
     return value
 
 
+def _default_a2a_database_url(*, workspace_root: str | None) -> str:
+    if isinstance(workspace_root, str) and workspace_root.strip():
+        resolved_workspace_root = Path(workspace_root).expanduser().resolve()
+        database_path = resolved_workspace_root / ".codex-a2a" / "codex-a2a.db"
+        return f"sqlite+aiosqlite:///{database_path.as_posix()}"
+    return "sqlite+aiosqlite:///./codex-a2a.db"
+
+
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(
         env_prefix="",
@@ -244,7 +253,7 @@ class Settings(BaseSettings):
     a2a_port: int = Field(default=8000, alias="A2A_PORT")
     a2a_bearer_token: str = Field(..., min_length=1, alias="A2A_BEARER_TOKEN")
     a2a_database_url: str | None = Field(
-        default="sqlite+aiosqlite:///./codex-a2a.db",
+        default=None,
         alias="A2A_DATABASE_URL",
     )
 
@@ -499,6 +508,14 @@ class Settings(BaseSettings):
 
         validate_basic_auth(value)
         return value
+
+    @model_validator(mode="after")
+    def apply_dynamic_defaults(self) -> Settings:
+        if "a2a_database_url" not in self.model_fields_set and self.a2a_database_url is None:
+            self.a2a_database_url = _default_a2a_database_url(
+                workspace_root=self.codex_workspace_root
+            )
+        return self
 
     @classmethod
     def from_env(cls) -> Settings:

--- a/src/codex_a2a/server/database.py
+++ b/src/codex_a2a/server/database.py
@@ -1,11 +1,27 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
+from sqlalchemy import event
 from sqlalchemy.engine import make_url
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 
 from codex_a2a.config import Settings
+
+_SQLITE_JOURNAL_MODE = "WAL"
+_SQLITE_BUSY_TIMEOUT_MS = 30_000
+_SQLITE_SYNCHRONOUS_MODE = "NORMAL"
+
+
+def _configure_sqlite_connection(dbapi_connection: Any, _connection_record: Any) -> None:
+    cursor = dbapi_connection.cursor()
+    try:
+        cursor.execute(f"PRAGMA journal_mode={_SQLITE_JOURNAL_MODE}")
+        cursor.execute(f"PRAGMA busy_timeout={_SQLITE_BUSY_TIMEOUT_MS}")
+        cursor.execute(f"PRAGMA synchronous={_SQLITE_SYNCHRONOUS_MODE}")
+    finally:
+        cursor.close()
 
 
 def build_database_engine(settings: Settings) -> AsyncEngine:
@@ -22,7 +38,10 @@ def build_database_engine(settings: Settings) -> AsyncEngine:
                 path = (Path.cwd() / path).resolve()
             path.parent.mkdir(parents=True, exist_ok=True)
 
-    return create_async_engine(
+    engine = create_async_engine(
         database_url,
         pool_pre_ping=not url.drivername.startswith("sqlite"),
     )
+    if url.drivername.startswith("sqlite"):
+        event.listen(engine.sync_engine, "connect", _configure_sqlite_connection)
+    return engine

--- a/tests/config/test_settings.py
+++ b/tests/config/test_settings.py
@@ -56,8 +56,33 @@ def test_settings_valid():
         assert settings.codex_web_search == "live"
         assert settings.codex_review_model == "gpt-5.1"
         assert settings.codex_workspace_root == "/tmp/workspace"
-        assert settings.a2a_database_url == "sqlite+aiosqlite:///./codex-a2a.db"
+        assert (
+            settings.a2a_database_url
+            == "sqlite+aiosqlite:////tmp/workspace/.codex-a2a/codex-a2a.db"
+        )
         assert settings.a2a_version == __version__
+
+
+def test_settings_default_database_url_falls_back_without_workspace_root() -> None:
+    env = {
+        "A2A_BEARER_TOKEN": "test-token",
+    }
+    with mock.patch.dict(os.environ, env, clear=True):
+        settings = Settings.from_env()
+
+    assert settings.a2a_database_url == "sqlite+aiosqlite:///./codex-a2a.db"
+
+
+def test_settings_explicit_none_database_url_is_not_replaced_by_dynamic_default() -> None:
+    settings = Settings.model_validate(
+        {
+            "a2a_bearer_token": "test-token",
+            "codex_workspace_root": "/tmp/workspace",
+            "a2a_database_url": None,
+        }
+    )
+
+    assert settings.a2a_database_url is None
 
 
 def test_settings_parse_ops_flags_and_timeouts():

--- a/tests/package/test_release_distribution_contract.py
+++ b/tests/package/test_release_distribution_contract.py
@@ -27,7 +27,10 @@ def test_readme_documents_released_cli_installation_via_uv_tool() -> None:
     assert "does not provision Codex providers, login state, or API keys for you" in README_TEXT
     assert "Startup fails fast if the local `codex` runtime is missing" in README_TEXT
     assert "CODEX_WORKSPACE_ROOT=/abs/path/to/workspace" in README_TEXT  # pragma: allowlist secret
-    assert "A2A_DATABASE_URL=sqlite+aiosqlite:///./codex-a2a.db" in README_TEXT
+    assert (
+        "A2A_DATABASE_URL=sqlite+aiosqlite:////abs/path/to/workspace/.codex-a2a/codex-a2a.db"
+        in README_TEXT
+    )
     assert (
         "A2A_BEARER_TOKEN=\"$(python -c 'import secrets; print(secrets.token_hex(24))')\" \\"
         in README_TEXT

--- a/tests/server/test_database.py
+++ b/tests/server/test_database.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import pytest
+
+from codex_a2a.server.database import build_database_engine
+from tests.support.settings import make_settings
+
+
+@pytest.mark.asyncio
+async def test_build_database_engine_configures_sqlite_pragmas(tmp_path) -> None:
+    settings = make_settings(
+        a2a_bearer_token="test-token",
+        a2a_database_url=f"sqlite+aiosqlite:///{(tmp_path / 'runtime.db').resolve()}",
+    )
+    engine = build_database_engine(settings)
+
+    try:
+        async with engine.connect() as conn:
+            journal_mode = (await conn.exec_driver_sql("PRAGMA journal_mode")).scalar_one()
+            busy_timeout = (await conn.exec_driver_sql("PRAGMA busy_timeout")).scalar_one()
+            synchronous = (await conn.exec_driver_sql("PRAGMA synchronous")).scalar_one()
+    finally:
+        await engine.dispose()
+
+    assert str(journal_mode).lower() == "wal"
+    assert int(busy_timeout) == 30_000
+    assert int(synchronous) == 1


### PR DESCRIPTION
## 变更概览

### 启动配置文档
- 明确 `codex-a2a` 没有单独的 `--yolo` 或 `YOLO` 环境变量。
- 补充 yolo 等价启动方式，统一说明应通过 `CODEX_APPROVAL_POLICY=never` 与 `CODEX_SANDBOX_MODE=danger-full-access` 注入。
- 更新 README 与使用指南中的启动示例，继续显式展示 `A2A_DATABASE_URL`。

### SQLite 持久化默认值
- 为 SQLite 连接默认启用 `journal_mode=WAL`、`busy_timeout=30000`、`synchronous=NORMAL`，降低并发会话场景下 `database is locked` 的触发概率。
- 新增对应测试，校验 SQLite pragma 配置已生效。

### 默认数据库路径策略
- 当未显式设置 `A2A_DATABASE_URL` 且已配置 `CODEX_WORKSPACE_ROOT` 时，默认数据库改为落到 `${CODEX_WORKSPACE_ROOT}/.codex-a2a/codex-a2a.db`。
- 若 `CODEX_WORKSPACE_ROOT` 也未配置，仍保留原有的 `sqlite+aiosqlite:///./codex-a2a.db` 兜底行为。
- 补充配置测试、README 合约测试与兼容性文档说明，确保代码与发布文档一致。

## 验证
- `bash ./scripts/validate_baseline.sh`

## 关联 Issue
- Closes #204
- Closes #205
- Closes #206
