### PR TITLE
chore: prefer a single Dependabot PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,29 +5,12 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 1
     commit-message:
       prefix: "deps"
     labels:
       - "dependencies"
     groups:
-      uv-minor-and-patch:
-        patterns:
-          - "*"
-        update-types:
-          - "minor"
-          - "patch"
-
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 3
-    commit-message:
-      prefix: "deps"
-    labels:
-      - "dependencies"
-    groups:
-      github-actions:
+      uv-all-updates:
         patterns:
           - "*"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -30,6 +30,6 @@ The `Publish` workflow now separates build, PyPI publish, and GitHub Release syn
 
 - `validate_baseline.sh` and `dependency_health.sh` intentionally remain separate entrypoints and share common prerequisites through [`health_common.sh`](./health_common.sh).
 - `validate_baseline.sh` now blocks on runtime dependency vulnerability audit, while `dependency_health.sh` remains focused on broader dependency review (`outdated` + dev audit).
-- [`.github/dependabot.yml`](../.github/dependabot.yml) enables weekly Dependabot version updates for `uv` and GitHub Actions with grouped low-risk updates, while the repository scripts remain the explicit audit and validation entrypoints.
+- [`.github/dependabot.yml`](../.github/dependabot.yml) prefers a single weekly grouped Dependabot PR for `uv`, while the repository scripts remain the explicit audit and validation entrypoints.
 - End-user runtime startup does not use repository scripts. Prefer the published CLI command documented in [README.md](../README.md) and [docs/guide.md](../docs/guide.md).
 - Keep long-form documentation changes in `docs/` to avoid divergence.

--- a/tests/scripts/test_script_health_contract.py
+++ b/tests/scripts/test_script_health_contract.py
@@ -42,12 +42,11 @@ def test_scripts_index_documents_split_health_entrypoints() -> None:
     assert "standalone dependency review flow" in SCRIPTS_INDEX_TEXT
     assert "health_common.sh" in SCRIPTS_INDEX_TEXT
     assert "intentionally remain separate entrypoints" in SCRIPTS_INDEX_TEXT
-    assert "weekly Dependabot version updates" in SCRIPTS_INDEX_TEXT
+    assert "single weekly grouped Dependabot PR for `uv`" in SCRIPTS_INDEX_TEXT
 
 
-def test_dependabot_configuration_covers_uv_and_github_actions() -> None:
+def test_dependabot_configuration_prefers_a_single_grouped_uv_pr() -> None:
     assert 'package-ecosystem: "uv"' in DEPENDABOT_TEXT
-    assert 'package-ecosystem: "github-actions"' in DEPENDABOT_TEXT
-    assert "open-pull-requests-limit: 5" in DEPENDABOT_TEXT
-    assert "open-pull-requests-limit: 3" in DEPENDABOT_TEXT
-    assert "uv-minor-and-patch" in DEPENDABOT_TEXT
+    assert 'package-ecosystem: "github-actions"' not in DEPENDABOT_TEXT
+    assert "open-pull-requests-limit: 1" in DEPENDABOT_TEXT
+    assert "uv-all-updates" in DEPENDABOT_TEXT


### PR DESCRIPTION
## 概要

将 Dependabot 配置收敛为单 PR 风格：仅保留 `uv` 自动版本更新，并将全部 `uv` 可升级项合并为单个每周 PR，以降低依赖升级审阅噪声。

## 变更

### `.github`

- 更新 `.github/dependabot.yml`
- 移除 `github-actions` 的 Dependabot 自动升级配置
- 将 `uv` 的 `open-pull-requests-limit` 收敛为 `1`
- 将 `uv` 全部更新合并为单个分组 `uv-all-updates`

### `scripts`

- 更新 `scripts/README.md`
- 明确仓库偏好单个每周 `uv` Dependabot PR
- 保持脚本作为显式依赖审计与验证入口

### `tests`

- 更新 `tests/scripts/test_script_health_contract.py`
- 将契约断言调整为单 PR 偏好：不再允许 `github-actions` ecosystem，要求 `uv` 仅保留单分组与单并发 PR

## 验证

- `uv run pytest tests/scripts/test_script_health_contract.py`
- `bash ./scripts/validate_baseline.sh`
- `bash ./scripts/dependency_health.sh`

## 关联

- Closes #247
