### PR TITLE
feat: add protocol compatibility and conformance workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ The normative compatibility split and deployment model live in [Compatibility Gu
 - [Architecture Guide](docs/architecture.md) System structure, boundaries, and request flow.
 - [Maintainer Architecture Guide](docs/maintainer-architecture.md) Internal module structure, request call chains, and persistence touchpoints for contributors.
 - [Compatibility Guide](docs/compatibility.md) Supported Python/runtime surface, extension stability, and ecosystem-facing compatibility expectations.
+- [External Conformance Experiments](docs/conformance.md) Manual A2A TCK experiment entrypoint and triage workflow.
 - [Security Policy](SECURITY.md) Threat model, deployment caveats, and vulnerability disclosure guidance.
 
 ## Development

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -93,6 +93,7 @@ Use the docs by responsibility:
 - [Maintainer Architecture Guide](maintainer-architecture.md): internal module boundaries, request call chains, and persistence touchpoints
 - [Extension Specifications](extension-specifications.md): stable extension URI/spec index and public-vs-extended disclosure rules
 - [Compatibility Guide](compatibility.md): current compatibility promises and stability expectations
+- [External Conformance Experiments](conformance.md): manual A2A TCK experiment entrypoint and triage workflow
 - [Contributing Guide](../CONTRIBUTING.md): contributor workflow and validation
 - [Security Policy](../SECURITY.md): threat model and disclosure guidance
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -7,11 +7,11 @@ This document explains the compatibility promises this repository currently trie
 - Python versions: 3.11, 3.12, 3.13
 - A2A SDK line: `0.3.x`
 - A2A protocol version advertised by default: `0.3.0`
-- Normalized protocol compatibility line declared today: `0.3`
+- Normalized protocol compatibility lines declared today: `0.3`, `1.0`
 
 The repository pins the SDK version in `pyproject.toml` and validates the published CLI build in CI. Upgrade the SDK deliberately rather than relying on floating dependency resolution.
 
-The authenticated compatibility profile and wire contract publish `default_protocol_version`, `supported_protocol_versions`, and `protocol_compatibility`. Those fields are declarative discovery metadata. They do not imply request-time `A2A-Version` negotiation for protocol lines outside the current SDK-backed `0.3` behavior.
+The authenticated compatibility profile and wire contract publish `default_protocol_version`, `supported_protocol_versions`, and `protocol_compatibility`. Request-time `A2A-Version` negotiation currently supports the default `0.3` line plus a partial `1.0` compatibility line for response header echo, PascalCase JSON-RPC method aliases, and protocol-aware error shaping. Transport payload schemas, enums, pagination, and push-notification behavior remain SDK-owned `0.3` behavior until separately implemented.
 
 ## Contract Honesty
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -7,8 +7,11 @@ This document explains the compatibility promises this repository currently trie
 - Python versions: 3.11, 3.12, 3.13
 - A2A SDK line: `0.3.x`
 - A2A protocol version advertised by default: `0.3.0`
+- Normalized protocol compatibility line declared today: `0.3`
 
 The repository pins the SDK version in `pyproject.toml` and validates the published CLI build in CI. Upgrade the SDK deliberately rather than relying on floating dependency resolution.
+
+The authenticated compatibility profile and wire contract publish `default_protocol_version`, `supported_protocol_versions`, and `protocol_compatibility`. Those fields are declarative discovery metadata. They do not imply request-time `A2A-Version` negotiation for protocol lines outside the current SDK-backed `0.3` behavior.
 
 ## Contract Honesty
 

--- a/docs/conformance-triage.md
+++ b/docs/conformance-triage.md
@@ -1,0 +1,49 @@
+# External Conformance Triage
+
+This document is the standing triage template for local `./scripts/conformance.sh` runs against the official `a2aproject/a2a-tck`.
+
+## Standards Used For Triage
+
+- `a2a-sdk==0.3.26` as installed in this repository.
+- The default A2A protocol version advertised by this repository: `0.3.0`.
+- Repository compatibility policy:
+  - machine-readable Agent Card and OpenAPI contracts must reflect implemented runtime behavior;
+  - external TCK results are investigation input rather than default merge gates;
+  - unsupported `1.0` behavior should be tracked as future compatibility work, not silently declared as supported.
+
+## Classification Labels
+
+- `Runtime issue`: the failure reproduces against the repository's declared runtime behavior and should be fixed here.
+- `TCK mismatch`: the failure appears to conflict with the installed SDK line or this repository's declared v0.3 baseline.
+- `Future protocol gap`: the failure is not a v0.3 regression, but it identifies work needed for stronger v1.0 compatibility.
+- `Local experiment artifact`: the failure comes from the dummy-backed SUT, local auth, local URLs, timing, or other experiment setup details.
+- `Needs repro`: the failure needs a focused local probe before assigning ownership.
+
+## Triage Workflow
+
+For each failed or errored node ID:
+
+1. Copy the node ID from `failed-tests.json`.
+2. Inspect the corresponding raw details in `pytest-report.json` and `tck.log`.
+3. Compare the expectation with `docs/compatibility.md`, authenticated Agent Card params, and OpenAPI `x-a2a-extension-contracts`.
+4. Assign one classification label.
+5. Record whether the next action belongs in this repository, the TCK, or a future protocol compatibility issue.
+
+## Per-Test Triage
+
+Add dated entries below after a real run:
+
+```text
+YYYY-MM-DD:
+- <nodeid>: <classification>. <short rationale>. Next action: <repo/TCK/future/none>.
+```
+
+## Summary
+
+Keep the summary short and separate:
+
+- Count clean runtime issues.
+- Count TCK mismatches.
+- Count future protocol gaps.
+- Count local experiment artifacts.
+- List follow-up issue numbers when created.

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -1,0 +1,77 @@
+# External Conformance Experiments
+
+This repository keeps internal regression and external interoperability experiments separate on purpose.
+
+## Scope
+
+- `./scripts/doctor.sh` and `./scripts/validate_baseline.sh` remain the default internal regression entrypoints.
+- `./scripts/conformance.sh` is a local/manual experiment entrypoint for official external tooling.
+- External conformance output is investigation input, not an automatic merge gate.
+
+## Current Experiment Shape
+
+The default `./scripts/conformance.sh` workflow does the following:
+
+1. Syncs the repository environment unless explicitly skipped.
+2. Caches or refreshes the official `a2aproject/a2a-tck` checkout.
+3. Starts a local dummy-backed `codex-a2a` runtime unless `CONFORMANCE_SUT_URL` points to an existing SUT.
+4. Runs the requested TCK category, defaulting to `mandatory`.
+5. Preserves raw logs and machine-readable reports under `run/conformance/<timestamp>/`.
+
+The default local SUT uses the repository test double `DummyChatCodexClient`. That keeps the experiment reproducible without requiring a live Codex upstream.
+
+## Usage
+
+Run the default mandatory experiment:
+
+```bash
+bash ./scripts/conformance.sh
+```
+
+Run a different TCK category:
+
+```bash
+bash ./scripts/conformance.sh capabilities
+```
+
+Target an already running runtime instead of the local dummy-backed SUT:
+
+```bash
+CONFORMANCE_SUT_URL=http://127.0.0.1:8000 \
+A2A_AUTH_TYPE=bearer \
+A2A_AUTH_TOKEN=dev-token \
+bash ./scripts/conformance.sh mandatory
+```
+
+Skip local environment sync when the repository and cached TCK environment are already current:
+
+```bash
+CONFORMANCE_SKIP_REPO_SYNC=1 \
+CONFORMANCE_SKIP_TCK_SYNC=1 \
+bash ./scripts/conformance.sh mandatory
+```
+
+## Artifacts
+
+Each run keeps the following artifacts in the selected output directory:
+
+- `agent-card.json`: fetched public Agent Card
+- `health.json`: fetched authenticated health payload when the local SUT is used
+- `repo-health.log`: repository environment sync and dependency compatibility output
+- `tck.log`: raw TCK console output
+- `pytest-report.json`: pytest-json-report output emitted by the TCK runner when available
+- `failed-tests.json`: compact list of failed/error node IDs for triage when a report is available
+- `metadata.json`: experiment metadata including local repo commit and cached TCK commit
+
+## Interpretation Guidance
+
+When a TCK run fails, inspect the raw report before changing the runtime:
+
+- Some failures may point to real runtime gaps.
+- Some failures may come from TCK assumptions that do not match `a2a-sdk==0.3.26`.
+- Some failures may come from A2A v0.3 versus v1.0 naming or schema drift.
+- Some failures may be local experiment artifacts from the dummy-backed runtime.
+
+The experiment is useful only if those categories stay separate during triage.
+
+Record first-pass classifications in [conformance-triage.md](./conformance-triage.md).

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -73,6 +73,6 @@ When a TCK run fails, inspect the raw report before changing the runtime:
 - Some failures may be local experiment artifacts from the dummy-backed runtime.
 
 The experiment is useful only if those categories stay separate during triage.
-Use the authenticated compatibility profile and wire contract `protocol_compatibility` fields as the repository-owned declaration of which protocol lines are supported today versus reserved for future work.
+Use the authenticated compatibility profile and wire contract `protocol_compatibility` fields as the repository-owned declaration of which protocol lines are supported today, partially supported for compatibility, or reserved for future work.
 
 Record first-pass classifications in [conformance-triage.md](./conformance-triage.md).

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -73,5 +73,6 @@ When a TCK run fails, inspect the raw report before changing the runtime:
 - Some failures may be local experiment artifacts from the dummy-backed runtime.
 
 The experiment is useful only if those categories stay separate during triage.
+Use the authenticated compatibility profile and wire contract `protocol_compatibility` fields as the repository-owned declaration of which protocol lines are supported today versus reserved for future work.
 
 Record first-pass classifications in [conformance-triage.md](./conformance-triage.md).

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -163,7 +163,7 @@ Extension boundary principles:
 
 Current implementation note:
 
-- The compatibility profile is declarative. It does not introduce a global runtime `core-only` switch.
+- The compatibility profile is declarative. It does not introduce a global runtime `core-only` switch; request-time `A2A-Version` negotiation is limited to the protocol lines and gaps published in the profile.
 - This is intentional: current shared session/stream/interrupt behavior is part of the deployed interoperability contract, so a blanket runtime profile split would be misleading without broader wire-level changes.
 - For compatibility policy and stability expectations, use [compatibility.md](./compatibility.md) as the normative repo document rather than this usage guide.
 
@@ -199,6 +199,7 @@ Use the grouped sections below as the deployment-first reading order:
 - `A2A_VERSION`: agent version string
 - `A2A_PROJECT`: optional project label injected into examples and discovery metadata
 - `A2A_PROTOCOL_VERSION`: advertised A2A protocol version, default `0.3.0`
+- `A2A_SUPPORTED_PROTOCOL_VERSIONS`: comma-separated request negotiation lines, default `0.3,1.0`
 - `A2A_DOCUMENTATION_URL`: optional external documentation URL exposed on Agent Card
 - `A2A_STATIC_AUTH_CREDENTIALS`: JSON array of static inbound credentials. Supports multiple `bearer` and `basic` entries, each with a stable `principal`; `bearer` entries must declare `principal`, while `basic` entries derive `principal` from `username`.
 
@@ -278,6 +279,7 @@ These variables are forwarded to the local `codex app-server` subprocess.
 | `A2A_VERSION` | Agent version |
 | `A2A_PROJECT` | Project label |
 | `A2A_PROTOCOL_VERSION` | Protocol version |
+| `A2A_SUPPORTED_PROTOCOL_VERSIONS` | Supported protocol versions |
 | `A2A_DOCUMENTATION_URL` | Documentation URL |
 | `A2A_ENABLE_HEALTH_ENDPOINT` | Enable /health |
 | `A2A_ENABLE_SESSION_SHELL` | Enable session shell |

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -12,6 +12,7 @@ This document only explains the remaining repository-local maintainer scripts. U
 
 ## Which Script to Use
 
+- [`scripts/doctor.sh`](./doctor.sh): run the default local validation baseline through the shortest maintainer entrypoint.
 - [`scripts/validate_baseline.sh`](./validate_baseline.sh): run the default local validation baseline used by contributors and CI.
 - [`scripts/validate_runtime_matrix.sh`](./validate_runtime_matrix.sh): run the reduced runtime-only validation used by the multi-version CI matrix.
 - [`scripts/dependency_health.sh`](./dependency_health.sh): run the standalone dependency review flow (`sync`/`pip check`, outdated package listing, and dev vulnerability audit).
@@ -28,6 +29,7 @@ The `Publish` workflow now separates build, PyPI publish, and GitHub Release syn
 
 ## Notes
 
+- `doctor.sh` is a thin alias for the default local regression baseline; `validate_baseline.sh` remains the CI-facing script name.
 - `validate_baseline.sh` and `dependency_health.sh` intentionally remain separate entrypoints and share common prerequisites through [`health_common.sh`](./health_common.sh).
 - `validate_baseline.sh` now blocks on runtime dependency vulnerability audit, while `dependency_health.sh` remains focused on broader dependency review (`outdated` + dev audit).
 - [`.github/dependabot.yml`](../.github/dependabot.yml) prefers a single weekly grouped Dependabot PR for `uv`, while the repository scripts remain the explicit audit and validation entrypoints.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -15,6 +15,7 @@ This document only explains the remaining repository-local maintainer scripts. U
 - [`scripts/doctor.sh`](./doctor.sh): run the default local validation baseline through the shortest maintainer entrypoint.
 - [`scripts/validate_baseline.sh`](./validate_baseline.sh): run the default local validation baseline used by contributors and CI.
 - [`scripts/validate_runtime_matrix.sh`](./validate_runtime_matrix.sh): run the reduced runtime-only validation used by the multi-version CI matrix.
+- [`scripts/conformance.sh`](./conformance.sh): run the official A2A TCK as a local/manual external compatibility experiment.
 - [`scripts/dependency_health.sh`](./dependency_health.sh): run the standalone dependency review flow (`sync`/`pip check`, outdated package listing, and dev vulnerability audit).
 - [`scripts/smoke_test_built_cli.sh`](./smoke_test_built_cli.sh): validate that a built wheel can be installed through `uv tool` and becomes healthy.
 - [`scripts/sync_codex_docs.sh`](./sync_codex_docs.sh): refresh local upstream Codex reference snapshots when maintainers need them.
@@ -30,6 +31,7 @@ The `Publish` workflow now separates build, PyPI publish, and GitHub Release syn
 ## Notes
 
 - `doctor.sh` is a thin alias for the default local regression baseline; `validate_baseline.sh` remains the CI-facing script name.
+- `conformance.sh` intentionally stays outside the default regression gate. Use it to gather external compatibility evidence, then triage results in [`docs/conformance-triage.md`](../docs/conformance-triage.md).
 - `validate_baseline.sh` and `dependency_health.sh` intentionally remain separate entrypoints and share common prerequisites through [`health_common.sh`](./health_common.sh).
 - `validate_baseline.sh` now blocks on runtime dependency vulnerability audit, while `dependency_health.sh` remains focused on broader dependency review (`outdated` + dev audit).
 - [`.github/dependabot.yml`](../.github/dependabot.yml) prefers a single weekly grouped Dependabot PR for `uv`, while the repository scripts remain the explicit audit and validation entrypoints.

--- a/scripts/conformance.sh
+++ b/scripts/conformance.sh
@@ -1,0 +1,252 @@
+#!/usr/bin/env bash
+# Run a local-only external A2A conformance experiment without changing default gates.
+set -euo pipefail
+
+# shellcheck source=./health_common.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/health_common.sh"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bash ./scripts/conformance.sh [category]
+
+Purpose:
+  Run the official A2A TCK as a local/manual experiment.
+  This script is intentionally separate from doctor.sh, validate_baseline.sh, and CI gates.
+
+Category:
+  Defaults to "mandatory". Any category supported by a2aproject/a2a-tck run_tck.py is accepted.
+
+Selected environment variables:
+  CONFORMANCE_OUTPUT_DIR              Override artifact directory (default: run/conformance/<timestamp>)
+  CONFORMANCE_TCK_DIR                 Override cached TCK checkout path (default: .cache/a2a-tck)
+  CONFORMANCE_TCK_REPO                Override TCK repo URL (default: https://github.com/a2aproject/a2a-tck.git)
+  CONFORMANCE_TCK_REF                 Override TCK git ref (default: main)
+  CONFORMANCE_TRANSPORTS              Override requested transports (default: jsonrpc)
+  CONFORMANCE_TRANSPORT_STRATEGY      Override TCK transport strategy (default: agent_preferred)
+  CONFORMANCE_SUT_URL                 Use an already running SUT instead of the local dummy-backed runtime
+  CONFORMANCE_SUT_PORT                Override local dummy-backed SUT port (default: 8011)
+  CONFORMANCE_SKIP_REPO_SYNC=1        Skip uv sync/uv pip check for this repository
+  CONFORMANCE_SKIP_TCK_SYNC=1         Skip uv sync inside the cached TCK checkout
+  CONFORMANCE_AUTH_TYPE               Default auth type when A2A_AUTH_TYPE is unset (default: bearer)
+  CONFORMANCE_AUTH_TOKEN              Default auth token when A2A_AUTH_TOKEN is unset (default: test-token)
+
+Advanced authentication:
+  The script preserves caller-provided A2A_AUTH_* variables and only sets defaults
+  for the common bearer-token case used by the local dummy-backed runtime.
+EOF
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ "$#" -gt 1 ]]; then
+  echo "Expected at most one positional argument: category" >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+category="${1:-${CONFORMANCE_CATEGORY:-mandatory}}"
+timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+output_dir="${CONFORMANCE_OUTPUT_DIR:-${ROOT_DIR}/run/conformance/${timestamp}}"
+tck_dir="${CONFORMANCE_TCK_DIR:-${ROOT_DIR}/.cache/a2a-tck}"
+tck_repo="${CONFORMANCE_TCK_REPO:-https://github.com/a2aproject/a2a-tck.git}"
+tck_ref="${CONFORMANCE_TCK_REF:-main}"
+transport_strategy="${CONFORMANCE_TRANSPORT_STRATEGY:-agent_preferred}"
+transports="${CONFORMANCE_TRANSPORTS:-jsonrpc}"
+sut_port="${CONFORMANCE_SUT_PORT:-8011}"
+repo_log="${output_dir}/repo-health.log"
+tck_sync_log="${output_dir}/tck-sync.log"
+sut_log="${output_dir}/sut.log"
+tck_log="${output_dir}/tck.log"
+
+mkdir -p "${output_dir}"
+
+cleanup() {
+  local exit_code="$1"
+  if [[ -n "${sut_pid:-}" ]] && kill -0 "${sut_pid}" >/dev/null 2>&1; then
+    kill "${sut_pid}" >/dev/null 2>&1 || true
+    wait "${sut_pid}" >/dev/null 2>&1 || true
+  fi
+  exit "${exit_code}"
+}
+
+trap 'cleanup $?' EXIT
+
+cd "${ROOT_DIR}"
+
+if [[ "${CONFORMANCE_SKIP_REPO_SYNC:-0}" != "1" ]]; then
+  run_shared_repo_health_prerequisites "conformance" >"${repo_log}" 2>&1
+fi
+
+mkdir -p "$(dirname "${tck_dir}")"
+if [[ ! -d "${tck_dir}/.git" ]]; then
+  git clone --depth 1 "${tck_repo}" "${tck_dir}" >"${output_dir}/tck-clone.log" 2>&1
+fi
+
+git -C "${tck_dir}" fetch --depth 1 origin "${tck_ref}" >"${output_dir}/tck-fetch.log" 2>&1
+git -C "${tck_dir}" checkout --quiet FETCH_HEAD
+
+if [[ "${CONFORMANCE_SKIP_TCK_SYNC:-0}" != "1" ]]; then
+  (
+    cd "${tck_dir}"
+    uv sync
+  ) >"${tck_sync_log}" 2>&1
+fi
+
+if [[ -z "${A2A_AUTH_TYPE:-}" ]]; then
+  export A2A_AUTH_TYPE="${CONFORMANCE_AUTH_TYPE:-bearer}"
+fi
+if [[ -z "${A2A_AUTH_TOKEN:-}" && "${A2A_AUTH_TYPE}" == "bearer" ]]; then
+  export A2A_AUTH_TOKEN="${CONFORMANCE_AUTH_TOKEN:-test-token}"
+fi
+
+sut_url="${CONFORMANCE_SUT_URL:-}"
+if [[ -z "${sut_url}" ]]; then
+  sut_url="http://127.0.0.1:${sut_port}"
+  export CONFORMANCE_SUT_PORT="${sut_port}"
+  export CONFORMANCE_SUT_URL="${sut_url}"
+  uv run python - <<'PY' >"${sut_log}" 2>&1 &
+import os
+
+import uvicorn
+
+import codex_a2a.server.application as app_module
+from tests.support.dummy_clients import DummyChatCodexClient
+from tests.support.settings import make_settings
+
+app_module.CodexClient = DummyChatCodexClient
+settings = make_settings(
+    a2a_host="127.0.0.1",
+    a2a_port=int(os.environ["CONFORMANCE_SUT_PORT"]),
+    a2a_public_url=os.environ["CONFORMANCE_SUT_URL"],
+    a2a_bearer_token=os.environ.get("A2A_AUTH_TOKEN", "test-token"),
+    a2a_database_url=None,
+)
+app = app_module.create_app(settings)
+uvicorn.run(app, host="127.0.0.1", port=settings.a2a_port, log_level="warning")
+PY
+  sut_pid="$!"
+
+  for _ in $(seq 1 50); do
+    if curl -fsS "${sut_url}/.well-known/agent-card.json" >"${output_dir}/agent-card.json"; then
+      if curl -fsS -H "Authorization: Bearer ${A2A_AUTH_TOKEN:-test-token}" "${sut_url}/health" \
+        >"${output_dir}/health.json"; then
+        break
+      fi
+    fi
+    sleep 0.2
+  done
+
+  if [[ ! -f "${output_dir}/agent-card.json" || ! -f "${output_dir}/health.json" ]]; then
+    echo "SUT did not become ready at ${sut_url}" >&2
+    cat "${sut_log}" >&2 || true
+    exit 1
+  fi
+else
+  curl -fsS "${sut_url}/.well-known/agent-card.json" >"${output_dir}/agent-card.json"
+fi
+
+json_report_name="pytest-${category}.json"
+
+set +e
+(
+  cd "${tck_dir}"
+  CONFORMANCE_CATEGORY="${category}" \
+  CONFORMANCE_SUT_URL="${sut_url}" \
+  CONFORMANCE_JSON_REPORT_NAME="${json_report_name}" \
+  CONFORMANCE_TRANSPORT_STRATEGY="${transport_strategy}" \
+  CONFORMANCE_TRANSPORTS="${transports}" \
+  uv run python - <<'PY'
+from __future__ import annotations
+
+import os
+import run_tck
+
+raise SystemExit(
+    run_tck.run_test_category(
+        category=os.environ["CONFORMANCE_CATEGORY"],
+        sut_url=os.environ["CONFORMANCE_SUT_URL"],
+        verbose=False,
+        verbose_log=True,
+        generate_report=False,
+        json_report=os.environ["CONFORMANCE_JSON_REPORT_NAME"],
+        transport_strategy=os.environ["CONFORMANCE_TRANSPORT_STRATEGY"],
+        enable_equivalence_testing=None,
+        transports=os.environ["CONFORMANCE_TRANSPORTS"],
+    )
+)
+PY
+) 2>&1 | tee "${tck_log}"
+tck_exit="${PIPESTATUS[0]}"
+set -e
+
+report_path="${tck_dir}/reports/${json_report_name}"
+if [[ -f "${report_path}" ]]; then
+  cp "${report_path}" "${output_dir}/pytest-report.json"
+fi
+
+CONFORMANCE_CATEGORY="${category}" \
+CONFORMANCE_OUTPUT_DIR="${output_dir}" \
+CONFORMANCE_SUT_URL="${sut_url}" \
+CONFORMANCE_TCK_DIR="${tck_dir}" \
+CONFORMANCE_TCK_REF="${tck_ref}" \
+CONFORMANCE_TRANSPORTS="${transports}" \
+CONFORMANCE_TRANSPORT_STRATEGY="${transport_strategy}" \
+uv run python - <<'PY'
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+output_dir = Path(os.environ["CONFORMANCE_OUTPUT_DIR"])
+report_path = output_dir / "pytest-report.json"
+
+metadata = {
+    "category": os.environ["CONFORMANCE_CATEGORY"],
+    "sut_url": os.environ["CONFORMANCE_SUT_URL"],
+    "tck_dir": os.environ["CONFORMANCE_TCK_DIR"],
+    "tck_ref": os.environ["CONFORMANCE_TCK_REF"],
+    "transports": os.environ["CONFORMANCE_TRANSPORTS"],
+    "transport_strategy": os.environ["CONFORMANCE_TRANSPORT_STRATEGY"],
+    "repo_commit": subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip(),
+    "tck_commit": subprocess.check_output(
+        ["git", "-C", os.environ["CONFORMANCE_TCK_DIR"], "rev-parse", "HEAD"],
+        text=True,
+    ).strip(),
+}
+
+(output_dir / "metadata.json").write_text(json.dumps(metadata, indent=2) + "\n")
+
+if report_path.exists():
+    report = json.loads(report_path.read_text())
+    failures = []
+    for test in report.get("tests", []):
+        outcome = test.get("outcome")
+        if outcome in {"failed", "error"}:
+            failures.append(
+                {
+                    "nodeid": test.get("nodeid"),
+                    "outcome": outcome,
+                    "keywords": sorted(test.get("keywords", [])),
+                }
+            )
+    (output_dir / "failed-tests.json").write_text(json.dumps(failures, indent=2) + "\n")
+PY
+
+echo "Conformance artifacts: ${output_dir}"
+echo "TCK log: ${tck_log}"
+if [[ -f "${output_dir}/pytest-report.json" ]]; then
+  echo "Pytest JSON report: ${output_dir}/pytest-report.json"
+fi
+if [[ -f "${output_dir}/failed-tests.json" ]]; then
+  echo "Failed tests index: ${output_dir}/failed-tests.json"
+fi
+
+exit "${tck_exit}"

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Run the default repository validation entrypoint.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+exec bash "${SCRIPT_DIR}/validate_baseline.sh" "$@"

--- a/src/codex_a2a/config.py
+++ b/src/codex_a2a/config.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, BeforeValidator, ConfigDict, Field, field_valida
 from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 
 from codex_a2a import __version__
+from codex_a2a.protocol_versions import normalize_protocol_version, normalize_protocol_versions
 
 _SANDBOX_MODES = {
     "unknown",
@@ -320,6 +321,10 @@ class Settings(BaseSettings):
     a2a_description: str = Field(default="A2A wrapper service for Codex", alias="A2A_DESCRIPTION")
     a2a_version: str = Field(default=__version__, alias="A2A_VERSION")
     a2a_protocol_version: str = Field(default="0.3.0", alias="A2A_PROTOCOL_VERSION")
+    a2a_supported_protocol_versions: Annotated[list[str], NoDecode] = Field(
+        default_factory=lambda: ["0.3", "1.0"],
+        alias="A2A_SUPPORTED_PROTOCOL_VERSIONS",
+    )
     a2a_enable_health_endpoint: bool = Field(default=True, alias="A2A_ENABLE_HEALTH_ENDPOINT")
     a2a_enable_session_shell: bool = Field(default=False, alias="A2A_ENABLE_SESSION_SHELL")
     a2a_enable_turn_control: bool = Field(default=True, alias="A2A_ENABLE_TURN_CONTROL")
@@ -439,11 +444,23 @@ class Settings(BaseSettings):
         "codex_sandbox_workspace_write_writable_roots",
         "a2a_execution_sandbox_writable_roots",
         "a2a_execution_network_allowed_domains",
+        "a2a_supported_protocol_versions",
         mode="before",
     )
     @classmethod
     def parse_execution_lists(cls, value: Any) -> Any:
         return _parse_str_list(value)
+
+    @field_validator("a2a_protocol_version")
+    @classmethod
+    def validate_a2a_protocol_version(cls, value: str) -> str:
+        normalize_protocol_version(value)
+        return value
+
+    @field_validator("a2a_supported_protocol_versions")
+    @classmethod
+    def validate_a2a_supported_protocol_versions(cls, value: list[str]) -> list[str]:
+        return list(normalize_protocol_versions(value))
 
     @field_validator("a2a_execution_sandbox_mode")
     @classmethod
@@ -602,6 +619,9 @@ class Settings(BaseSettings):
                 )
         else:
             raise ValueError("Configure runtime authentication via A2A_STATIC_AUTH_CREDENTIALS")
+        normalized_protocol_version = normalize_protocol_version(self.a2a_protocol_version)
+        if normalized_protocol_version not in self.a2a_supported_protocol_versions:
+            raise ValueError("A2A_SUPPORTED_PROTOCOL_VERSIONS must include A2A_PROTOCOL_VERSION")
         if "a2a_database_url" not in self.model_fields_set and self.a2a_database_url is None:
             self.a2a_database_url = _default_a2a_database_url(
                 workspace_root=self.codex_workspace_root

--- a/src/codex_a2a/contracts/extensions.py
+++ b/src/codex_a2a/contracts/extensions.py
@@ -15,6 +15,12 @@ from codex_a2a.contracts.runtime_output import (
 from codex_a2a.execution.request_overrides import request_execution_options_fields
 from codex_a2a.execution.tool_call_payloads import build_tool_call_payload_contract_params
 from codex_a2a.profile.runtime import RuntimeProfile
+from codex_a2a.protocol_versions import (
+    build_protocol_compatibility_summary,
+    default_supported_protocol_versions,
+    normalize_protocol_version,
+    normalize_protocol_versions,
+)
 
 COMPATIBILITY_PROFILE_EXTENSION_URI = "urn:codex-a2a:compatibility-profile/v1"
 WIRE_CONTRACT_EXTENSION_URI = "urn:codex-a2a:wire-contract/v1"
@@ -981,7 +987,19 @@ def build_wire_contract_extension_params(
     *,
     protocol_version: str,
     runtime_profile: RuntimeProfile,
+    supported_protocol_versions: tuple[str, ...] | list[str] | None = None,
+    default_protocol_version: str | None = None,
 ) -> dict[str, Any]:
+    declared_default_protocol_version = normalize_protocol_version(
+        default_protocol_version or protocol_version
+    )
+    declared_supported_protocol_versions = normalize_protocol_versions(
+        supported_protocol_versions or default_supported_protocol_versions(protocol_version)
+    )
+    protocol_compatibility = build_protocol_compatibility_summary(
+        default_protocol_version=declared_default_protocol_version,
+        supported_protocol_versions=declared_supported_protocol_versions,
+    )
     snapshot = build_capability_snapshot(runtime_profile=runtime_profile)
     resubscribe_behavior = {
         "scope": "service-level",
@@ -1002,6 +1020,9 @@ def build_wire_contract_extension_params(
     }
     return {
         "protocol_version": protocol_version,
+        "default_protocol_version": declared_default_protocol_version,
+        "supported_protocol_versions": list(declared_supported_protocol_versions),
+        "protocol_compatibility": protocol_compatibility,
         "preferred_transport": "HTTP+JSON",
         "additional_transports": ["JSON-RPC"],
         "core": {
@@ -1040,7 +1061,19 @@ def build_compatibility_profile_params(
     *,
     protocol_version: str,
     runtime_profile: RuntimeProfile,
+    supported_protocol_versions: tuple[str, ...] | list[str] | None = None,
+    default_protocol_version: str | None = None,
 ) -> dict[str, Any]:
+    declared_default_protocol_version = normalize_protocol_version(
+        default_protocol_version or protocol_version
+    )
+    declared_supported_protocol_versions = normalize_protocol_versions(
+        supported_protocol_versions or default_supported_protocol_versions(protocol_version)
+    )
+    protocol_compatibility = build_protocol_compatibility_summary(
+        default_protocol_version=declared_default_protocol_version,
+        supported_protocol_versions=declared_supported_protocol_versions,
+    )
     snapshot = build_capability_snapshot(runtime_profile=runtime_profile)
     resubscribe_behavior = {
         "scope": "service-level",
@@ -1226,6 +1259,9 @@ def build_compatibility_profile_params(
     return {
         "profile_id": runtime_profile.profile_id,
         "protocol_version": protocol_version,
+        "default_protocol_version": declared_default_protocol_version,
+        "supported_protocol_versions": list(declared_supported_protocol_versions),
+        "protocol_compatibility": protocol_compatibility,
         "deployment": runtime_profile.deployment.as_dict(),
         "runtime_features": runtime_profile.runtime_features_dict(),
         "core": {
@@ -1317,6 +1353,10 @@ def build_compatibility_profile_params(
             (
                 "Treat this service's terminal tasks/resubscribe replay-once behavior as a "
                 "declared service-level contract rather than a generic A2A baseline promise."
+            ),
+            (
+                "Treat protocol_compatibility as the runtime truth for which protocol "
+                "line is supported today versus reserved for future compatibility work."
             ),
         ],
     }

--- a/src/codex_a2a/execution/discovery_runtime.py
+++ b/src/codex_a2a/execution/discovery_runtime.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any
 from a2a.types import DataPart, Task, TaskState, TaskStatus
 
 from codex_a2a.execution.output_mapping import build_assistant_message, enqueue_artifact_update
+from codex_a2a.execution.watch_events import normalize_watch_event_filter
 
 logger = logging.getLogger(__name__)
 
@@ -46,7 +47,11 @@ class CodexDiscoveryRuntime:
         request: dict[str, Any] | None,
         context: ServerCallContext | None,
     ) -> dict[str, Any]:
-        events = self._normalize_events(request)
+        events = normalize_watch_event_filter(
+            request,
+            supported_events=SUPPORTED_DISCOVERY_EVENTS,
+            allowed_events=sorted(SUPPORTED_DISCOVERY_EVENTS),
+        )
         task_id = str(uuid.uuid4())
         context_id = task_id
         handle = DiscoveryWatchHandle(
@@ -85,22 +90,6 @@ class CodexDiscoveryRuntime:
             producer=lambda event_queue: self._run_watch(handle=handle, event_queue=event_queue),
         )
         return {"ok": True, "task_id": task_id, "context_id": context_id}
-
-    def _normalize_events(self, request: dict[str, Any] | None) -> frozenset[str]:
-        if not isinstance(request, dict):
-            return SUPPORTED_DISCOVERY_EVENTS
-        raw_events = request.get("events")
-        if raw_events is None:
-            return SUPPORTED_DISCOVERY_EVENTS
-        if not isinstance(raw_events, list) or not raw_events:
-            raise ValueError("request.events must be a non-empty array")
-        events: set[str] = set()
-        for item in raw_events:
-            if not isinstance(item, str) or item not in SUPPORTED_DISCOVERY_EVENTS:
-                allowed = ", ".join(sorted(SUPPORTED_DISCOVERY_EVENTS))
-                raise ValueError(f"request.events entries must be one of: {allowed}")
-            events.add(item)
-        return frozenset(events)
 
     async def _run_watch(self, *, handle: DiscoveryWatchHandle, event_queue) -> None:  # noqa: ANN001
         append = False

--- a/src/codex_a2a/execution/review_runtime.py
+++ b/src/codex_a2a/execution/review_runtime.py
@@ -10,6 +10,7 @@ from a2a.types import DataPart, Task, TaskState, TaskStatus, TaskStatusUpdateEve
 
 from codex_a2a.contracts.extensions import REVIEW_CONTROL_SUPPORTED_EVENTS
 from codex_a2a.execution.output_mapping import build_assistant_message, enqueue_artifact_update
+from codex_a2a.execution.watch_events import normalize_watch_event_filter
 
 logger = logging.getLogger(__name__)
 
@@ -53,7 +54,10 @@ class CodexReviewRuntime:
         request: dict[str, Any] | None,
         context: ServerCallContext | None,
     ) -> dict[str, Any]:
-        events = self._normalize_events(request)
+        events = normalize_watch_event_filter(
+            request,
+            supported_events=REVIEW_CONTROL_SUPPORTED_EVENTS,
+        )
         task_id = str(uuid.uuid4())
         context_id = task_id
         handle = ReviewWatchHandle(
@@ -98,22 +102,6 @@ class CodexReviewRuntime:
             producer=lambda event_queue: self._run_watch(handle=handle, event_queue=event_queue),
         )
         return {"ok": True, "task_id": task_id, "context_id": context_id}
-
-    def _normalize_events(self, request: dict[str, Any] | None) -> frozenset[str]:
-        if not isinstance(request, dict):
-            return frozenset(REVIEW_CONTROL_SUPPORTED_EVENTS)
-        raw_events = request.get("events")
-        if raw_events is None:
-            return frozenset(REVIEW_CONTROL_SUPPORTED_EVENTS)
-        if not isinstance(raw_events, list) or not raw_events:
-            raise ValueError("request.events must be a non-empty array")
-        normalized: set[str] = set()
-        for item in raw_events:
-            if not isinstance(item, str) or item not in REVIEW_CONTROL_SUPPORTED_EVENTS:
-                allowed = ", ".join(REVIEW_CONTROL_SUPPORTED_EVENTS)
-                raise ValueError(f"request.events entries must be one of: {allowed}")
-            normalized.add(item)
-        return frozenset(normalized)
 
     async def _run_watch(self, *, handle: ReviewWatchHandle, event_queue) -> None:  # noqa: ANN001
         append = False

--- a/src/codex_a2a/execution/stream_interrupts.py
+++ b/src/codex_a2a/execution/stream_interrupts.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any
 
+from codex_a2a import payload_helpers
 from codex_a2a.upstream.interrupts import resolve_permission_interrupt_semantic
 
 _INTERRUPT_ASKED_EVENT_TYPES = {
@@ -21,54 +22,9 @@ _INTERRUPT_RESOLVED_EVENT_TYPES = {
 }
 
 
-def _normalized_string(value: Any) -> str | None:
-    if not isinstance(value, str):
-        return None
-    normalized = value.strip()
-    return normalized or None
-
-
-def _mapping_value(value: Any) -> Mapping[str, Any] | None:
-    if isinstance(value, Mapping):
-        return value
-    return None
-
-
-def _nested_value(root: Mapping[str, Any], *path: str) -> Any:
-    current: Any = root
-    for key in path:
-        if not isinstance(current, Mapping):
-            return None
-        current = current.get(key)
-    return current
-
-
-def _first_nested_string(root: Mapping[str, Any], *paths: tuple[str, ...]) -> str | None:
-    for path in paths:
-        value = _normalized_string(_nested_value(root, *path))
-        if value is not None:
-            return value
-    return None
-
-
-def extract_string_list(value: Any) -> list[str]:
-    if not isinstance(value, list):
-        return []
-    result: list[str] = []
-    seen: set[str] = set()
-    for item in value:
-        if not isinstance(item, str):
-            continue
-        normalized = item.strip()
-        if normalized and normalized not in seen:
-            seen.add(normalized)
-            result.append(normalized)
-    return result
-
-
 def extract_interrupt_text_details(props: Mapping[str, Any]) -> dict[str, Any]:
     details: dict[str, Any] = {}
-    display_message = _first_nested_string(
+    display_message = payload_helpers.first_nested_string(
         props,
         ("display_message",),
         ("message",),
@@ -91,41 +47,45 @@ def extract_interrupt_text_details(props: Mapping[str, Any]) -> dict[str, Any]:
 
 
 def extract_interrupt_questions(props: Mapping[str, Any]) -> list[Any]:
-    questions = _nested_value(props, "questions")
+    questions = payload_helpers.nested_value(props, "questions")
     if isinstance(questions, list):
         return questions
-    nested_questions = _nested_value(props, "context", "questions")
+    nested_questions = payload_helpers.nested_value(props, "context", "questions")
     if isinstance(nested_questions, list):
         return nested_questions
-    raw_questions = _nested_value(props, "metadata", "raw", "questions")
+    raw_questions = payload_helpers.nested_value(props, "metadata", "raw", "questions")
     if isinstance(raw_questions, list):
         return raw_questions
-    raw_nested_questions = _nested_value(props, "metadata", "raw", "context", "questions")
+    raw_nested_questions = payload_helpers.nested_value(
+        props, "metadata", "raw", "context", "questions"
+    )
     if isinstance(raw_nested_questions, list):
         return raw_nested_questions
     return []
 
 
 def extract_interrupt_permissions(props: Mapping[str, Any]) -> dict[str, Any] | None:
-    permissions = _nested_value(props, "permissions")
+    permissions = payload_helpers.nested_value(props, "permissions")
     if isinstance(permissions, Mapping):
         return dict(permissions)
-    raw_permissions = _nested_value(props, "metadata", "raw", "permissions")
+    raw_permissions = payload_helpers.nested_value(props, "metadata", "raw", "permissions")
     if isinstance(raw_permissions, Mapping):
         return dict(raw_permissions)
     return None
 
 
 def extract_interrupt_patterns(props: Mapping[str, Any]) -> list[str]:
-    patterns = extract_string_list(_nested_value(props, "patterns"))
+    patterns = payload_helpers.string_list(payload_helpers.nested_value(props, "patterns"))
     if patterns:
         return patterns
 
-    raw_patterns = extract_string_list(_nested_value(props, "metadata", "raw", "patterns"))
+    raw_patterns = payload_helpers.string_list(
+        payload_helpers.nested_value(props, "metadata", "raw", "patterns")
+    )
     if raw_patterns:
         return raw_patterns
 
-    fallback_path = _first_nested_string(
+    fallback_path = payload_helpers.first_nested_string(
         props,
         ("metadata", "path"),
         ("path",),
@@ -134,17 +94,17 @@ def extract_interrupt_patterns(props: Mapping[str, Any]) -> list[str]:
     if fallback_path is not None:
         return [fallback_path]
 
-    parsed_cmd = _nested_value(props, "metadata", "raw", "parsedCmd")
+    parsed_cmd = payload_helpers.nested_value(props, "metadata", "raw", "parsedCmd")
     if not isinstance(parsed_cmd, list):
         return []
 
     resolved_patterns: list[str] = []
     seen: set[str] = set()
     for entry in parsed_cmd:
-        mapping = _mapping_value(entry)
+        mapping = payload_helpers.mapping_value(entry)
         if mapping is None:
             continue
-        path = _normalized_string(mapping.get("path"))
+        path = payload_helpers.normalized_string(mapping.get("path"))
         if path is None or path in seen:
             continue
         seen.add(path)
@@ -191,12 +151,12 @@ def extract_interrupt_asked_event(event: Mapping[str, Any]) -> dict[str, Any] | 
     if not normalized_request_id:
         return None
     if event_type == "permission.asked":
-        permission = _first_nested_string(
+        permission = payload_helpers.first_nested_string(
             props,
             ("permission",),
             ("metadata", "raw", "permission"),
         ) or resolve_permission_interrupt_semantic(
-            _first_nested_string(
+            payload_helpers.first_nested_string(
                 props,
                 ("metadata", "method"),
             )
@@ -204,8 +164,10 @@ def extract_interrupt_asked_event(event: Mapping[str, Any]) -> dict[str, Any] | 
         details: dict[str, Any] = {
             "permission": permission,
             "patterns": extract_interrupt_patterns(props),
-            "always": extract_string_list(_nested_value(props, "always"))
-            or extract_string_list(_nested_value(props, "metadata", "raw", "always")),
+            "always": payload_helpers.string_list(payload_helpers.nested_value(props, "always"))
+            or payload_helpers.string_list(
+                payload_helpers.nested_value(props, "metadata", "raw", "always")
+            ),
         }
         details.update(extract_interrupt_text_details(props))
         return {
@@ -223,30 +185,32 @@ def extract_interrupt_asked_event(event: Mapping[str, Any]) -> dict[str, Any] | 
         }
     if event_type == "elicitation.asked":
         details = {
-            "server_name": _first_nested_string(
+            "server_name": payload_helpers.first_nested_string(
                 props,
                 ("server_name",),
                 ("metadata", "raw", "serverName"),
             ),
-            "mode": _first_nested_string(
+            "mode": payload_helpers.first_nested_string(
                 props,
                 ("mode",),
                 ("metadata", "raw", "mode"),
             ),
-            "requested_schema": _nested_value(props, "requested_schema")
-            or _nested_value(props, "metadata", "raw", "requestedSchema"),
-            "url": _first_nested_string(
+            "requested_schema": payload_helpers.nested_value(props, "requested_schema")
+            or payload_helpers.nested_value(props, "metadata", "raw", "requestedSchema"),
+            "url": payload_helpers.first_nested_string(
                 props,
                 ("url",),
                 ("metadata", "raw", "url"),
             ),
-            "elicitation_id": _first_nested_string(
+            "elicitation_id": payload_helpers.first_nested_string(
                 props,
                 ("elicitation_id",),
                 ("metadata", "raw", "elicitationId"),
             ),
         }
-        meta = _nested_value(props, "meta") or _nested_value(props, "metadata", "raw", "_meta")
+        meta = payload_helpers.nested_value(props, "meta") or payload_helpers.nested_value(
+            props, "metadata", "raw", "_meta"
+        )
         if isinstance(meta, Mapping):
             details["meta"] = dict(meta)
         details.update(extract_interrupt_text_details(props))

--- a/src/codex_a2a/execution/thread_lifecycle_runtime.py
+++ b/src/codex_a2a/execution/thread_lifecycle_runtime.py
@@ -21,6 +21,7 @@ from a2a.utils.errors import ServerError
 
 from codex_a2a.contracts.extensions import THREAD_LIFECYCLE_SUPPORTED_EVENTS
 from codex_a2a.execution.output_mapping import build_assistant_message, enqueue_artifact_update
+from codex_a2a.execution.watch_events import normalize_watch_event_filter
 
 logger = logging.getLogger(__name__)
 
@@ -78,7 +79,10 @@ class CodexThreadLifecycleRuntime:
         request: dict[str, Any] | None,
         context: ServerCallContext | None,
     ) -> dict[str, Any]:
-        events = self._normalize_events(request)
+        events = normalize_watch_event_filter(
+            request,
+            supported_events=THREAD_LIFECYCLE_SUPPORTED_EVENTS,
+        )
         thread_ids = self._normalize_thread_ids(request)
         task_id = str(uuid.uuid4())
         context_id = task_id
@@ -185,22 +189,6 @@ class CodexThreadLifecycleRuntime:
                 watch_id=owner.watch_id,
                 release_reason="restart_reconcile",
             )
-
-    def _normalize_events(self, request: dict[str, Any] | None) -> frozenset[str]:
-        if not isinstance(request, dict):
-            return frozenset(THREAD_LIFECYCLE_SUPPORTED_EVENTS)
-        raw_events = request.get("events")
-        if raw_events is None:
-            return frozenset(THREAD_LIFECYCLE_SUPPORTED_EVENTS)
-        if not isinstance(raw_events, list) or not raw_events:
-            raise ValueError("request.events must be a non-empty array")
-        normalized: set[str] = set()
-        for item in raw_events:
-            if not isinstance(item, str) or item not in THREAD_LIFECYCLE_SUPPORTED_EVENTS:
-                allowed = ", ".join(THREAD_LIFECYCLE_SUPPORTED_EVENTS)
-                raise ValueError(f"request.events entries must be one of: {allowed}")
-            normalized.add(item)
-        return frozenset(normalized)
 
     def _normalize_thread_ids(self, request: dict[str, Any] | None) -> frozenset[str] | None:
         if not isinstance(request, dict):

--- a/src/codex_a2a/execution/watch_events.py
+++ b/src/codex_a2a/execution/watch_events.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+
+def normalize_watch_event_filter(
+    request: dict[str, Any] | None,
+    *,
+    supported_events: Iterable[str],
+    allowed_events: Iterable[str] | None = None,
+    field_name: str = "request.events",
+) -> frozenset[str]:
+    supported = tuple(supported_events)
+    supported_lookup = frozenset(supported)
+    if allowed_events is None:
+        allowed = supported
+    else:
+        allowed = tuple(allowed_events)
+
+    if not isinstance(request, dict):
+        return supported_lookup
+    raw_events = request.get("events")
+    if raw_events is None:
+        return supported_lookup
+    if not isinstance(raw_events, list) or not raw_events:
+        raise ValueError(f"{field_name} must be a non-empty array")
+
+    normalized: set[str] = set()
+    for item in raw_events:
+        if not isinstance(item, str) or item not in supported_lookup:
+            allowed_message = ", ".join(allowed)
+            raise ValueError(f"{field_name} entries must be one of: {allowed_message}")
+        normalized.add(item)
+    return frozenset(normalized)

--- a/src/codex_a2a/jsonrpc/application.py
+++ b/src/codex_a2a/jsonrpc/application.py
@@ -21,6 +21,7 @@ from codex_a2a.execution.thread_lifecycle_runtime import CodexThreadLifecycleRun
 from codex_a2a.jsonrpc.discovery_control import handle_discovery_control_request
 from codex_a2a.jsonrpc.discovery_query import handle_discovery_query_request
 from codex_a2a.jsonrpc.dispatch import ExtensionMethodRegistry
+from codex_a2a.jsonrpc.errors import adapt_jsonrpc_error_for_protocol
 from codex_a2a.jsonrpc.exec_control import handle_exec_control_request
 from codex_a2a.jsonrpc.hooks import SessionGuardHooks
 from codex_a2a.jsonrpc.interrupt_recovery import handle_interrupt_recovery_request
@@ -30,6 +31,7 @@ from codex_a2a.jsonrpc.session_control import handle_session_control_request
 from codex_a2a.jsonrpc.session_query import handle_session_query_request
 from codex_a2a.jsonrpc.thread_lifecycle_control import handle_thread_lifecycle_control_request
 from codex_a2a.jsonrpc.turn_control import handle_turn_control_request
+from codex_a2a.protocol_versions import get_current_protocol_version
 from codex_a2a.upstream.client import CodexClient
 
 
@@ -219,6 +221,7 @@ class CodexSessionQueryJSONRPCApplication(A2AFastAPIApplication):
         request_id: str | int,
         method: str,
     ) -> JSONResponse:
+        protocol_version = get_current_protocol_version(self._protocol_version)
         return self._generate_error_response(
             request_id,
             JSONRPCError(
@@ -228,9 +231,20 @@ class CodexSessionQueryJSONRPCApplication(A2AFastAPIApplication):
                     "type": "METHOD_NOT_SUPPORTED",
                     "method": method,
                     "supported_methods": self._supported_methods,
-                    "protocol_version": self._protocol_version,
+                    "protocol_version": protocol_version,
                 },
             ),
+        )
+
+    def _generate_error_response(
+        self,
+        request_id: str | int | None,
+        error: JSONRPCError | A2AError,
+    ) -> JSONResponse:
+        protocol_version = get_current_protocol_version(self._protocol_version)
+        return super()._generate_error_response(
+            request_id,
+            adapt_jsonrpc_error_for_protocol(protocol_version, error),
         )
 
     def _jsonrpc_success_response(self, request_id: str | int, result: Any) -> JSONResponse:

--- a/src/codex_a2a/jsonrpc/application.py
+++ b/src/codex_a2a/jsonrpc/application.py
@@ -76,9 +76,6 @@ class CodexSessionQueryJSONRPCApplication(A2AFastAPIApplication):
         self._method_thread_metadata_update = methods["thread_metadata_update"]
         self._method_thread_watch = methods["thread_watch"]
         self._method_thread_watch_release = methods["thread_watch_release"]
-        self._method_interrupts_list = methods.get("interrupts_list")
-        self._method_turn_steer = methods.get("turn_steer")
-        self._method_review_start = methods.get("review_start")
         self._method_review_watch = methods.get("review_watch")
         self._method_exec_start = methods.get("exec_start")
         self._method_exec_write = methods.get("exec_write")

--- a/src/codex_a2a/jsonrpc/control_params.py
+++ b/src/codex_a2a/jsonrpc/control_params.py
@@ -11,6 +11,7 @@ from codex_a2a.jsonrpc.params_common import (
     _StrictModel,
     format_loc,
     map_extra_forbidden,
+    metadata_validation_error,
     normalize_non_empty_string,
     strip_optional_string,
 )
@@ -397,37 +398,8 @@ def _raise_control_validation_error(exc: ValidationError) -> None:
             message="request.process_id must be a non-empty string",
             data={"type": "INVALID_FIELD", "field": "request.process_id"},
         )
-    if loc == ("metadata",):
-        raise JsonRpcParamsValidationError(
-            message="metadata must be an object",
-            data={"type": "INVALID_FIELD", "field": "metadata"},
-        )
-    if loc == ("metadata", "codex"):
-        raise JsonRpcParamsValidationError(
-            message="metadata.codex must be an object",
-            data={"type": "INVALID_FIELD", "field": "metadata.codex"},
-        )
-    if loc == ("metadata", "codex", "directory"):
-        raise JsonRpcParamsValidationError(
-            message="metadata.codex.directory must be a string",
-            data={"type": "INVALID_FIELD", "field": "metadata.codex.directory"},
-        )
-    if loc == ("metadata", "codex", "execution"):
-        raise JsonRpcParamsValidationError(
-            message="metadata.codex.execution must be an object",
-            data={"type": "INVALID_FIELD", "field": "metadata.codex.execution"},
-        )
-    if loc in {
-        ("metadata", "codex", "execution", "model"),
-        ("metadata", "codex", "execution", "effort"),
-        ("metadata", "codex", "execution", "summary"),
-        ("metadata", "codex", "execution", "personality"),
-    }:
-        field = format_loc(loc)
-        raise JsonRpcParamsValidationError(
-            message=message_text,
-            data={"type": "INVALID_FIELD", "field": field},
-        )
+    if (metadata_error := metadata_validation_error(loc, message_text=message_text)) is not None:
+        raise metadata_error
     if loc in {
         ("request", "arguments"),
         ("request", "messageID"),

--- a/src/codex_a2a/jsonrpc/discovery_payload_mapping.py
+++ b/src/codex_a2a/jsonrpc/discovery_payload_mapping.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from codex_a2a.upstream.discovery_payloads import normalize_app_items
+
 
 def _normalized_interface(value: Any) -> dict[str, Any] | None:
     if not isinstance(value, dict):
@@ -71,32 +73,9 @@ def map_apps_list(raw_result: Any) -> tuple[list[dict[str, Any]], str | None]:
     data = raw_result.get("data")
     if not isinstance(data, list):
         raise ValueError("app/list payload missing data array")
-    items: list[dict[str, Any]] = []
-    for app in data:
-        if not isinstance(app, dict):
-            continue
-        app_id = app.get("id")
-        name = app.get("name")
-        if not isinstance(app_id, str) or not app_id.strip():
-            continue
-        if not isinstance(name, str) or not name.strip():
-            continue
-        items.append(
-            {
-                "id": app_id.strip(),
-                "name": name.strip(),
-                "description": app.get("description"),
-                "is_accessible": bool(app.get("isAccessible", False)),
-                "is_enabled": bool(app.get("isEnabled", False)),
-                "install_url": app.get("installUrl"),
-                "mention_path": f"app://{app_id.strip()}",
-                "branding": app.get("branding"),
-                "labels": app.get("labels"),
-                "codex": {"raw": app},
-            }
-        )
     next_cursor = raw_result.get("nextCursor")
-    return items, next_cursor if isinstance(next_cursor, str) and next_cursor else None
+    normalized_cursor = next_cursor if isinstance(next_cursor, str) and next_cursor else None
+    return normalize_app_items(data), normalized_cursor
 
 
 def map_plugin_marketplaces(raw_result: Any) -> dict[str, Any]:

--- a/src/codex_a2a/jsonrpc/discovery_query.py
+++ b/src/codex_a2a/jsonrpc/discovery_query.py
@@ -20,10 +20,10 @@ from codex_a2a.jsonrpc.discovery_payload_mapping import (
     map_skill_scopes,
 )
 from codex_a2a.jsonrpc.errors import (
-    ERR_UPSTREAM_HTTP_ERROR,
     ERR_UPSTREAM_PAYLOAD_ERROR,
-    ERR_UPSTREAM_UNREACHABLE,
     invalid_params_response,
+    upstream_http_error_response,
+    upstream_unreachable_response,
 )
 from codex_a2a.jsonrpc.params import JsonRpcParamsValidationError
 
@@ -59,29 +59,17 @@ async def handle_discovery_query_request(
     except JsonRpcParamsValidationError as exc:
         return invalid_params_response(app, base_request.id, exc)
     except httpx.HTTPStatusError as exc:
-        return app._generate_error_response(
+        return upstream_http_error_response(
+            app,
             base_request.id,
-            JSONRPCError(
-                code=ERR_UPSTREAM_HTTP_ERROR,
-                message="Upstream Codex error",
-                data={
-                    "type": "UPSTREAM_HTTP_ERROR",
-                    "method": base_request.method,
-                    "upstream_status": exc.response.status_code,
-                },
-            ),
+            upstream_status=exc.response.status_code,
+            data={"method": base_request.method},
         )
     except httpx.HTTPError:
-        return app._generate_error_response(
+        return upstream_unreachable_response(
+            app,
             base_request.id,
-            JSONRPCError(
-                code=ERR_UPSTREAM_UNREACHABLE,
-                message="Upstream Codex unreachable",
-                data={
-                    "type": "UPSTREAM_UNREACHABLE",
-                    "method": base_request.method,
-                },
-            ),
+            data={"method": base_request.method},
         )
     except ValueError as exc:
         logger.warning("Upstream Codex discovery payload mismatch: %s", exc)

--- a/src/codex_a2a/jsonrpc/errors.py
+++ b/src/codex_a2a/jsonrpc/errors.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any
 
@@ -7,6 +8,7 @@ from a2a.types import A2AError, InvalidParamsError, JSONRPCError
 from starlette.responses import Response
 
 from codex_a2a.jsonrpc.params import JsonRpcParamsValidationError
+from codex_a2a.protocol_versions import normalize_protocol_version
 
 if TYPE_CHECKING:
     from codex_a2a.jsonrpc.application import CodexSessionQueryJSONRPCApplication
@@ -20,6 +22,195 @@ ERR_INTERRUPT_NOT_FOUND = -32004
 ERR_UPSTREAM_PAYLOAD_ERROR = -32005
 ERR_INTERRUPT_EXPIRED = -32007
 ERR_INTERRUPT_TYPE_MISMATCH = -32008
+A2A_ERROR_DOMAIN = "a2a-protocol.org"
+GOOGLE_RPC_ERROR_INFO_TYPE = "type.googleapis.com/google.rpc.ErrorInfo"
+STANDARD_JSONRPC_ERROR_MESSAGES = {
+    -32700: "Invalid JSON payload",
+    -32600: "Request payload validation error",
+    -32601: "Method not found",
+    -32602: "Invalid parameters",
+    -32603: "Internal error",
+}
+STANDARD_JSONRPC_ERROR_CODES = frozenset(STANDARD_JSONRPC_ERROR_MESSAGES)
+
+
+def protocol_uses_v1_error_format(protocol_version: str | None) -> bool:
+    if protocol_version is None:
+        return False
+    return normalize_protocol_version(protocol_version).startswith("1.")
+
+
+def _to_upper_snake_case(name: str) -> str:
+    normalized: list[str] = []
+    previous_was_lower = False
+    for char in name:
+        if char.isupper() and previous_was_lower:
+            normalized.append("_")
+        if char in {" ", "-"}:
+            normalized.append("_")
+            previous_was_lower = False
+            continue
+        normalized.append(char.upper())
+        previous_was_lower = char.islower()
+    return "".join(normalized).strip("_")
+
+
+def _to_lower_camel_case(name: str) -> str:
+    if "_" not in name:
+        return name
+    head, *tail = [part for part in name.split("_") if part]
+    return head + "".join(part[:1].upper() + part[1:] for part in tail)
+
+
+def _camelize(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {_to_lower_camel_case(str(key)): _camelize(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_camelize(item) for item in value]
+    return value
+
+
+def _stringify_metadata_value(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, bool | int | float):
+        return str(value)
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+
+
+def _build_error_info_detail(
+    *,
+    reason: str,
+    metadata: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "@type": GOOGLE_RPC_ERROR_INFO_TYPE,
+        "reason": _to_upper_snake_case(reason),
+        "domain": A2A_ERROR_DOMAIN,
+    }
+    if metadata:
+        payload["metadata"] = {
+            _to_lower_camel_case(str(key)): _stringify_metadata_value(value)
+            for key, value in metadata.items()
+            if value is not None
+        }
+    return payload
+
+
+def _build_context_detail(type_name: str, payload: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "@type": f"type.googleapis.com/codex_a2a.{type_name}",
+        **_camelize(dict(payload)),
+    }
+
+
+def _reason_from_error(error: object) -> str | None:
+    data = getattr(error, "data", None)
+    if isinstance(data, Mapping):
+        data_type = data.get("type")
+        if isinstance(data_type, str) and data_type.strip():
+            return data_type
+    class_name = type(error).__name__
+    if class_name.endswith("Error") and class_name != "JSONRPCError":
+        return class_name[:-5]
+    return None
+
+
+def _metadata_from_error(error: object) -> dict[str, Any]:
+    data = getattr(error, "data", None)
+    if not isinstance(data, Mapping):
+        return {}
+    return {str(key): value for key, value in data.items() if key != "type"}
+
+
+def adapt_jsonrpc_error_for_protocol(
+    protocol_version: str,
+    error: JSONRPCError | A2AError,
+) -> JSONRPCError | A2AError:
+    if not protocol_uses_v1_error_format(protocol_version):
+        return error
+
+    root_error = error.root if isinstance(error, A2AError) else error
+    root_data = getattr(root_error, "data", None)
+
+    if root_error.code in STANDARD_JSONRPC_ERROR_CODES:
+        adapted_data = None
+        if isinstance(root_data, Mapping):
+            adapted_data = _camelize(
+                {str(key): value for key, value in root_data.items() if key != "type"}
+            )
+        elif root_data is not None:
+            adapted_data = root_data
+        return JSONRPCError(
+            code=root_error.code,
+            message=STANDARD_JSONRPC_ERROR_MESSAGES[root_error.code],
+            data=adapted_data,
+        )
+
+    reason = _reason_from_error(root_error)
+    metadata = _metadata_from_error(root_error)
+    details: list[dict[str, Any]] = []
+    if reason is not None:
+        details.append(_build_error_info_detail(reason=reason, metadata=metadata))
+    if metadata:
+        details.append(_build_context_detail("ErrorContext", metadata))
+
+    message = root_error.message
+    if message is None:
+        message = STANDARD_JSONRPC_ERROR_MESSAGES.get(root_error.code, "Internal error")
+
+    return JSONRPCError(
+        code=root_error.code,
+        message=message,
+        data=details or None,
+    )
+
+
+def build_http_error_body(
+    *,
+    protocol_version: str,
+    status_code: int,
+    status: str,
+    message: str,
+    legacy_payload: dict[str, Any],
+    reason: str | None = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    if not protocol_uses_v1_error_format(protocol_version):
+        return legacy_payload
+
+    details: list[dict[str, Any]] = []
+    if reason is not None:
+        details.append(_build_error_info_detail(reason=reason, metadata=metadata))
+    if metadata:
+        details.append(_build_context_detail("HttpErrorContext", dict(metadata)))
+
+    error_payload: dict[str, Any] = {
+        "code": status_code,
+        "status": status,
+        "message": message,
+    }
+    if details:
+        error_payload["details"] = details
+    return {"error": error_payload}
+
+
+def version_not_supported_error(
+    *,
+    requested_version: str,
+    supported_protocol_versions: list[str],
+    default_protocol_version: str,
+) -> JSONRPCError:
+    return JSONRPCError(
+        code=-32001,
+        message=f"Unsupported A2A version: {requested_version}",
+        data={
+            "type": "VERSION_NOT_SUPPORTED",
+            "requested_version": requested_version,
+            "supported_protocol_versions": supported_protocol_versions,
+            "default_protocol_version": default_protocol_version,
+        },
+    )
 
 
 def interrupt_expected_type(

--- a/src/codex_a2a/jsonrpc/errors.py
+++ b/src/codex_a2a/jsonrpc/errors.py
@@ -304,6 +304,21 @@ def extract_directory_from_metadata(
         )
 
 
+def extract_directory_from_params_metadata(
+    app: CodexSessionQueryJSONRPCApplication,
+    *,
+    request_id: str | int | None,
+    metadata: Any,
+) -> tuple[str | None, Response | None]:
+    codex_metadata = getattr(metadata, "codex", None)
+    directory = getattr(codex_metadata, "directory", None) if codex_metadata is not None else None
+    return extract_directory_from_metadata(
+        app,
+        request_id=request_id,
+        directory=directory,
+    )
+
+
 def interrupt_error_response(
     app: CodexSessionQueryJSONRPCApplication,
     request_id: str | int | None,

--- a/src/codex_a2a/jsonrpc/errors.py
+++ b/src/codex_a2a/jsonrpc/errors.py
@@ -280,6 +280,46 @@ def authorization_forbidden_response(
     )
 
 
+def upstream_http_error_response(
+    app: CodexSessionQueryJSONRPCApplication,
+    request_id: str | int | None,
+    *,
+    upstream_status: int,
+    data: Mapping[str, Any] | None = None,
+) -> Response:
+    payload: dict[str, Any] = {"type": "UPSTREAM_HTTP_ERROR"}
+    if data is not None:
+        payload.update(data)
+    payload["upstream_status"] = upstream_status
+    return app._generate_error_response(
+        request_id,
+        JSONRPCError(
+            code=ERR_UPSTREAM_HTTP_ERROR,
+            message="Upstream Codex error",
+            data=payload,
+        ),
+    )
+
+
+def upstream_unreachable_response(
+    app: CodexSessionQueryJSONRPCApplication,
+    request_id: str | int | None,
+    *,
+    data: Mapping[str, Any] | None = None,
+) -> Response:
+    payload: dict[str, Any] = {"type": "UPSTREAM_UNREACHABLE"}
+    if data is not None:
+        payload.update(data)
+    return app._generate_error_response(
+        request_id,
+        JSONRPCError(
+            code=ERR_UPSTREAM_UNREACHABLE,
+            message="Upstream Codex unreachable",
+            data=payload,
+        ),
+    )
+
+
 def extract_directory_from_metadata(
     app: CodexSessionQueryJSONRPCApplication,
     *,

--- a/src/codex_a2a/jsonrpc/exec_control.py
+++ b/src/codex_a2a/jsonrpc/exec_control.py
@@ -17,7 +17,7 @@ from codex_a2a.jsonrpc.errors import (
     ERR_UPSTREAM_HTTP_ERROR,
     ERR_UPSTREAM_UNREACHABLE,
     authorization_forbidden_response,
-    extract_directory_from_metadata,
+    extract_directory_from_params_metadata,
     invalid_params_response,
 )
 from codex_a2a.jsonrpc.params import (
@@ -67,14 +67,10 @@ async def handle_exec_control_request(
     except JsonRpcParamsValidationError as exc:
         return invalid_params_response(app, base_request.id, exc)
 
-    directory, metadata_error = extract_directory_from_metadata(
+    directory, metadata_error = extract_directory_from_params_metadata(
         app,
         request_id=base_request.id,
-        directory=(
-            parsed_params.metadata.codex.directory
-            if parsed_params.metadata is not None and parsed_params.metadata.codex is not None
-            else None
-        ),
+        metadata=parsed_params.metadata,
     )
     if metadata_error is not None:
         return metadata_error

--- a/src/codex_a2a/jsonrpc/exec_control.py
+++ b/src/codex_a2a/jsonrpc/exec_control.py
@@ -14,11 +14,11 @@ from codex_a2a.auth import (
     request_has_capability,
 )
 from codex_a2a.jsonrpc.errors import (
-    ERR_UPSTREAM_HTTP_ERROR,
-    ERR_UPSTREAM_UNREACHABLE,
     authorization_forbidden_response,
     extract_directory_from_params_metadata,
     invalid_params_response,
+    upstream_http_error_response,
+    upstream_unreachable_response,
 )
 from codex_a2a.jsonrpc.params import (
     ExecResizeControlParams,
@@ -164,29 +164,19 @@ async def handle_exec_control_request(
             A2AError(root=InternalError(message=str(exc))),
         )
     except httpx.HTTPStatusError as exc:
-        return app._generate_error_response(
+        process_id = str(request_payload.get("processId", "")).strip()
+        return upstream_http_error_response(
+            app,
             base_request.id,
-            JSONRPCError(
-                code=ERR_UPSTREAM_HTTP_ERROR,
-                message="Upstream Codex error",
-                data={
-                    "type": "UPSTREAM_HTTP_ERROR",
-                    "upstream_status": exc.response.status_code,
-                    "process_id": str(request_payload.get("processId", "")).strip(),
-                },
-            ),
+            upstream_status=exc.response.status_code,
+            data={"process_id": process_id},
         )
     except httpx.HTTPError:
-        return app._generate_error_response(
+        process_id = str(request_payload.get("processId", "")).strip()
+        return upstream_unreachable_response(
+            app,
             base_request.id,
-            JSONRPCError(
-                code=ERR_UPSTREAM_UNREACHABLE,
-                message="Upstream Codex unreachable",
-                data={
-                    "type": "UPSTREAM_UNREACHABLE",
-                    "process_id": str(request_payload.get("processId", "")).strip(),
-                },
-            ),
+            data={"process_id": process_id},
         )
     except Exception as exc:
         logger.exception("Codex exec JSON-RPC method failed")

--- a/src/codex_a2a/jsonrpc/interrupt_params.py
+++ b/src/codex_a2a/jsonrpc/interrupt_params.py
@@ -10,6 +10,7 @@ from codex_a2a.jsonrpc.params_common import (
     _StrictModel,
     format_loc,
     map_extra_forbidden,
+    metadata_validation_error,
     normalize_non_empty_string,
     strip_optional_string,
 )
@@ -205,21 +206,8 @@ def _raise_interrupt_validation_error(exc: ValidationError) -> None:
             message="content must be null when action is decline or cancel",
             data={"type": "INVALID_FIELD", "field": "content"},
         )
-    if loc == ("metadata",):
-        raise JsonRpcParamsValidationError(
-            message="metadata must be an object",
-            data={"type": "INVALID_FIELD", "field": "metadata"},
-        )
-    if loc == ("metadata", "codex"):
-        raise JsonRpcParamsValidationError(
-            message="metadata.codex must be an object",
-            data={"type": "INVALID_FIELD", "field": "metadata.codex"},
-        )
-    if loc == ("metadata", "codex", "directory"):
-        raise JsonRpcParamsValidationError(
-            message="metadata.codex.directory must be a string",
-            data={"type": "INVALID_FIELD", "field": "metadata.codex.directory"},
-        )
+    if (metadata_error := metadata_validation_error(loc)) is not None:
+        raise metadata_error
     if loc:
         raise JsonRpcParamsValidationError(
             message=str(first.get("msg", "Invalid params")).removeprefix("Value error, "),

--- a/src/codex_a2a/jsonrpc/interrupts.py
+++ b/src/codex_a2a/jsonrpc/interrupts.py
@@ -12,7 +12,7 @@ from codex_a2a.jsonrpc.errors import (
     ERR_INTERRUPT_NOT_FOUND,
     ERR_UPSTREAM_HTTP_ERROR,
     ERR_UPSTREAM_UNREACHABLE,
-    extract_directory_from_metadata,
+    extract_directory_from_params_metadata,
     interrupt_error_response,
     interrupt_expected_type,
     invalid_params_response,
@@ -72,14 +72,10 @@ async def handle_interrupt_callback_request(
         return invalid_params_response(app, base_request.id, exc)
 
     request_id = parsed_params.request_id
-    directory, metadata_error = extract_directory_from_metadata(
+    directory, metadata_error = extract_directory_from_params_metadata(
         app,
         request_id=base_request.id,
-        directory=(
-            parsed_params.metadata.codex.directory
-            if parsed_params.metadata is not None and parsed_params.metadata.codex is not None
-            else None
-        ),
+        metadata=parsed_params.metadata,
     )
     if metadata_error is not None:
         return metadata_error

--- a/src/codex_a2a/jsonrpc/interrupts.py
+++ b/src/codex_a2a/jsonrpc/interrupts.py
@@ -4,18 +4,18 @@ import logging
 from typing import TYPE_CHECKING, cast
 
 import httpx
-from a2a.types import A2AError, InternalError, JSONRPCError, JSONRPCRequest
+from a2a.types import A2AError, InternalError, JSONRPCRequest
 from starlette.requests import Request
 from starlette.responses import Response
 
 from codex_a2a.jsonrpc.errors import (
     ERR_INTERRUPT_NOT_FOUND,
-    ERR_UPSTREAM_HTTP_ERROR,
-    ERR_UPSTREAM_UNREACHABLE,
     extract_directory_from_params_metadata,
     interrupt_error_response,
     interrupt_expected_type,
     invalid_params_response,
+    upstream_http_error_response,
+    upstream_unreachable_response,
 )
 from codex_a2a.jsonrpc.interrupt_lifecycle import (
     interrupt_error_from_exception,
@@ -177,26 +177,17 @@ async def handle_interrupt_callback_request(
                 message="Interrupt request not found",
                 data={"type": "INTERRUPT_REQUEST_NOT_FOUND", "request_id": request_id},
             )
-        return app._generate_error_response(
+        return upstream_http_error_response(
+            app,
             base_request.id,
-            JSONRPCError(
-                code=ERR_UPSTREAM_HTTP_ERROR,
-                message="Upstream Codex error",
-                data={
-                    "type": "UPSTREAM_HTTP_ERROR",
-                    "upstream_status": upstream_status,
-                    "request_id": request_id,
-                },
-            ),
+            upstream_status=upstream_status,
+            data={"request_id": request_id},
         )
     except httpx.HTTPError:
-        return app._generate_error_response(
+        return upstream_unreachable_response(
+            app,
             base_request.id,
-            JSONRPCError(
-                code=ERR_UPSTREAM_UNREACHABLE,
-                message="Upstream Codex unreachable",
-                data={"type": "UPSTREAM_UNREACHABLE", "request_id": request_id},
-            ),
+            data={"request_id": request_id},
         )
     except Exception as exc:
         logger.exception("Codex interrupt callback JSON-RPC method failed")

--- a/src/codex_a2a/jsonrpc/owner_guard.py
+++ b/src/codex_a2a/jsonrpc/owner_guard.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from a2a.types import JSONRPCError
+from starlette.requests import Request
+from starlette.responses import Response
+
+if TYPE_CHECKING:
+    from codex_a2a.jsonrpc.application import CodexSessionQueryJSONRPCApplication
+
+
+async def validate_thread_owner(
+    app: CodexSessionQueryJSONRPCApplication,
+    *,
+    request: Request,
+    request_id: str | int | None,
+    thread_id: str,
+    error_code: int,
+    error_message: str,
+    error_type: str,
+) -> Response | None:
+    identity = getattr(request.state, "user_identity", None)
+    if (
+        not isinstance(identity, str)
+        or not identity
+        or app._guard_hooks.session_owner_matcher is None
+    ):
+        return None
+    owned = await app._guard_hooks.session_owner_matcher(identity=identity, session_id=thread_id)
+    if owned is False:
+        return app._generate_error_response(
+            request_id,
+            JSONRPCError(
+                code=error_code,
+                message=error_message,
+                data={"type": error_type, "thread_id": thread_id},
+            ),
+        )
+    return None

--- a/src/codex_a2a/jsonrpc/params_common.py
+++ b/src/codex_a2a/jsonrpc/params_common.py
@@ -122,6 +122,45 @@ def map_extra_forbidden(errors: Sequence[Mapping[str, Any]]) -> JsonRpcParamsVal
     )
 
 
+def metadata_validation_error(
+    loc: tuple[Any, ...],
+    *,
+    message_text: str | None = None,
+) -> JsonRpcParamsValidationError | None:
+    metadata_errors = {
+        ("metadata",): ("metadata must be an object", "metadata"),
+        ("metadata", "codex"): ("metadata.codex must be an object", "metadata.codex"),
+        (
+            "metadata",
+            "codex",
+            "directory",
+        ): ("metadata.codex.directory must be a string", "metadata.codex.directory"),
+        (
+            "metadata",
+            "codex",
+            "execution",
+        ): ("metadata.codex.execution must be an object", "metadata.codex.execution"),
+    }
+    mapped_error = metadata_errors.get(loc)
+    if mapped_error is not None:
+        message, field = mapped_error
+        return JsonRpcParamsValidationError(
+            message=message,
+            data={"type": "INVALID_FIELD", "field": field},
+        )
+    if loc in {
+        ("metadata", "codex", "execution", "model"),
+        ("metadata", "codex", "execution", "effort"),
+        ("metadata", "codex", "execution", "summary"),
+        ("metadata", "codex", "execution", "personality"),
+    }:
+        return JsonRpcParamsValidationError(
+            message=message_text or "Invalid params",
+            data={"type": "INVALID_FIELD", "field": format_loc(loc)},
+        )
+    return None
+
+
 class CodexExecutionMetadataParams(_StrictModel):
     model: str | None = None
     effort: str | None = None

--- a/src/codex_a2a/jsonrpc/review_control.py
+++ b/src/codex_a2a/jsonrpc/review_control.py
@@ -8,6 +8,7 @@ from starlette.requests import Request
 from starlette.responses import Response
 
 from codex_a2a.jsonrpc.errors import invalid_params_response
+from codex_a2a.jsonrpc.owner_guard import validate_thread_owner
 from codex_a2a.jsonrpc.params import (
     JsonRpcParamsValidationError,
     ReviewStartControlParams,
@@ -44,24 +45,17 @@ async def handle_review_control_request(
         return invalid_params_response(app, base_request.id, exc)
 
     thread_id = parsed_params.thread_id
-    identity = getattr(request.state, "user_identity", None)
-    if (
-        isinstance(identity, str)
-        and identity
-        and app._guard_hooks.session_owner_matcher is not None
-    ):
-        owned = await app._guard_hooks.session_owner_matcher(
-            identity=identity, session_id=thread_id
-        )
-        if owned is False:
-            return app._generate_error_response(
-                base_request.id,
-                JSONRPCError(
-                    code=ERR_REVIEW_FORBIDDEN,
-                    message="Review forbidden",
-                    data={"type": "REVIEW_FORBIDDEN", "thread_id": thread_id},
-                ),
-            )
+    owner_error = await validate_thread_owner(
+        app,
+        request=request,
+        request_id=base_request.id,
+        thread_id=thread_id,
+        error_code=ERR_REVIEW_FORBIDDEN,
+        error_message="Review forbidden",
+        error_type="REVIEW_FORBIDDEN",
+    )
+    if owner_error is not None:
+        return owner_error
 
     try:
         if base_request.method == app._method_review_watch:

--- a/src/codex_a2a/jsonrpc/session_control.py
+++ b/src/codex_a2a/jsonrpc/session_control.py
@@ -18,7 +18,7 @@ from codex_a2a.jsonrpc.errors import (
     ERR_UPSTREAM_HTTP_ERROR,
     ERR_UPSTREAM_UNREACHABLE,
     authorization_forbidden_response,
-    extract_directory_from_metadata,
+    extract_directory_from_params_metadata,
     invalid_params_response,
     session_forbidden_response,
 )
@@ -71,14 +71,10 @@ async def handle_session_control_request(
         and parsed_params.metadata.codex.execution is not None
     ):
         execution_options = parsed_params.metadata.codex.execution.to_execution_options()
-    directory, metadata_error = extract_directory_from_metadata(
+    directory, metadata_error = extract_directory_from_params_metadata(
         app,
         request_id=base_request.id,
-        directory=(
-            parsed_params.metadata.codex.directory
-            if parsed_params.metadata is not None and parsed_params.metadata.codex is not None
-            else None
-        ),
+        metadata=parsed_params.metadata,
     )
     if metadata_error is not None:
         return metadata_error

--- a/src/codex_a2a/jsonrpc/session_control.py
+++ b/src/codex_a2a/jsonrpc/session_control.py
@@ -15,12 +15,12 @@ from codex_a2a.auth import (
 )
 from codex_a2a.jsonrpc.errors import (
     ERR_SESSION_NOT_FOUND,
-    ERR_UPSTREAM_HTTP_ERROR,
-    ERR_UPSTREAM_UNREACHABLE,
     authorization_forbidden_response,
     extract_directory_from_params_metadata,
     invalid_params_response,
     session_forbidden_response,
+    upstream_http_error_response,
+    upstream_unreachable_response,
 )
 from codex_a2a.jsonrpc.params import (
     CommandControlParams,
@@ -163,26 +163,17 @@ async def handle_session_control_request(
                     data={"type": "SESSION_NOT_FOUND", "session_id": session_id},
                 ),
             )
-        return app._generate_error_response(
+        return upstream_http_error_response(
+            app,
             base_request.id,
-            JSONRPCError(
-                code=ERR_UPSTREAM_HTTP_ERROR,
-                message="Upstream Codex error",
-                data={
-                    "type": "UPSTREAM_HTTP_ERROR",
-                    "upstream_status": upstream_status,
-                    "session_id": session_id,
-                },
-            ),
+            upstream_status=upstream_status,
+            data={"session_id": session_id},
         )
     except httpx.HTTPError:
-        return app._generate_error_response(
+        return upstream_unreachable_response(
+            app,
             base_request.id,
-            JSONRPCError(
-                code=ERR_UPSTREAM_UNREACHABLE,
-                message="Upstream Codex unreachable",
-                data={"type": "UPSTREAM_UNREACHABLE", "session_id": session_id},
-            ),
+            data={"session_id": session_id},
         )
     except CodexRPCError as exc:
         if is_thread_not_found_error(exc):

--- a/src/codex_a2a/jsonrpc/session_query.py
+++ b/src/codex_a2a/jsonrpc/session_query.py
@@ -9,10 +9,10 @@ from starlette.responses import Response
 
 from codex_a2a.jsonrpc.errors import (
     ERR_SESSION_NOT_FOUND,
-    ERR_UPSTREAM_HTTP_ERROR,
     ERR_UPSTREAM_PAYLOAD_ERROR,
-    ERR_UPSTREAM_UNREACHABLE,
     invalid_params_response,
+    upstream_http_error_response,
+    upstream_unreachable_response,
 )
 from codex_a2a.jsonrpc.params import (
     JsonRpcParamsValidationError,
@@ -62,25 +62,15 @@ async def handle_session_query_request(
                     data={"type": "SESSION_NOT_FOUND", "session_id": session_id},
                 ),
             )
-        return app._generate_error_response(
+        return upstream_http_error_response(
+            app,
             base_request.id,
-            JSONRPCError(
-                code=ERR_UPSTREAM_HTTP_ERROR,
-                message="Upstream Codex error",
-                data={
-                    "type": "UPSTREAM_HTTP_ERROR",
-                    "upstream_status": upstream_status,
-                },
-            ),
+            upstream_status=upstream_status,
         )
     except httpx.HTTPError:
-        return app._generate_error_response(
+        return upstream_unreachable_response(
+            app,
             base_request.id,
-            JSONRPCError(
-                code=ERR_UPSTREAM_UNREACHABLE,
-                message="Upstream Codex unreachable",
-                data={"type": "UPSTREAM_UNREACHABLE"},
-            ),
         )
     except CodexRPCError as exc:
         if is_thread_not_found_error(exc) and session_id is not None:

--- a/src/codex_a2a/jsonrpc/thread_lifecycle_control.py
+++ b/src/codex_a2a/jsonrpc/thread_lifecycle_control.py
@@ -13,6 +13,7 @@ from codex_a2a.jsonrpc.errors import (
     ERR_UPSTREAM_UNREACHABLE,
     invalid_params_response,
 )
+from codex_a2a.jsonrpc.owner_guard import validate_thread_owner
 from codex_a2a.jsonrpc.params import (
     JsonRpcParamsValidationError,
     ThreadArchiveControlParams,
@@ -38,33 +39,6 @@ ERR_THREAD_NOT_FOUND = -32010
 ERR_THREAD_FORBIDDEN = -32011
 ERR_WATCH_NOT_FOUND = -32014
 ERR_WATCH_FORBIDDEN = -32015
-
-
-async def _validate_thread_owner(
-    app: CodexSessionQueryJSONRPCApplication,
-    *,
-    request: Request,
-    request_id: str | int | None,
-    thread_id: str,
-) -> Response | None:
-    identity = getattr(request.state, "user_identity", None)
-    if (
-        not isinstance(identity, str)
-        or not identity
-        or app._guard_hooks.session_owner_matcher is None
-    ):
-        return None
-    owned = await app._guard_hooks.session_owner_matcher(identity=identity, session_id=thread_id)
-    if owned is False:
-        return app._generate_error_response(
-            request_id,
-            JSONRPCError(
-                code=ERR_THREAD_FORBIDDEN,
-                message="Thread forbidden",
-                data={"type": "THREAD_FORBIDDEN", "thread_id": thread_id},
-            ),
-        )
-    return None
 
 
 def _thread_not_found_response(
@@ -139,11 +113,14 @@ async def handle_thread_lifecycle_control_request(
         return invalid_params_response(app, base_request.id, exc)
 
     if thread_id is not None:
-        owner_error = await _validate_thread_owner(
+        owner_error = await validate_thread_owner(
             app,
             request=request,
             request_id=base_request.id,
             thread_id=thread_id,
+            error_code=ERR_THREAD_FORBIDDEN,
+            error_message="Thread forbidden",
+            error_type="THREAD_FORBIDDEN",
         )
         if owner_error is not None:
             return owner_error

--- a/src/codex_a2a/jsonrpc/thread_lifecycle_control.py
+++ b/src/codex_a2a/jsonrpc/thread_lifecycle_control.py
@@ -9,9 +9,9 @@ from starlette.requests import Request
 from starlette.responses import Response
 
 from codex_a2a.jsonrpc.errors import (
-    ERR_UPSTREAM_HTTP_ERROR,
-    ERR_UPSTREAM_UNREACHABLE,
     invalid_params_response,
+    upstream_http_error_response,
+    upstream_unreachable_response,
 )
 from codex_a2a.jsonrpc.owner_guard import validate_thread_owner
 from codex_a2a.jsonrpc.params import (
@@ -199,31 +199,17 @@ async def handle_thread_lifecycle_control_request(
         upstream_status = exc.response.status_code
         if upstream_status == 404 and thread_id is not None:
             return _thread_not_found_response(app, base_request.id, thread_id=thread_id)
-        return app._generate_error_response(
+        return upstream_http_error_response(
+            app,
             base_request.id,
-            JSONRPCError(
-                code=ERR_UPSTREAM_HTTP_ERROR,
-                message="Upstream Codex error",
-                data={
-                    "type": "UPSTREAM_HTTP_ERROR",
-                    "thread_id": thread_id,
-                    "upstream_status": upstream_status,
-                    "method": base_request.method,
-                },
-            ),
+            upstream_status=upstream_status,
+            data={"thread_id": thread_id, "method": base_request.method},
         )
     except httpx.HTTPError:
-        return app._generate_error_response(
+        return upstream_unreachable_response(
+            app,
             base_request.id,
-            JSONRPCError(
-                code=ERR_UPSTREAM_UNREACHABLE,
-                message="Upstream Codex unreachable",
-                data={
-                    "type": "UPSTREAM_UNREACHABLE",
-                    "thread_id": thread_id,
-                    "method": base_request.method,
-                },
-            ),
+            data={"thread_id": thread_id, "method": base_request.method},
         )
     except LookupError:
         assert task_id is not None

--- a/src/codex_a2a/jsonrpc/thread_lifecycle_params.py
+++ b/src/codex_a2a/jsonrpc/thread_lifecycle_params.py
@@ -11,6 +11,7 @@ from codex_a2a.jsonrpc.params_common import (
     _StrictModel,
     format_loc,
     map_extra_forbidden,
+    metadata_validation_error,
     normalize_non_empty_string,
     strip_optional_string,
 )
@@ -184,21 +185,8 @@ def _raise_thread_lifecycle_validation_error(exc: ValidationError) -> None:
             message="params.request must be an object",
             data={"type": "INVALID_FIELD", "field": "request"},
         )
-    if loc == ("metadata",):
-        raise JsonRpcParamsValidationError(
-            message="metadata must be an object",
-            data={"type": "INVALID_FIELD", "field": "metadata"},
-        )
-    if loc == ("metadata", "codex"):
-        raise JsonRpcParamsValidationError(
-            message="metadata.codex must be an object",
-            data={"type": "INVALID_FIELD", "field": "metadata.codex"},
-        )
-    if loc == ("metadata", "codex", "directory"):
-        raise JsonRpcParamsValidationError(
-            message="metadata.codex.directory must be a string",
-            data={"type": "INVALID_FIELD", "field": "metadata.codex.directory"},
-        )
+    if (metadata_error := metadata_validation_error(loc)) is not None:
+        raise metadata_error
     if message_text == "request.git_info must include at least one field":
         raise JsonRpcParamsValidationError(
             message=message_text,

--- a/src/codex_a2a/jsonrpc/turn_control.py
+++ b/src/codex_a2a/jsonrpc/turn_control.py
@@ -16,6 +16,7 @@ from codex_a2a.jsonrpc.errors import (
     authorization_forbidden_response,
     invalid_params_response,
 )
+from codex_a2a.jsonrpc.owner_guard import validate_thread_owner
 from codex_a2a.jsonrpc.params import (
     JsonRpcParamsValidationError,
     TurnSteerControlParams,
@@ -62,23 +63,17 @@ async def handle_turn_control_request(
             credential_id=credential_id if isinstance(credential_id, str) else None,
             required_principal=OPERATOR_PRINCIPAL,
         )
-    if (
-        isinstance(identity, str)
-        and identity
-        and app._guard_hooks.session_owner_matcher is not None
-    ):
-        owned = await app._guard_hooks.session_owner_matcher(
-            identity=identity, session_id=thread_id
-        )
-        if owned is False:
-            return app._generate_error_response(
-                base_request.id,
-                JSONRPCError(
-                    code=ERR_TURN_FORBIDDEN,
-                    message="Turn forbidden",
-                    data={"type": "TURN_FORBIDDEN", "thread_id": thread_id},
-                ),
-            )
+    owner_error = await validate_thread_owner(
+        app,
+        request=request,
+        request_id=base_request.id,
+        thread_id=thread_id,
+        error_code=ERR_TURN_FORBIDDEN,
+        error_message="Turn forbidden",
+        error_type="TURN_FORBIDDEN",
+    )
+    if owner_error is not None:
+        return owner_error
 
     try:
         result = await app._codex_client.turn_steer(

--- a/src/codex_a2a/payload_helpers.py
+++ b/src/codex_a2a/payload_helpers.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+
+def normalized_string(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    return normalized or None
+
+
+def mapping_value(value: Any) -> Mapping[str, Any] | None:
+    if isinstance(value, Mapping):
+        return value
+    return None
+
+
+def nested_value(root: Mapping[str, Any], *path: str) -> Any:
+    current: Any = root
+    for key in path:
+        if not isinstance(current, Mapping):
+            return None
+        current = current.get(key)
+    return current
+
+
+def first_nested_string(root: Mapping[str, Any], *paths: tuple[str, ...]) -> str | None:
+    for path in paths:
+        value = normalized_string(nested_value(root, *path))
+        if value is not None:
+            return value
+    return None
+
+
+def first_string(payload: Mapping[str, Any], *keys: str) -> str | None:
+    return first_nested_string(payload, *((key,) for key in keys))
+
+
+def string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    result: list[str] = []
+    seen: set[str] = set()
+    for item in value:
+        normalized = normalized_string(item)
+        if normalized is None or normalized in seen:
+            continue
+        seen.add(normalized)
+        result.append(normalized)
+    return result

--- a/src/codex_a2a/protocol_versions.py
+++ b/src/codex_a2a/protocol_versions.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+from typing import Any
+
+_PROTOCOL_VERSION_PATTERN = re.compile(r"^(?P<major>\d+)\.(?P<minor>\d+)(?:\.\d+)?$")
+
+V1_COMPATIBILITY_GAPS: tuple[str, ...] = (
+    "Request-time A2A-Version negotiation is not implemented yet.",
+    "JSON-RPC method aliases and transport payloads still follow the SDK-owned 0.3 baseline.",
+)
+
+
+def normalize_protocol_version(value: str) -> str:
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError("Protocol version must be a non-empty string.")
+    match = _PROTOCOL_VERSION_PATTERN.fullmatch(normalized)
+    if match is None:
+        raise ValueError("Protocol version must use Major.Minor or Major.Minor.Patch format.")
+    return f"{match.group('major')}.{match.group('minor')}"
+
+
+def normalize_protocol_versions(values: Iterable[str]) -> tuple[str, ...]:
+    normalized_versions: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        normalized = normalize_protocol_version(str(value))
+        if normalized in seen:
+            continue
+        seen.add(normalized)
+        normalized_versions.append(normalized)
+    if not normalized_versions:
+        raise ValueError("At least one supported protocol version must be declared.")
+    return tuple(normalized_versions)
+
+
+def default_supported_protocol_versions(protocol_version: str) -> tuple[str, ...]:
+    return (normalize_protocol_version(protocol_version),)
+
+
+def build_protocol_compatibility_summary(
+    *,
+    default_protocol_version: str,
+    supported_protocol_versions: Iterable[str],
+) -> dict[str, Any]:
+    normalized_default = normalize_protocol_version(default_protocol_version)
+    normalized_supported = normalize_protocol_versions(supported_protocol_versions)
+    versions: dict[str, dict[str, Any]] = {
+        "0.3": {
+            "enabled": "0.3" in normalized_supported,
+            "default": normalized_default == "0.3",
+            "status": "supported",
+            "supported_features": [
+                "Default compatibility line for the current SDK baseline.",
+                "SDK-owned JSON-RPC and HTTP+JSON method surface.",
+                "SDK-owned transport payloads, enums, pagination, and push-notification surfaces.",
+            ],
+            "known_gaps": [],
+        },
+        "1.0": {
+            "enabled": "1.0" in normalized_supported,
+            "default": normalized_default == "1.0",
+            "status": "future" if "1.0" not in normalized_supported else "partial",
+            "supported_features": [],
+            "known_gaps": list(V1_COMPATIBILITY_GAPS),
+        },
+    }
+
+    for version in normalized_supported:
+        if version in versions:
+            continue
+        versions[version] = {
+            "enabled": True,
+            "default": normalized_default == version,
+            "status": "custom",
+            "supported_features": [
+                "Declared by repository configuration.",
+                "Version-specific compatibility details are not yet modeled.",
+            ],
+            "known_gaps": [
+                "This protocol line does not yet have a dedicated compatibility summary.",
+            ],
+        }
+
+    return {
+        "default_protocol_version": normalized_default,
+        "supported_protocol_versions": list(normalized_supported),
+        "versions": versions,
+    }

--- a/src/codex_a2a/protocol_versions.py
+++ b/src/codex_a2a/protocol_versions.py
@@ -2,14 +2,47 @@ from __future__ import annotations
 
 import re
 from collections.abc import Iterable
+from contextvars import ContextVar, Token
+from dataclasses import dataclass
 from typing import Any
 
 _PROTOCOL_VERSION_PATTERN = re.compile(r"^(?P<major>\d+)\.(?P<minor>\d+)(?:\.\d+)?$")
+_CURRENT_PROTOCOL_VERSION: ContextVar[str | None] = ContextVar(
+    "_CURRENT_PROTOCOL_VERSION",
+    default=None,
+)
 
 V1_COMPATIBILITY_GAPS: tuple[str, ...] = (
-    "Request-time A2A-Version negotiation is not implemented yet.",
-    "JSON-RPC method aliases and transport payloads still follow the SDK-owned 0.3 baseline.",
+    (
+        "Transport payloads, enums, pagination, and push-notification surfaces still "
+        "follow the SDK-owned 0.3 baseline."
+    ),
 )
+
+
+class UnsupportedProtocolVersionError(ValueError):
+    def __init__(
+        self,
+        requested_version: str,
+        *,
+        supported_protocol_versions: tuple[str, ...],
+        default_protocol_version: str,
+    ) -> None:
+        self.requested_version = requested_version
+        self.supported_protocol_versions = supported_protocol_versions
+        self.default_protocol_version = default_protocol_version
+        supported_display = ", ".join(supported_protocol_versions)
+        super().__init__(
+            f"Unsupported A2A protocol version {requested_version!r}. "
+            f"Supported versions: {supported_display}."
+        )
+
+
+@dataclass(frozen=True)
+class NegotiatedProtocolVersion:
+    requested_version: str
+    negotiated_version: str
+    explicit: bool
 
 
 def normalize_protocol_version(value: str) -> str:
@@ -37,7 +70,63 @@ def normalize_protocol_versions(values: Iterable[str]) -> tuple[str, ...]:
 
 
 def default_supported_protocol_versions(protocol_version: str) -> tuple[str, ...]:
-    return (normalize_protocol_version(protocol_version),)
+    normalized = normalize_protocol_version(protocol_version)
+    if normalized == "0.3":
+        return ("0.3", "1.0")
+    return (normalized,)
+
+
+def negotiate_protocol_version(
+    *,
+    header_value: str | None,
+    query_value: str | None,
+    default_protocol_version: str,
+    supported_protocol_versions: Iterable[str],
+) -> NegotiatedProtocolVersion:
+    normalized_default = normalize_protocol_version(default_protocol_version)
+    normalized_supported = normalize_protocol_versions(supported_protocol_versions)
+
+    raw_header = (header_value or "").strip()
+    raw_query = (query_value or "").strip()
+    explicit = bool(raw_header or raw_query)
+    raw_requested = raw_header or raw_query or normalized_default
+
+    try:
+        normalized_requested = normalize_protocol_version(raw_requested)
+    except ValueError as exc:
+        raise UnsupportedProtocolVersionError(
+            raw_requested,
+            supported_protocol_versions=normalized_supported,
+            default_protocol_version=normalized_default,
+        ) from exc
+
+    if normalized_requested not in normalized_supported:
+        raise UnsupportedProtocolVersionError(
+            normalized_requested,
+            supported_protocol_versions=normalized_supported,
+            default_protocol_version=normalized_default,
+        )
+
+    return NegotiatedProtocolVersion(
+        requested_version=normalized_requested,
+        negotiated_version=normalized_requested,
+        explicit=explicit,
+    )
+
+
+def set_current_protocol_version(protocol_version: str) -> Token[str | None]:
+    return _CURRENT_PROTOCOL_VERSION.set(normalize_protocol_version(protocol_version))
+
+
+def reset_current_protocol_version(token: Token[str | None]) -> None:
+    _CURRENT_PROTOCOL_VERSION.reset(token)
+
+
+def get_current_protocol_version(default: str) -> str:
+    protocol_version = _CURRENT_PROTOCOL_VERSION.get()
+    if protocol_version:
+        return protocol_version
+    return normalize_protocol_version(default)
 
 
 def build_protocol_compatibility_summary(
@@ -63,7 +152,15 @@ def build_protocol_compatibility_summary(
             "enabled": "1.0" in normalized_supported,
             "default": normalized_default == "1.0",
             "status": "future" if "1.0" not in normalized_supported else "partial",
-            "supported_features": [],
+            "supported_features": (
+                [
+                    "A2A-Version request-time negotiation and response header echo.",
+                    "PascalCase JSON-RPC method aliases for the current SDK-backed method surface.",
+                    "Protocol-aware JSON-RPC and HTTP error shaping.",
+                ]
+                if "1.0" in normalized_supported
+                else []
+            ),
             "known_gaps": list(V1_COMPATIBILITY_GAPS),
         },
     }

--- a/src/codex_a2a/server/agent_card.py
+++ b/src/codex_a2a/server/agent_card.py
@@ -213,10 +213,14 @@ def _build_agent_extensions(
     )
     wire_contract_extension_params = build_wire_contract_extension_params(
         protocol_version=settings.a2a_protocol_version,
+        supported_protocol_versions=settings.a2a_supported_protocol_versions,
+        default_protocol_version=settings.a2a_protocol_version,
         runtime_profile=runtime_profile,
     )
     compatibility_profile_params = build_compatibility_profile_params(
         protocol_version=settings.a2a_protocol_version,
+        supported_protocol_versions=settings.a2a_supported_protocol_versions,
+        default_protocol_version=settings.a2a_protocol_version,
         runtime_profile=runtime_profile,
     )
 

--- a/src/codex_a2a/server/http_middlewares.py
+++ b/src/codex_a2a/server/http_middlewares.py
@@ -4,9 +4,11 @@ import hashlib
 import json
 import logging
 import time
+from typing import cast
 from urllib.parse import unquote
 
 from a2a.server.tasks.task_store import TaskStore
+from a2a.types import JSONRPCError
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from starlette.datastructures import Headers
@@ -16,11 +18,23 @@ from starlette.types import ASGIApp, Receive, Scope, Send
 
 from codex_a2a.auth import authenticate_static_credential, build_static_auth_credentials
 from codex_a2a.config import Settings
+from codex_a2a.jsonrpc.errors import (
+    adapt_jsonrpc_error_for_protocol,
+    build_http_error_body,
+    version_not_supported_error,
+)
 from codex_a2a.logging_context import (
     CORRELATION_ID_HEADER,
     reset_correlation_id,
     resolve_correlation_id,
     set_correlation_id,
+)
+from codex_a2a.protocol_versions import (
+    UnsupportedProtocolVersionError,
+    negotiate_protocol_version,
+    normalize_protocol_version,
+    reset_current_protocol_version,
+    set_current_protocol_version,
 )
 from codex_a2a.server.task_store import TaskStoreOperationError, task_store_failure_message
 
@@ -40,6 +54,13 @@ _OPENAPI_PATHS = {
 _REST_MESSAGE_PATHS = {
     "/v1/message:send",
     "/v1/message:stream",
+}
+_V1_JSONRPC_METHOD_ALIASES = {
+    "CancelTask": "tasks/cancel",
+    "GetExtendedAgentCard": "agent/getAuthenticatedExtendedCard",
+    "GetTask": "tasks/get",
+    "SendMessage": "message/send",
+    "SendStreamingMessage": "message/stream",
 }
 GZIP_COMPRESSIBLE_PATHS = (
     _PUBLIC_AGENT_CARD_PATHS | _AUTHENTICATED_EXTENDED_CARD_PATHS | _OPENAPI_PATHS
@@ -204,6 +225,129 @@ def _looks_like_jsonrpc_envelope(payload: dict | None) -> bool:
     return isinstance(method, str) and isinstance(version, str)
 
 
+def _requires_protocol_negotiation(request: Request) -> bool:
+    path = request.url.path
+    return request.method == "POST" and (path == "/" or path.startswith("/v1/"))
+
+
+def _jsonrpc_request_id(payload: dict | None) -> str | int | None:
+    if payload is None:
+        return None
+    request_id = payload.get("id")
+    if isinstance(request_id, bool):
+        return None
+    if isinstance(request_id, str | int):
+        return request_id
+    return None
+
+
+def _requested_protocol_version(request: Request) -> tuple[str | None, str | None]:
+    header_value = request.headers.get("A2A-Version")
+    query_value = request.query_params.get("A2A-Version")
+    if query_value is None:
+        query_value = request.query_params.get("a2a-version")
+    return header_value, query_value
+
+
+def _error_protocol_version(requested_version: str, default_protocol_version: str) -> str:
+    try:
+        return normalize_protocol_version(requested_version)
+    except ValueError:
+        return normalize_protocol_version(default_protocol_version)
+
+
+def _jsonrpc_error_response(
+    *,
+    request_id: str | int | None,
+    protocol_version: str,
+    error: JSONRPCError,
+) -> JSONResponse:
+    adapted_error = adapt_jsonrpc_error_for_protocol(protocol_version, error)
+    if not isinstance(adapted_error, JSONRPCError):  # pragma: no cover - defensive
+        adapted_error = cast(JSONRPCError, adapted_error.root)
+    return JSONResponse(
+        {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "error": adapted_error.model_dump(mode="json", exclude_none=True),
+        },
+        status_code=200,
+    )
+
+
+def _unsupported_protocol_jsonrpc_response(
+    *,
+    request_id: str | int | None,
+    exc: UnsupportedProtocolVersionError,
+) -> JSONResponse:
+    error_protocol_version = _error_protocol_version(
+        exc.requested_version,
+        exc.default_protocol_version,
+    )
+    return _jsonrpc_error_response(
+        request_id=request_id,
+        protocol_version=error_protocol_version,
+        error=version_not_supported_error(
+            requested_version=exc.requested_version,
+            supported_protocol_versions=list(exc.supported_protocol_versions),
+            default_protocol_version=exc.default_protocol_version,
+        ),
+    )
+
+
+def _unsupported_protocol_http_response(exc: UnsupportedProtocolVersionError) -> JSONResponse:
+    metadata = {
+        "requested_version": exc.requested_version,
+        "supported_protocol_versions": list(exc.supported_protocol_versions),
+        "default_protocol_version": exc.default_protocol_version,
+    }
+    protocol_version = _error_protocol_version(
+        exc.requested_version,
+        exc.default_protocol_version,
+    )
+    return JSONResponse(
+        build_http_error_body(
+            protocol_version=protocol_version,
+            status_code=400,
+            status="INVALID_ARGUMENT",
+            message=f"Unsupported A2A version: {exc.requested_version}",
+            reason="VERSION_NOT_SUPPORTED",
+            metadata=metadata,
+            legacy_payload={
+                "error": "Unsupported A2A version",
+                **metadata,
+            },
+        ),
+        status_code=400,
+    )
+
+
+async def _normalize_v1_jsonrpc_method_alias(
+    request: Request,
+    *,
+    protocol_version: str,
+) -> None:
+    if protocol_version != "1.0" or request.method != "POST" or request.url.path != "/":
+        return
+    body = await _get_request_body(request)
+    payload = _parse_json_body(body)
+    if payload is None:
+        return
+    method = payload.get("method")
+    if not isinstance(method, str):
+        return
+    normalized_method = _V1_JSONRPC_METHOD_ALIASES.get(method)
+    if normalized_method is None:
+        return
+    payload = dict(payload)
+    payload["method"] = normalized_method
+    request._body = json.dumps(
+        payload,
+        ensure_ascii=False,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
 def install_http_middlewares(
     app: FastAPI,
     *,
@@ -228,6 +372,45 @@ def install_http_middlewares(
             status_code=401,
             headers={"WWW-Authenticate": ", ".join(challenges)},
         )
+
+    @app.middleware("http")
+    async def negotiate_a2a_protocol(request: Request, call_next):
+        if not _requires_protocol_negotiation(request):
+            return await call_next(request)
+
+        header_value, query_value = _requested_protocol_version(request)
+        try:
+            negotiated = negotiate_protocol_version(
+                header_value=header_value,
+                query_value=query_value,
+                default_protocol_version=settings.a2a_protocol_version,
+                supported_protocol_versions=settings.a2a_supported_protocol_versions,
+            )
+        except UnsupportedProtocolVersionError as exc:
+            request_id: str | int | None = None
+            if request.method == "POST" and request.url.path == "/":
+                request_id = _jsonrpc_request_id(_parse_json_body(await _get_request_body(request)))
+                return _unsupported_protocol_jsonrpc_response(
+                    request_id=request_id,
+                    exc=exc,
+                )
+            return _unsupported_protocol_http_response(exc)
+
+        request.state.a2a_requested_protocol_version = negotiated.requested_version
+        request.state.a2a_protocol_version = negotiated.negotiated_version
+        request.state.a2a_protocol_version_explicit = negotiated.explicit
+        await _normalize_v1_jsonrpc_method_alias(
+            request,
+            protocol_version=negotiated.negotiated_version,
+        )
+
+        token = set_current_protocol_version(negotiated.negotiated_version)
+        try:
+            response = await call_next(request)
+        finally:
+            reset_current_protocol_version(token)
+        response.headers["A2A-Version"] = negotiated.negotiated_version
+        return response
 
     @app.middleware("http")
     async def cache_agent_card_responses(request: Request, call_next):

--- a/src/codex_a2a/server/openapi.py
+++ b/src/codex_a2a/server/openapi.py
@@ -558,10 +558,14 @@ def patch_openapi_contract(
     )
     wire_contract = build_wire_contract_extension_params(
         protocol_version=protocol_version,
+        supported_protocol_versions=settings.a2a_supported_protocol_versions,
+        default_protocol_version=settings.a2a_protocol_version,
         runtime_profile=runtime_profile,
     )
     compatibility_profile = build_compatibility_profile_params(
         protocol_version=protocol_version,
+        supported_protocol_versions=settings.a2a_supported_protocol_versions,
+        default_protocol_version=settings.a2a_protocol_version,
         runtime_profile=runtime_profile,
     )
     original_openapi = app.openapi

--- a/src/codex_a2a/upstream/discovery_payloads.py
+++ b/src/codex_a2a/upstream/discovery_payloads.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def normalize_app_item(app: Any) -> dict[str, Any] | None:
+    if not isinstance(app, dict):
+        return None
+    app_id = app.get("id")
+    name = app.get("name")
+    if not isinstance(app_id, str) or not app_id.strip():
+        return None
+    if not isinstance(name, str) or not name.strip():
+        return None
+    normalized_app_id = app_id.strip()
+    return {
+        "id": normalized_app_id,
+        "name": name.strip(),
+        "description": app.get("description"),
+        "is_accessible": bool(app.get("isAccessible", False)),
+        "is_enabled": bool(app.get("isEnabled", False)),
+        "install_url": app.get("installUrl"),
+        "mention_path": f"app://{normalized_app_id}",
+        "branding": app.get("branding"),
+        "labels": app.get("labels"),
+        "codex": {"raw": app},
+    }
+
+
+def normalize_app_items(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    return [item for app in value if (item := normalize_app_item(app)) is not None]

--- a/src/codex_a2a/upstream/interrupts.py
+++ b/src/codex_a2a/upstream/interrupts.py
@@ -5,6 +5,8 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any
 
+from codex_a2a import payload_helpers
+
 _PERMISSION_INTERRUPT_METHOD_MAP = {
     "item/commandExecution/requestApproval": "command_execution",
     "execCommandApproval": "command_execution",
@@ -13,49 +15,8 @@ _PERMISSION_INTERRUPT_METHOD_MAP = {
 }
 
 
-def _normalized_string(value: Any) -> str | None:
-    if not isinstance(value, str):
-        return None
-    normalized = value.strip()
-    return normalized or None
-
-
-def _mapping_value(value: Any) -> Mapping[str, Any] | None:
-    if isinstance(value, Mapping):
-        return value
-    return None
-
-
-def _first_nested_string(payload: Mapping[str, Any], *paths: tuple[str, ...]) -> str | None:
-    for path in paths:
-        current: Any = payload
-        for key in path:
-            if not isinstance(current, Mapping):
-                break
-            current = current.get(key)
-        else:
-            value = _normalized_string(current)
-            if value is not None:
-                return value
-    return None
-
-
-def _extract_string_list(value: Any) -> list[str]:
-    if not isinstance(value, list):
-        return []
-    values: list[str] = []
-    seen: set[str] = set()
-    for item in value:
-        normalized = _normalized_string(item)
-        if normalized is None or normalized in seen:
-            continue
-        seen.add(normalized)
-        values.append(normalized)
-    return values
-
-
 def _extract_permission_patterns(params: dict[str, Any]) -> list[str]:
-    patterns = _extract_string_list(params.get("patterns"))
+    patterns = payload_helpers.string_list(params.get("patterns"))
     if patterns:
         return patterns
 
@@ -68,7 +29,7 @@ def _extract_permission_patterns(params: dict[str, Any]) -> list[str]:
     for entry in parsed_cmd:
         if not isinstance(entry, Mapping):
             continue
-        path = _normalized_string(entry.get("path"))
+        path = payload_helpers.normalized_string(entry.get("path"))
         if path is None or path in seen:
             continue
         seen.add(path)
@@ -81,21 +42,21 @@ def _extract_question_properties_questions(params: dict[str, Any]) -> list[Any]:
     if isinstance(questions, list):
         return questions
 
-    context = _mapping_value(params.get("context"))
+    context = payload_helpers.mapping_value(params.get("context"))
     if context is not None and isinstance(context.get("questions"), list):
         return context["questions"]
     return []
 
 
 def _extract_mapping(params: dict[str, Any], key: str) -> dict[str, Any] | None:
-    value = _mapping_value(params.get(key))
+    value = payload_helpers.mapping_value(params.get(key))
     if value is None:
         return None
     return dict(value)
 
 
 def resolve_permission_interrupt_semantic(method: str | None) -> str | None:
-    normalized_method = _normalized_string(method)
+    normalized_method = payload_helpers.normalized_string(method)
     if normalized_method is None:
         return None
     return _PERMISSION_INTERRUPT_METHOD_MAP.get(normalized_method)
@@ -154,7 +115,7 @@ def build_codex_permission_interrupt_properties(
         "sessionID": session_id,
         "metadata": {"method": method, "raw": params},
     }
-    display_message = _first_nested_string(
+    display_message = payload_helpers.first_nested_string(
         params,
         ("request", "description"),
         ("description",),
@@ -169,7 +130,7 @@ def build_codex_permission_interrupt_properties(
     patterns = _extract_permission_patterns(params)
     if patterns:
         properties["patterns"] = patterns
-    always = _extract_string_list(params.get("always"))
+    always = payload_helpers.string_list(params.get("always"))
     if always:
         properties["always"] = always
     return properties
@@ -184,7 +145,7 @@ def build_codex_question_interrupt_properties(
         "questions": _extract_question_properties_questions(params),
         "metadata": {"method": method, "raw": params},
     }
-    display_message = _first_nested_string(
+    display_message = payload_helpers.first_nested_string(
         params,
         ("description",),
         ("context", "description"),
@@ -203,7 +164,7 @@ def build_codex_permissions_interrupt_properties(
         "sessionID": session_id,
         "metadata": {"method": method, "raw": params},
     }
-    display_message = _first_nested_string(
+    display_message = payload_helpers.first_nested_string(
         params,
         ("reason",),
         ("description",),
@@ -224,25 +185,25 @@ def build_codex_elicitation_interrupt_properties(
         "sessionID": session_id,
         "metadata": {"method": method, "raw": params},
     }
-    display_message = _first_nested_string(
+    display_message = payload_helpers.first_nested_string(
         params,
         ("message",),
     )
     if display_message is not None:
         properties["display_message"] = display_message
-    server_name = _normalized_string(params.get("serverName"))
+    server_name = payload_helpers.normalized_string(params.get("serverName"))
     if server_name is not None:
         properties["server_name"] = server_name
-    mode = _normalized_string(params.get("mode"))
+    mode = payload_helpers.normalized_string(params.get("mode"))
     if mode is not None:
         properties["mode"] = mode
     requested_schema = _extract_mapping(params, "requestedSchema")
     if requested_schema is not None:
         properties["requested_schema"] = requested_schema
-    url = _normalized_string(params.get("url"))
+    url = payload_helpers.normalized_string(params.get("url"))
     if url is not None:
         properties["url"] = url
-    elicitation_id = _normalized_string(params.get("elicitationId"))
+    elicitation_id = payload_helpers.normalized_string(params.get("elicitationId"))
     if elicitation_id is not None:
         properties["elicitation_id"] = elicitation_id
     meta = _extract_mapping(params, "_meta")

--- a/src/codex_a2a/upstream/notification_mapping.py
+++ b/src/codex_a2a/upstream/notification_mapping.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from codex_a2a import payload_helpers
 from codex_a2a.execution.tool_call_payloads import (
     ToolCallSourceMethod,
     as_tool_call_payload,
@@ -10,28 +11,13 @@ from codex_a2a.execution.tool_call_payloads import (
 )
 
 
-def _normalized_string(value: Any) -> str | None:
-    if not isinstance(value, str):
-        return None
-    normalized = value.strip()
-    return normalized or None
-
-
-def _first_string(payload: dict[str, Any], *keys: str) -> str | None:
-    for key in keys:
-        value = _normalized_string(payload.get(key))
-        if value is not None:
-            return value
-    return None
-
-
 def _extract_tool_status(payload: dict[str, Any]) -> str | None:
-    value = _first_string(payload, "status")
+    value = payload_helpers.first_string(payload, "status")
     if value is not None:
         return value
     state = payload.get("state")
     if isinstance(state, dict):
-        return _first_string(state, "status")
+        return payload_helpers.first_string(state, "status")
     return None
 
 
@@ -39,7 +25,7 @@ def _tool_source_method(method: str) -> ToolCallSourceMethod | None:
     parts = method.split("/")
     if len(parts) < 2:
         return None
-    normalized = _normalized_string(parts[1])
+    normalized = payload_helpers.normalized_string(parts[1])
     if normalized == "commandExecution":
         return "commandExecution"
     if normalized == "fileChange":
@@ -48,19 +34,19 @@ def _tool_source_method(method: str) -> ToolCallSourceMethod | None:
 
 
 def build_tool_call_output_event(method: str, params: dict[str, Any]) -> dict[str, Any] | None:
-    thread_id = _first_string(params, "threadId")
+    thread_id = payload_helpers.first_string(params, "threadId")
     delta = params.get("delta")
     if thread_id is None or not isinstance(delta, str) or delta == "":
         return None
 
-    explicit_call_id = _first_string(params, "callID", "callId", "call_id")
-    item_id = _first_string(params, "itemId")
+    explicit_call_id = payload_helpers.first_string(params, "callID", "callId", "call_id")
+    item_id = payload_helpers.first_string(params, "itemId")
     call_id = explicit_call_id or item_id
     part_id = item_id or call_id
     if part_id is None:
         return None
 
-    tool = _first_string(params, "tool", "name")
+    tool = payload_helpers.first_string(params, "tool", "name")
     status = _extract_tool_status(params)
     source_method = _tool_source_method(method)
     if source_method is None:
@@ -102,7 +88,7 @@ def build_tool_call_output_event(method: str, params: dict[str, Any]) -> dict[st
 
 
 def build_tool_call_state_event(params: dict[str, Any]) -> dict[str, Any] | None:
-    thread_id = _first_string(params, "threadId")
+    thread_id = payload_helpers.first_string(params, "threadId")
     item = params.get("item")
     if thread_id is None or not isinstance(item, dict):
         return None
@@ -111,7 +97,7 @@ def build_tool_call_state_event(params: dict[str, Any]) -> dict[str, Any] | None
     if payload is None:
         return None
 
-    part_id = _first_string(item, "id")
+    part_id = payload_helpers.first_string(item, "id")
     if part_id is None:
         return None
 

--- a/src/codex_a2a/upstream/stream_bridge.py
+++ b/src/codex_a2a/upstream/stream_bridge.py
@@ -6,6 +6,7 @@ import logging
 from collections.abc import AsyncIterator, Awaitable, Callable
 from typing import Any
 
+from codex_a2a.upstream.discovery_payloads import normalize_app_items
 from codex_a2a.upstream.models import _TurnTracker
 from codex_a2a.upstream.notification_mapping import (
     build_tool_call_output_event,
@@ -218,36 +219,10 @@ class CodexStreamEventBridge:
             return
 
         if method == "app/list/updated":
-            raw_items = params.get("data")
-            items: list[dict[str, Any]] = []
-            if isinstance(raw_items, list):
-                for app in raw_items:
-                    if not isinstance(app, dict):
-                        continue
-                    app_id = app.get("id")
-                    name = app.get("name")
-                    if not isinstance(app_id, str) or not app_id.strip():
-                        continue
-                    if not isinstance(name, str) or not name.strip():
-                        continue
-                    items.append(
-                        {
-                            "id": app_id.strip(),
-                            "name": name.strip(),
-                            "description": app.get("description"),
-                            "is_accessible": bool(app.get("isAccessible", False)),
-                            "is_enabled": bool(app.get("isEnabled", False)),
-                            "install_url": app.get("installUrl"),
-                            "mention_path": f"app://{app_id.strip()}",
-                            "branding": app.get("branding"),
-                            "labels": app.get("labels"),
-                            "codex": {"raw": app},
-                        }
-                    )
             await emit(
                 {
                     "type": "discovery.apps.updated",
-                    "properties": {"items": items},
+                    "properties": {"items": normalize_app_items(params.get("data"))},
                 }
             )
             return

--- a/tests/config/test_settings.py
+++ b/tests/config/test_settings.py
@@ -74,6 +74,34 @@ def test_settings_valid():
             == "sqlite+aiosqlite:////tmp/workspace/.codex-a2a/codex-a2a.db"
         )
         assert settings.a2a_version == __version__
+        assert settings.a2a_protocol_version == "0.3.0"
+        assert settings.a2a_supported_protocol_versions == ["0.3", "1.0"]
+
+
+def test_settings_parse_a2a_supported_protocol_versions() -> None:
+    env = {
+        **_registry_env(),
+        "A2A_PROTOCOL_VERSION": "0.3.0",
+        "A2A_SUPPORTED_PROTOCOL_VERSIONS": "0.3.0,1.0,1.0.0",
+    }
+    with mock.patch.dict(os.environ, env, clear=True):
+        settings = Settings.from_env()
+
+    assert settings.a2a_protocol_version == "0.3.0"
+    assert settings.a2a_supported_protocol_versions == ["0.3", "1.0"]
+
+
+def test_settings_reject_supported_protocol_versions_missing_default() -> None:
+    env = {
+        **_registry_env(),
+        "A2A_PROTOCOL_VERSION": "0.3.0",
+        "A2A_SUPPORTED_PROTOCOL_VERSIONS": "1.0",
+    }
+    with mock.patch.dict(os.environ, env, clear=True):
+        with pytest.raises(ValidationError) as excinfo:
+            Settings.from_env()
+
+    assert "A2A_SUPPORTED_PROTOCOL_VERSIONS must include A2A_PROTOCOL_VERSION" in str(excinfo.value)
 
 
 def test_settings_accept_static_auth_registry_without_legacy_credentials() -> None:

--- a/tests/contracts/test_extension_contract_consistency.py
+++ b/tests/contracts/test_extension_contract_consistency.py
@@ -383,8 +383,7 @@ def test_openapi_jsonrpc_contract_extension_matches_ssot() -> None:
         "OpenAPI compatibility profile drifted from extension_contracts SSOT."
     )
     assert (
-        compatibility_profile["protocol_compatibility"]
-        == wire_contract["protocol_compatibility"]
+        compatibility_profile["protocol_compatibility"] == wire_contract["protocol_compatibility"]
     ), "OpenAPI protocol compatibility summary drifted between profile and wire contract."
 
 

--- a/tests/contracts/test_extension_contract_consistency.py
+++ b/tests/contracts/test_extension_contract_consistency.py
@@ -382,6 +382,10 @@ def test_openapi_jsonrpc_contract_extension_matches_ssot() -> None:
     assert compatibility_profile == expected_compatibility_profile, (
         "OpenAPI compatibility profile drifted from extension_contracts SSOT."
     )
+    assert (
+        compatibility_profile["protocol_compatibility"]
+        == wire_contract["protocol_compatibility"]
+    ), "OpenAPI protocol compatibility summary drifted between profile and wire contract."
 
 
 def test_openapi_and_agent_card_extension_contracts_match() -> None:

--- a/tests/execution/test_thread_lifecycle_runtime.py
+++ b/tests/execution/test_thread_lifecycle_runtime.py
@@ -49,6 +49,7 @@ class BlockingThreadLifecycleClientStub:
     def __init__(self) -> None:
         self.connection_scope_id = "scope-test"
         self.thread_unsubscribe_calls: list[str] = []
+        self._events: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
 
     async def stream_events(  # noqa: ANN201
         self,
@@ -57,12 +58,11 @@ class BlockingThreadLifecycleClientStub:
         directory: str | None = None,
     ) -> AsyncIterator[dict[str, Any]]:
         del directory
-        while True:
-            if stop_event is not None and stop_event.is_set():
-                break
-            await asyncio.sleep(0.01)
-            if False:  # pragma: no cover
-                yield {}
+        while stop_event is None or not stop_event.is_set():
+            try:
+                yield await asyncio.wait_for(self._events.get(), timeout=0.01)
+            except TimeoutError:
+                continue
 
     async def thread_unsubscribe(self, thread_id: str) -> None:
         self.thread_unsubscribe_calls.append(thread_id)

--- a/tests/package/test_release_distribution_contract.py
+++ b/tests/package/test_release_distribution_contract.py
@@ -47,6 +47,7 @@ def test_readme_documents_released_cli_installation_via_uv_tool() -> None:
     assert "create a PR from the working branch" in README_TEXT
     assert "merge into `main` after human review" in README_TEXT
     assert "[Compatibility Guide](docs/compatibility.md)" in README_TEXT
+    assert "[External Conformance Experiments](docs/conformance.md)" in README_TEXT
     assert "[Contributing Guide](CONTRIBUTING.md)" in README_TEXT
     assert "single-tenant trust boundary" in README_TEXT
     assert "Portable vs Private Surface" in README_TEXT
@@ -94,6 +95,8 @@ def test_dependency_health_workflow_runs_as_a_standalone_check() -> None:
 
 
 def test_scripts_index_exposes_built_cli_smoke_test() -> None:
+    assert "doctor.sh" in SCRIPTS_README_TEXT
+    assert "conformance.sh" in SCRIPTS_README_TEXT
     assert "validate_runtime_matrix.sh" in SCRIPTS_README_TEXT
     assert "dependency_health.sh" in SCRIPTS_README_TEXT
     assert "smoke_test_built_cli.sh" in SCRIPTS_README_TEXT

--- a/tests/scripts/test_script_health_contract.py
+++ b/tests/scripts/test_script_health_contract.py
@@ -3,6 +3,7 @@ from pathlib import Path
 DEPENDENCY_HEALTH_TEXT = Path("scripts/dependency_health.sh").read_text()
 HEALTH_COMMON_TEXT = Path("scripts/health_common.sh").read_text()
 SCRIPTS_INDEX_TEXT = Path("scripts/README.md").read_text()
+DOCTOR_TEXT = Path("scripts/doctor.sh").read_text()
 VALIDATE_BASELINE_TEXT = Path("scripts/validate_baseline.sh").read_text()
 DEPENDABOT_TEXT = Path(".github/dependabot.yml").read_text()
 
@@ -24,6 +25,13 @@ def test_validate_baseline_keeps_local_regression_scope() -> None:
     assert "uv pip list --outdated" not in VALIDATE_BASELINE_TEXT
 
 
+def test_doctor_is_thin_default_regression_alias() -> None:
+    assert 'exec bash "${SCRIPT_DIR}/validate_baseline.sh" "$@"' in DOCTOR_TEXT
+    assert "uv run pytest" not in DOCTOR_TEXT
+    assert "uv run mypy" not in DOCTOR_TEXT
+    assert "uv run pip-audit" not in DOCTOR_TEXT
+
+
 def test_dependency_health_keeps_dependency_review_scope() -> None:
     assert (
         'source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/health_common.sh"'
@@ -38,6 +46,8 @@ def test_dependency_health_keeps_dependency_review_scope() -> None:
 
 
 def test_scripts_index_documents_split_health_entrypoints() -> None:
+    assert "doctor.sh" in SCRIPTS_INDEX_TEXT
+    assert "shortest maintainer entrypoint" in SCRIPTS_INDEX_TEXT
     assert "default local validation baseline used by contributors and CI" in SCRIPTS_INDEX_TEXT
     assert "standalone dependency review flow" in SCRIPTS_INDEX_TEXT
     assert "health_common.sh" in SCRIPTS_INDEX_TEXT

--- a/tests/scripts/test_script_health_contract.py
+++ b/tests/scripts/test_script_health_contract.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 DEPENDENCY_HEALTH_TEXT = Path("scripts/dependency_health.sh").read_text()
+CONFORMANCE_TEXT = Path("scripts/conformance.sh").read_text()
 HEALTH_COMMON_TEXT = Path("scripts/health_common.sh").read_text()
 SCRIPTS_INDEX_TEXT = Path("scripts/README.md").read_text()
 DOCTOR_TEXT = Path("scripts/doctor.sh").read_text()
@@ -32,6 +33,17 @@ def test_doctor_is_thin_default_regression_alias() -> None:
     assert "uv run pip-audit" not in DOCTOR_TEXT
 
 
+def test_conformance_keeps_external_tck_experiment_scope() -> None:
+    assert "Run the official A2A TCK as a local/manual experiment." in CONFORMANCE_TEXT
+    assert 'run_shared_repo_health_prerequisites "conformance"' in CONFORMANCE_TEXT
+    assert "https://github.com/a2aproject/a2a-tck.git" in CONFORMANCE_TEXT
+    assert "DummyChatCodexClient" in CONFORMANCE_TEXT
+    assert "run_tck.run_test_category" in CONFORMANCE_TEXT
+    assert "failed-tests.json" in CONFORMANCE_TEXT
+    assert "uv run pre-commit run --all-files" not in CONFORMANCE_TEXT
+    assert "uv run mypy" not in CONFORMANCE_TEXT
+
+
 def test_dependency_health_keeps_dependency_review_scope() -> None:
     assert (
         'source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/health_common.sh"'
@@ -47,7 +59,9 @@ def test_dependency_health_keeps_dependency_review_scope() -> None:
 
 def test_scripts_index_documents_split_health_entrypoints() -> None:
     assert "doctor.sh" in SCRIPTS_INDEX_TEXT
+    assert "conformance.sh" in SCRIPTS_INDEX_TEXT
     assert "shortest maintainer entrypoint" in SCRIPTS_INDEX_TEXT
+    assert "outside the default regression gate" in SCRIPTS_INDEX_TEXT
     assert "default local validation baseline used by contributors and CI" in SCRIPTS_INDEX_TEXT
     assert "standalone dependency review flow" in SCRIPTS_INDEX_TEXT
     assert "health_common.sh" in SCRIPTS_INDEX_TEXT

--- a/tests/server/test_agent_card.py
+++ b/tests/server/test_agent_card.py
@@ -656,11 +656,19 @@ def test_authenticated_extended_agent_card_injects_profile_into_extensions() -> 
     wire_contract_params = _require_params(wire_contract)
     assert wire_contract_params["protocol_version"] == "0.3.0"
     assert wire_contract_params["default_protocol_version"] == "0.3"
-    assert wire_contract_params["supported_protocol_versions"] == ["0.3"]
+    assert wire_contract_params["supported_protocol_versions"] == ["0.3", "1.0"]
     assert wire_contract_params["protocol_compatibility"]["versions"]["0.3"]["status"] == (
         "supported"
     )
-    assert wire_contract_params["protocol_compatibility"]["versions"]["1.0"]["status"] == "future"
+    assert wire_contract_params["protocol_compatibility"]["versions"]["1.0"]["status"] == "partial"
+    assert (
+        "A2A-Version"
+        in (
+            wire_contract_params["protocol_compatibility"]["versions"]["1.0"]["supported_features"][
+                0
+            ]
+        )
+    )
     assert "agent/getAuthenticatedExtendedCard" in wire_contract_params["all_jsonrpc_methods"]
     assert "tasks/pushNotificationConfig/set" in wire_contract_params["all_jsonrpc_methods"]
     assert "POST /v1/message:send" in wire_contract_params["core"]["http_endpoints"]
@@ -671,7 +679,7 @@ def test_authenticated_extended_agent_card_injects_profile_into_extensions() -> 
     assert compatibility_params["profile_id"] == "codex-a2a-single-tenant-coding-v1"
     assert compatibility_params["protocol_version"] == "0.3.0"
     assert compatibility_params["default_protocol_version"] == "0.3"
-    assert compatibility_params["supported_protocol_versions"] == ["0.3"]
+    assert compatibility_params["supported_protocol_versions"] == ["0.3", "1.0"]
     assert (
         compatibility_params["protocol_compatibility"]
         == wire_contract_params["protocol_compatibility"]

--- a/tests/server/test_agent_card.py
+++ b/tests/server/test_agent_card.py
@@ -655,6 +655,12 @@ def test_authenticated_extended_agent_card_injects_profile_into_extensions() -> 
     wire_contract = ext_by_uri[WIRE_CONTRACT_EXTENSION_URI]
     wire_contract_params = _require_params(wire_contract)
     assert wire_contract_params["protocol_version"] == "0.3.0"
+    assert wire_contract_params["default_protocol_version"] == "0.3"
+    assert wire_contract_params["supported_protocol_versions"] == ["0.3"]
+    assert wire_contract_params["protocol_compatibility"]["versions"]["0.3"]["status"] == (
+        "supported"
+    )
+    assert wire_contract_params["protocol_compatibility"]["versions"]["1.0"]["status"] == "future"
     assert "agent/getAuthenticatedExtendedCard" in wire_contract_params["all_jsonrpc_methods"]
     assert "tasks/pushNotificationConfig/set" in wire_contract_params["all_jsonrpc_methods"]
     assert "POST /v1/message:send" in wire_contract_params["core"]["http_endpoints"]
@@ -664,6 +670,11 @@ def test_authenticated_extended_agent_card_injects_profile_into_extensions() -> 
     compatibility_params = _require_params(compatibility)
     assert compatibility_params["profile_id"] == "codex-a2a-single-tenant-coding-v1"
     assert compatibility_params["protocol_version"] == "0.3.0"
+    assert compatibility_params["default_protocol_version"] == "0.3"
+    assert compatibility_params["supported_protocol_versions"] == ["0.3"]
+    assert compatibility_params["protocol_compatibility"] == wire_contract_params[
+        "protocol_compatibility"
+    ]
     assert compatibility_params["deployment"] == profile["deployment"]
     assert compatibility_params["runtime_features"] == profile["runtime_features"]
     assert "agent/getAuthenticatedExtendedCard" in compatibility_params["core"]["jsonrpc_methods"]
@@ -700,6 +711,9 @@ def test_authenticated_extended_agent_card_injects_profile_into_extensions() -> 
     assert any("codex.turns.*" in note for note in compatibility_params["consumer_guidance"])
     assert any("codex.review.*" in note for note in compatibility_params["consumer_guidance"])
     assert any("codex.exec.*" in note for note in compatibility_params["consumer_guidance"])
+    assert any(
+        "protocol_compatibility" in note for note in compatibility_params["consumer_guidance"]
+    )
     interrupt_recovery_policy = compatibility_params["method_retention"]["codex.interrupts.list"]
     assert interrupt_recovery_policy["availability"] == "always"
     assert interrupt_recovery_policy["retention"] == "stable"

--- a/tests/server/test_agent_card.py
+++ b/tests/server/test_agent_card.py
@@ -672,9 +672,10 @@ def test_authenticated_extended_agent_card_injects_profile_into_extensions() -> 
     assert compatibility_params["protocol_version"] == "0.3.0"
     assert compatibility_params["default_protocol_version"] == "0.3"
     assert compatibility_params["supported_protocol_versions"] == ["0.3"]
-    assert compatibility_params["protocol_compatibility"] == wire_contract_params[
-        "protocol_compatibility"
-    ]
+    assert (
+        compatibility_params["protocol_compatibility"]
+        == wire_contract_params["protocol_compatibility"]
+    )
     assert compatibility_params["deployment"] == profile["deployment"]
     assert compatibility_params["runtime_features"] == profile["runtime_features"]
     assert "agent/getAuthenticatedExtendedCard" in compatibility_params["core"]["jsonrpc_methods"]

--- a/tests/server/test_transport_contract.py
+++ b/tests/server/test_transport_contract.py
@@ -735,10 +735,98 @@ async def test_dual_stack_send_accepts_transport_native_payloads(monkeypatch) ->
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
         rest_resp = await client.post("/v1/message:send", headers=headers, json=rest_payload)
         assert rest_resp.status_code == 200
+        assert rest_resp.headers["A2A-Version"] == "0.3"
 
         rpc_resp = await client.post("/", headers=headers, json=rpc_payload)
         assert rpc_resp.status_code == 200
+        assert rpc_resp.headers["A2A-Version"] == "0.3"
         assert rpc_resp.json().get("error") is None
+
+
+@pytest.mark.asyncio
+async def test_jsonrpc_v1_method_alias_uses_negotiated_protocol(monkeypatch) -> None:
+    import codex_a2a.server.application as app_module
+
+    monkeypatch.setattr(app_module, "CodexClient", DummyChatCodexClient)
+    app = app_module.create_app(make_settings(a2a_bearer_token="test-token"))
+    transport = httpx.ASGITransport(app=app)
+    headers = {"Authorization": "Bearer test-token", "A2A-Version": "1.0"}
+    rpc_payload = {
+        "jsonrpc": "2.0",
+        "id": 42,
+        "method": "SendMessage",
+        "params": {
+            "message": {
+                "messageId": "m-v1-alias",
+                "role": "user",
+                "parts": [{"kind": "text", "text": "hello from v1 alias"}],
+            }
+        },
+    }
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post("/", headers=headers, json=rpc_payload)
+
+    assert response.status_code == 200
+    assert response.headers["A2A-Version"] == "1.0"
+    payload = response.json()
+    assert payload["id"] == 42
+    assert payload.get("error") is None
+    assert "result" in payload
+
+
+@pytest.mark.asyncio
+async def test_jsonrpc_unsupported_protocol_version_preserves_request_id(monkeypatch) -> None:
+    import codex_a2a.server.application as app_module
+
+    monkeypatch.setattr(app_module, "CodexClient", DummyChatCodexClient)
+    app = app_module.create_app(make_settings(a2a_bearer_token="test-token"))
+    transport = httpx.ASGITransport(app=app)
+    headers = {"Authorization": "Bearer test-token", "A2A-Version": "2.0"}
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/",
+            headers=headers,
+            json={"jsonrpc": "2.0", "id": 43, "method": "message/send", "params": {}},
+        )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["id"] == 43
+    assert payload["error"]["code"] == -32001
+    assert payload["error"]["data"]["type"] == "VERSION_NOT_SUPPORTED"
+    assert payload["error"]["data"]["requested_version"] == "2.0"
+    assert payload["error"]["data"]["supported_protocol_versions"] == ["0.3", "1.0"]
+
+
+@pytest.mark.asyncio
+async def test_rest_unsupported_v1_protocol_version_uses_protocol_error_shape(
+    monkeypatch,
+) -> None:
+    import codex_a2a.server.application as app_module
+
+    monkeypatch.setattr(app_module, "CodexClient", DummyChatCodexClient)
+    app = app_module.create_app(make_settings(a2a_bearer_token="test-token"))
+    transport = httpx.ASGITransport(app=app)
+    headers = {"Authorization": "Bearer test-token", "A2A-Version": "1.1"}
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/v1/message:send",
+            headers=headers,
+            json=_rest_message_payload(),
+        )
+
+    assert response.status_code == 400
+    payload = response.json()
+    assert payload["error"]["code"] == 400
+    assert payload["error"]["status"] == "INVALID_ARGUMENT"
+    assert payload["error"]["message"] == "Unsupported A2A version: 1.1"
+    error_info = payload["error"]["details"][0]
+    assert error_info["reason"] == "VERSION_NOT_SUPPORTED"
+    assert error_info["metadata"]["requestedVersion"] == "1.1"
+    assert error_info["metadata"]["defaultProtocolVersion"] == "0.3"
 
 
 @pytest.mark.asyncio
@@ -828,9 +916,37 @@ async def test_jsonrpc_unsupported_method_returns_supported_method_contract(monk
     assert payload["error"]["message"] == "Unsupported method: SendMessage"
     assert payload["error"]["data"]["type"] == "METHOD_NOT_SUPPORTED"
     assert payload["error"]["data"]["method"] == "SendMessage"
-    assert payload["error"]["data"]["protocol_version"] == settings.a2a_protocol_version
+    assert payload["error"]["data"]["protocol_version"] == "0.3"
     assert "message/send" in payload["error"]["data"]["supported_methods"]
     assert "codex.sessions.list" in payload["error"]["data"]["supported_methods"]
+
+
+@pytest.mark.asyncio
+async def test_jsonrpc_v1_unsupported_method_uses_protocol_error_shape(monkeypatch) -> None:
+    import codex_a2a.server.application as app_module
+
+    monkeypatch.setattr(app_module, "CodexClient", DummyChatCodexClient)
+    settings = make_settings(a2a_bearer_token="test-token")
+    app = app_module.create_app(settings)
+    transport = httpx.ASGITransport(app=app)
+    headers = {"Authorization": "Bearer test-token", "A2A-Version": "1.0"}
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/",
+            headers=headers,
+            json={"jsonrpc": "2.0", "id": 44, "method": "UnknownMethod", "params": {}},
+        )
+
+    assert response.status_code == 200
+    assert response.headers["A2A-Version"] == "1.0"
+    payload = response.json()
+    assert payload["error"]["code"] == -32601
+    assert payload["error"]["message"] == "Method not found"
+    assert "type" not in payload["error"]["data"]
+    assert payload["error"]["data"]["method"] == "UnknownMethod"
+    assert payload["error"]["data"]["protocolVersion"] == "1.0"
+    assert "message/send" in payload["error"]["data"]["supportedMethods"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_protocol_versions.py
+++ b/tests/test_protocol_versions.py
@@ -1,0 +1,41 @@
+import pytest
+
+from codex_a2a.protocol_versions import (
+    build_protocol_compatibility_summary,
+    default_supported_protocol_versions,
+    normalize_protocol_version,
+    normalize_protocol_versions,
+)
+
+
+def test_normalize_protocol_version_accepts_major_minor_patch() -> None:
+    assert normalize_protocol_version("0.3.0") == "0.3"
+    assert normalize_protocol_version(" 1.0 ") == "1.0"
+
+
+def test_normalize_protocol_versions_deduplicates_in_order() -> None:
+    assert normalize_protocol_versions(["0.3.0", "0.3", "1.0.0"]) == ("0.3", "1.0")
+
+
+def test_normalize_protocol_version_rejects_invalid_values() -> None:
+    with pytest.raises(ValueError, match="Major.Minor"):
+        normalize_protocol_version("v0.3")
+
+
+def test_default_supported_protocol_versions_uses_declared_line() -> None:
+    assert default_supported_protocol_versions("0.3.0") == ("0.3",)
+
+
+def test_protocol_compatibility_summary_declares_current_and_future_lines() -> None:
+    summary = build_protocol_compatibility_summary(
+        default_protocol_version="0.3.0",
+        supported_protocol_versions=["0.3.0"],
+    )
+
+    assert summary["default_protocol_version"] == "0.3"
+    assert summary["supported_protocol_versions"] == ["0.3"]
+    assert summary["versions"]["0.3"]["enabled"] is True
+    assert summary["versions"]["0.3"]["default"] is True
+    assert summary["versions"]["0.3"]["status"] == "supported"
+    assert summary["versions"]["1.0"]["enabled"] is False
+    assert summary["versions"]["1.0"]["status"] == "future"

--- a/tests/test_protocol_versions.py
+++ b/tests/test_protocol_versions.py
@@ -1,8 +1,10 @@
 import pytest
 
 from codex_a2a.protocol_versions import (
+    UnsupportedProtocolVersionError,
     build_protocol_compatibility_summary,
     default_supported_protocol_versions,
+    negotiate_protocol_version,
     normalize_protocol_version,
     normalize_protocol_versions,
 )
@@ -23,19 +25,59 @@ def test_normalize_protocol_version_rejects_invalid_values() -> None:
 
 
 def test_default_supported_protocol_versions_uses_declared_line() -> None:
-    assert default_supported_protocol_versions("0.3.0") == ("0.3",)
+    assert default_supported_protocol_versions("0.3.0") == ("0.3", "1.0")
 
 
 def test_protocol_compatibility_summary_declares_current_and_future_lines() -> None:
     summary = build_protocol_compatibility_summary(
         default_protocol_version="0.3.0",
-        supported_protocol_versions=["0.3.0"],
+        supported_protocol_versions=["0.3.0", "1.0"],
     )
 
     assert summary["default_protocol_version"] == "0.3"
-    assert summary["supported_protocol_versions"] == ["0.3"]
+    assert summary["supported_protocol_versions"] == ["0.3", "1.0"]
     assert summary["versions"]["0.3"]["enabled"] is True
     assert summary["versions"]["0.3"]["default"] is True
     assert summary["versions"]["0.3"]["status"] == "supported"
-    assert summary["versions"]["1.0"]["enabled"] is False
-    assert summary["versions"]["1.0"]["status"] == "future"
+    assert summary["versions"]["1.0"]["enabled"] is True
+    assert summary["versions"]["1.0"]["status"] == "partial"
+    assert "A2A-Version" in summary["versions"]["1.0"]["supported_features"][0]
+
+
+def test_negotiate_protocol_version_defaults_to_configured_baseline() -> None:
+    negotiated = negotiate_protocol_version(
+        header_value=None,
+        query_value=None,
+        default_protocol_version="0.3.0",
+        supported_protocol_versions=["0.3", "1.0"],
+    )
+
+    assert negotiated.requested_version == "0.3"
+    assert negotiated.negotiated_version == "0.3"
+    assert negotiated.explicit is False
+
+
+def test_negotiate_protocol_version_prefers_header_over_query() -> None:
+    negotiated = negotiate_protocol_version(
+        header_value="1.0",
+        query_value="0.3",
+        default_protocol_version="0.3.0",
+        supported_protocol_versions=["0.3", "1.0"],
+    )
+
+    assert negotiated.requested_version == "1.0"
+    assert negotiated.negotiated_version == "1.0"
+    assert negotiated.explicit is True
+
+
+def test_negotiate_protocol_version_rejects_unsupported_line() -> None:
+    with pytest.raises(UnsupportedProtocolVersionError) as exc_info:
+        negotiate_protocol_version(
+            header_value="2.0",
+            query_value=None,
+            default_protocol_version="0.3.0",
+            supported_protocol_versions=["0.3", "1.0"],
+        )
+
+    assert exc_info.value.requested_version == "2.0"
+    assert exc_info.value.supported_protocol_versions == ("0.3", "1.0")


### PR DESCRIPTION
## 关联

Closes #249
Closes #251
Closes #252

## 按模块摘要

### 脚本与文档

- 新增 `scripts/doctor.sh`，作为 `scripts/validate_baseline.sh` 的薄封装，保留现有默认回归入口语义。
- 新增 `scripts/conformance.sh`、`docs/conformance.md`、`docs/conformance-triage.md`，把官方 A2A TCK 作为本地/manual 兼容性实验，而不是默认 regression gate。
- 更新 `README.md`、`docs/architecture.md`、`docs/compatibility.md`、`docs/guide.md`、`scripts/README.md`，明确 conformance 实验、协议兼容声明和环境变量。

### A2A 协议兼容

- 新增 `src/codex_a2a/protocol_versions.py`，集中处理协议版本规范化、默认支持版本、请求期协商、当前请求 protocol context 和 compatibility summary。
- 在 HTTP middleware 中补齐 `A2A-Version` header/query 协商、响应头回写、unsupported version 的 JSON-RPC / HTTP 错误响应，以及 `A2A-Version: 1.0` 下当前 SDK-backed JSON-RPC 方法的 PascalCase alias。
- 保持 `1.0` 为 partial compatibility：alias、协商和错误形状已实现；payload schema、enum、pagination、push-notification 行为仍按 SDK-owned `0.3` 基线诚实声明。

### 兼容性 profile 与 wire contract

- 在 Agent Card / OpenAPI extension contract 中新增 `default_protocol_version`、`supported_protocol_versions`、`protocol_compatibility`。
- 扩展 compatibility profile / wire contract 的测试，确保 runtime 声明、Agent Card 和 OpenAPI 合同一致。

### JSON-RPC 与运行时收敛

- 收敛 discovery app item normalization，避免 JSON-RPC list 与 upstream stream bridge 漂移。
- 收敛 metadata validation errors、metadata directory extraction、owner guard、upstream JSON-RPC error response 构造。
- 收敛 watch event normalization，并避免强抽 `_run_watch` 这类终止语义不同的流程。
- 新增 payload parsing helpers，复用 interrupt / notification payload 的 string、nested mapping、string-list 解析逻辑。

### 死代码与维护性清理

- 删除高置信度死代码扫描发现的测试死分支。
- 删除 JSON-RPC application 中只赋值、不读取的内部方法属性。
- 对 `vulture --min-confidence 60` 的剩余项做人工复核；保留 Pydantic validators、FastAPI middleware/route handler、测试 monkeypatch 属性、SDK 基类状态、DB 映射字段和对外 client 方法等动态使用或公开契约。

## Issue 关系审查

- `Closes #249`：准确。PR 已实现 opencode-a2a 借鉴项中的 `doctor.sh`、外部 conformance/TCK 实验入口、兼容 profile / wire contract 显式协议字段，以及默认回归与外部实验分离。
- `Closes #251`：准确。PR 已实现请求期 `A2A-Version` 协商、unsupported version 错误响应、响应头回写和当前 SDK-backed JSON-RPC 1.0 alias 兼容；未实现的 1.0 payload/schema 差异已按 partial compatibility 明确声明。
- `Closes #252`：准确。PR 已逐条收敛 issue 中列出的高性价比重复点；测试夹具重复在 issue 中定义为非阻塞低优先级项，后续相关测试模块改动时再按需整理。

## 验证

- `bash -n scripts/doctor.sh`
- `bash -n scripts/conformance.sh`
- `bash ./scripts/conformance.sh --help`
- `uvx vulture src tests scripts --min-confidence 80`
- `uvx vulture src tests scripts --min-confidence 60`（人工复核剩余项）
- 多组 focused `uv run ruff check ...`
- 多组 focused `uv run mypy --config-file mypy.ini ...`
- 多组 focused `uv run pytest --no-cov ...`
- `git diff --check`
- `bash ./scripts/validate_baseline.sh`

## 备注

- 当前完整基线输出确认打包安装解析到 `a2a-sdk==0.3.26`。
- 本 PR 仍是 Draft。
