### PR TITLE
chore: adopt selected a2a-sdk builtins

### DIFF
--- a/src/codex_a2a/client/__init__.py
+++ b/src/codex_a2a/client/__init__.py
@@ -1,5 +1,6 @@
 """Minimal A2A client facade package."""
 
+from .auth import StaticCredentialService
 from .client import A2AClient
 from .config import A2AClientConfig
 from .errors import (
@@ -25,6 +26,7 @@ __all__ = [
     "A2AClient",
     "A2AClientManager",
     "A2AClientConfig",
+    "StaticCredentialService",
     "A2AClientConfigError",
     "A2AClientError",
     "A2AClientLifecycleError",

--- a/src/codex_a2a/client/auth.py
+++ b/src/codex_a2a/client/auth.py
@@ -2,6 +2,10 @@ from __future__ import annotations
 
 from base64 import b64decode, b64encode
 from binascii import Error as BinasciiError
+from collections.abc import Mapping
+
+from a2a.client.auth.credentials import CredentialService
+from a2a.client.middleware import ClientCallContext
 
 BASIC_AUTH_FORMAT_ERROR = (
     "A2A_CLIENT_BASIC_AUTH must be 'username:password' or a base64-encoded "
@@ -32,3 +36,19 @@ def _decode_basic_auth(value: str) -> bytes:
         return b64decode(padded_value, validate=True)
     except (BinasciiError, ValueError) as exc:
         raise ValueError(BASIC_AUTH_FORMAT_ERROR) from exc
+
+
+class StaticCredentialService(CredentialService):
+    def __init__(self, credentials: Mapping[str, str]) -> None:
+        self._credentials = {
+            scheme_name: credential
+            for scheme_name, credential in dict(credentials).items()
+            if isinstance(scheme_name, str) and scheme_name and isinstance(credential, str)
+        }
+
+    async def get_credentials(
+        self,
+        security_scheme_name: str,
+        context: ClientCallContext | None,
+    ) -> str | None:
+        return self._credentials.get(security_scheme_name)

--- a/src/codex_a2a/client/client.py
+++ b/src/codex_a2a/client/client.py
@@ -7,6 +7,8 @@ from uuid import uuid4
 
 import httpx
 from a2a.client import A2ACardResolver, ClientConfig, ClientFactory
+from a2a.client.auth.credentials import CredentialService
+from a2a.client.auth.interceptor import AuthInterceptor
 from a2a.client.middleware import ClientCallContext, ClientCallInterceptor
 from a2a.types import (
     AgentCard,
@@ -21,6 +23,7 @@ from a2a.types import (
 )
 
 from .agent_card import build_agent_card_request_kwargs, resolve_agent_card_endpoint
+from .auth import StaticCredentialService
 from .config import A2AClientConfig
 from .errors import (
     A2AClientConfigError,
@@ -103,6 +106,7 @@ class A2AClient:
         httpx_client: httpx.AsyncClient | None = None,
         card_resolver_factory=A2ACardResolver,
         client_factory_type=ClientFactory,
+        credential_service: CredentialService | None = None,
     ) -> None:
         if not config.agent_url:
             raise A2AClientConfigError("agent_url is required")
@@ -118,6 +122,7 @@ class A2AClient:
         self._sdk_client: _SDKClientProtocol | None = None
         self._card_resolver_factory = card_resolver_factory
         self._client_factory_type = client_factory_type
+        self._credential_service = credential_service
         self._client_config = ClientConfig(
             streaming=True,
             supported_transports=list(config.supported_transports),
@@ -328,7 +333,15 @@ class A2AClient:
         return self._sdk_client
 
     def _build_interceptors(self) -> list[ClientCallInterceptor]:
-        return [_HeaderInterceptor(self._config.default_headers)]
+        interceptors: list[ClientCallInterceptor] = [
+            _HeaderInterceptor(self._config.default_headers)
+        ]
+        credential_service = self._credential_service
+        if credential_service is None and self._config.auth_credentials:
+            credential_service = StaticCredentialService(self._config.auth_credentials)
+        if credential_service is not None:
+            interceptors.append(AuthInterceptor(credential_service))
+        return interceptors
 
     def _build_user_message(
         self,

--- a/src/codex_a2a/client/config.py
+++ b/src/codex_a2a/client/config.py
@@ -14,6 +14,7 @@ class A2AClientConfig(BaseModel):
     request_timeout_seconds: float | None = None
     close_http_client: bool = True
     default_headers: dict[str, str] = Field(default_factory=dict)
+    auth_credentials: dict[str, str] = Field(default_factory=dict)
     accepted_output_modes: list[str] = Field(default_factory=list)
     extensions: list[str] = Field(default_factory=list)
 

--- a/src/codex_a2a/client/payload_text.py
+++ b/src/codex_a2a/client/payload_text.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any
 
-from a2a.types import Message, TextPart
+from a2a.types import Message, Part, TextPart
+from a2a.utils.message import get_message_text
+from a2a.utils.parts import get_text_parts
 
 
 def _extract_from_iterable(items: Any) -> str | None:
@@ -19,6 +21,11 @@ def _extract_from_iterable(items: Any) -> str | None:
 def _extract_from_parts(parts: Any) -> str | None:
     if not isinstance(parts, (list, tuple)):
         return None
+    if all(isinstance(part, Part) for part in parts):
+        sdk_text = "\n".join(text for text in get_text_parts(list(parts)) if text.strip())
+        if sdk_text:
+            return sdk_text
+
     collected: list[str] = []
     for part in parts:
         text_part = None
@@ -100,6 +107,9 @@ def extract_text_from_payload(payload: Any) -> str | None:
         return _extract_from_iterable(payload)
 
     if isinstance(payload, Message):
+        sdk_text = get_message_text(payload).strip()
+        if sdk_text:
+            return sdk_text
         return _extract_from_parts(payload.parts)
 
     if isinstance(payload, str):

--- a/src/codex_a2a/execution/output_mapping.py
+++ b/src/codex_a2a/execution/output_mapping.py
@@ -1,20 +1,20 @@
 from __future__ import annotations
 
-import uuid
 from collections.abc import Mapping
 from typing import Any
 
 from a2a.server.agent_execution import RequestContext
 from a2a.server.events.event_queue import EventQueue
+from a2a.server.tasks import TaskUpdater
 from a2a.types import (
     Artifact,
     DataPart,
     Message,
     Part,
-    Role,
     TaskArtifactUpdateEvent,
     TextPart,
 )
+from a2a.utils.message import new_agent_text_message
 
 from codex_a2a.contracts.runtime_output import (
     build_output_metadata as build_runtime_output_metadata,
@@ -28,13 +28,10 @@ def build_assistant_message(
     *,
     message_id: str | None = None,
 ) -> Message:
-    return Message(
-        message_id=message_id or str(uuid.uuid4()),
-        role=Role.agent,
-        parts=[Part(root=TextPart(text=text))],
-        task_id=task_id,
-        context_id=context_id,
-    )
+    message = new_agent_text_message(text, context_id=context_id, task_id=task_id)
+    if message_id is None:
+        return message
+    return message.model_copy(update={"message_id": message_id})
 
 
 async def enqueue_artifact_update(
@@ -50,6 +47,17 @@ async def enqueue_artifact_update(
     event_metadata: Mapping[str, Any] | None = None,
 ) -> None:
     normalized_last_chunk = True if last_chunk is True else None
+    if event_metadata is None:
+        updater = TaskUpdater(event_queue, task_id, context_id)
+        await updater.add_artifact(
+            parts=[Part(root=part)],
+            artifact_id=artifact_id,
+            metadata=dict(artifact_metadata) if artifact_metadata else None,
+            append=append,
+            last_chunk=normalized_last_chunk,
+        )
+        return
+
     artifact = Artifact(
         artifact_id=artifact_id,
         parts=[Part(root=part)],

--- a/tests/client/test_client_flow.py
+++ b/tests/client/test_client_flow.py
@@ -3,13 +3,16 @@ from __future__ import annotations
 from typing import Any
 
 import pytest
+from a2a.client.auth.interceptor import AuthInterceptor
 from a2a.types import (
     AgentCapabilities,
     AgentCard,
     Artifact,
+    HTTPAuthSecurityScheme,
     Message,
     Part,
     Role,
+    SecurityScheme,
     Task,
     TaskArtifactUpdateEvent,
     TaskIdParams,
@@ -23,6 +26,7 @@ from codex_a2a.client import (
     A2AClient,
     A2AClientConfig,
     A2AUnsupportedBindingError,
+    StaticCredentialService,
 )
 from codex_a2a.client.types import A2ACancelTaskRequest, A2AGetTaskRequest, A2ASendRequest
 
@@ -201,6 +205,55 @@ async def test_build_client_maps_unsupported_transport_binding() -> None:
 
     with pytest.raises(A2AUnsupportedBindingError):
         await client._build_client()
+
+
+def test_build_interceptors_adds_sdk_auth_interceptor_for_config_credentials() -> None:
+    client = A2AClient(
+        A2AClientConfig(
+            agent_url="https://example.org",
+            auth_credentials={"bearerAuth": "peer-token"},
+        ),
+        httpx_client=_MockAsyncHttpClient(),
+        card_resolver_factory=_MockAgentCardResolver,
+    )
+
+    interceptors = client._build_interceptors()  # noqa: SLF001
+
+    assert any(isinstance(interceptor, AuthInterceptor) for interceptor in interceptors)
+
+
+@pytest.mark.asyncio
+async def test_static_credential_service_works_with_sdk_auth_interceptor() -> None:
+    card = AgentCard(
+        name="mock",
+        description="mock agent",
+        url="https://example.org",
+        version="1.0.0",
+        capabilities=AgentCapabilities(),
+        default_input_modes=["text/plain"],
+        default_output_modes=["text/plain"],
+        skills=[],
+        security_schemes={
+            "bearerAuth": SecurityScheme(
+                root=HTTPAuthSecurityScheme(
+                    scheme="bearer",
+                    bearer_format="opaque",
+                )
+            )
+        },
+        security=[{"bearerAuth": []}],
+    )
+    interceptor = AuthInterceptor(StaticCredentialService({"bearerAuth": "peer-token"}))
+
+    _payload, http_kwargs = await interceptor.intercept(
+        "message/send",
+        {},
+        {},
+        card,
+        None,
+    )
+
+    assert http_kwargs["headers"]["Authorization"] == "Bearer peer-token"
 
 
 def test_extract_text_prefers_stream_artifact_payload() -> None:


### PR DESCRIPTION
## 背景

本 PR 处理 #254：基于 `a2a-sdk==0.3.26` 收敛本仓中低风险、可复用的 SDK 内置能力。此前评估中的 handler 生命周期重构不纳入本 PR：本仓在流式断连时取消 producer 并立即关闭 queue，而 SDK 默认会后台继续消费并持久化事件，两者语义不同，因此当前实现应保留。

Closes #254

## 按模块说明

### Client auth

- 新增 `StaticCredentialService`，实现 SDK `CredentialService` 接口。
- `A2AClient` 支持通过显式 `credential_service` 或 `A2AClientConfig.auth_credentials` 接入 SDK `AuthInterceptor`。
- 保留原 `_HeaderInterceptor`，继续负责默认 header 与 per-call 非标准 header 透传。

### Client payload text

- 标准 A2A `Message` / `Part` 文本提取路径优先使用 SDK `get_message_text` / `get_text_parts`。
- 保留本仓对 tuple/list、mapping、artifact、history、model_dump 等兼容结构的递归提取逻辑。

### Execution output mapping

- `build_assistant_message` 改用 SDK `new_agent_text_message`。
- 在没有 event-level metadata 的 artifact update 路径中使用 SDK `TaskUpdater.add_artifact`。
- 需要 event-level metadata 的路径继续保留手写 `TaskArtifactUpdateEvent`，避免丢失本仓运行时元数据。

### Tests

- 补充 SDK `AuthInterceptor` 与 `StaticCredentialService` 的客户端覆盖。

## 验证

- `uv run ruff check src/codex_a2a/client src/codex_a2a/execution/output_mapping.py tests/client/test_client_flow.py`
- `uv run pytest tests/client/test_client_flow.py tests/client/test_payload_text.py tests/execution/test_discovery_exec_runtime.py tests/execution/test_review_runtime.py tests/execution/test_thread_lifecycle_runtime.py -q --no-cov`
- `uv run mypy --config-file mypy.ini`
- `bash ./scripts/validate_baseline.sh`
