### PR TITLE
chore: reduce default logging noise

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -191,7 +191,7 @@ Use the grouped sections below as the deployment-first reading order:
 - `A2A_DATABASE_URL` also owns the adapter-managed runtime-state schema lifecycle. On startup, `codex-a2a` auto-creates the runtime-state tables, records a schema version for the `runtime_state` scope, and applies in-place migrations for those tables only.
 - The adapter-managed runtime-state schema is limited to `a2a_session_bindings`, `a2a_session_owners`, `a2a_pending_session_claims`, `a2a_pending_interrupt_requests`, and `a2a_schema_version`. It does not own the A2A SDK task-store tables or any upstream Codex/provider-local state.
 - For deployment-specific durability constraints and migration-scope boundaries, see [compatibility.md](./compatibility.md).
-- `A2A_LOG_LEVEL`: `DEBUG/INFO/WARNING/ERROR`, default `INFO`
+- `A2A_LOG_LEVEL`: `DEBUG/INFO/WARNING/ERROR`, default `WARNING`
 - `A2A_LOG_PAYLOADS`: log A2A/Codex payload bodies, default `false`
 - `A2A_LOG_BODY_LIMIT`: payload log body size limit, default `0` (no truncation)
 - `A2A_TITLE`: agent name, default `Codex A2A`

--- a/src/codex_a2a/config.py
+++ b/src/codex_a2a/config.py
@@ -330,7 +330,7 @@ class Settings(BaseSettings):
     a2a_enable_turn_control: bool = Field(default=True, alias="A2A_ENABLE_TURN_CONTROL")
     a2a_enable_review_control: bool = Field(default=False, alias="A2A_ENABLE_REVIEW_CONTROL")
     a2a_enable_exec_control: bool = Field(default=False, alias="A2A_ENABLE_EXEC_CONTROL")
-    a2a_log_level: str = Field(default="INFO", alias="A2A_LOG_LEVEL")
+    a2a_log_level: str = Field(default="WARNING", alias="A2A_LOG_LEVEL")
     a2a_log_payloads: bool = Field(default=False, alias="A2A_LOG_PAYLOADS")
     a2a_log_body_limit: int = Field(default=0, alias="A2A_LOG_BODY_LIMIT")
     a2a_documentation_url: str | None = Field(default=None, alias="A2A_DOCUMENTATION_URL")

--- a/src/codex_a2a/execution/cancellation.py
+++ b/src/codex_a2a/execution/cancellation.py
@@ -74,7 +74,7 @@ async def await_cancel_cleanup(
         return
 
     if waitables:
-        logger.info(
+        logger.debug(
             "Cancel abort wait skipped task_id=%s context_id=%s abort_timeout_seconds=%.3f",
             task_id,
             context_id,

--- a/src/codex_a2a/execution/executor.py
+++ b/src/codex_a2a/execution/executor.py
@@ -176,7 +176,7 @@ class CodexAgentExecutor(AgentExecutor):
         try:
             directory = self._resolve_and_validate_directory(requested_dir)
         except ValueError as e:
-            logger.warning("Directory validation failed: %s", e)
+            logger.debug("Directory validation failed: %s", e)
             await self._emit_error(
                 event_queue,
                 task_id=task_id,

--- a/src/codex_a2a/execution/stream_chunks.py
+++ b/src/codex_a2a/execution/stream_chunks.py
@@ -387,6 +387,14 @@ def tool_delta_chunks(
     if not isinstance(delta_value, Mapping):
         logger.warning(
             "Suppressing non-structured tool_call payload "
+            "task_id=%s session_id=%s source=%s payload_type=%s",
+            task_id,
+            session_id,
+            source,
+            type(delta_value).__name__,
+        )
+        logger.debug(
+            "Suppressed non-structured tool_call payload "
             "task_id=%s session_id=%s source=%s payload=%s",
             task_id,
             session_id,
@@ -398,6 +406,14 @@ def tool_delta_chunks(
     if payload is None:
         logger.warning(
             "Suppressing unrecognized tool_call payload "
+            "task_id=%s session_id=%s source=%s payload_keys=%s",
+            task_id,
+            session_id,
+            source,
+            sorted(str(key) for key in delta_value),
+        )
+        logger.debug(
+            "Suppressed unrecognized tool_call payload "
             "task_id=%s session_id=%s source=%s payload=%s",
             task_id,
             session_id,

--- a/src/codex_a2a/execution/stream_processor.py
+++ b/src/codex_a2a/execution/stream_processor.py
@@ -122,7 +122,7 @@ class StreamEventProcessor:
         self._diagnostics = StreamDiagnostics(started_at=time.monotonic())
 
     def log_started(self, logger) -> None:  # noqa: ANN001
-        logger.info(
+        logger.debug(
             "Codex event stream started task_id=%s session_id=%s idle_diagnostic_seconds=%.1f",
             self._task_id,
             self._session_id,
@@ -178,7 +178,7 @@ class StreamEventProcessor:
         if self._diagnostics.completion_observed:
             return
         self._diagnostics.completion_observed = True
-        logger.info(
+        logger.debug(
             "Codex event stream completion observed task_id=%s session_id=%s "
             "emitted_chunk_count=%s suppressed_chunk_count=%s",
             self._task_id,
@@ -192,7 +192,7 @@ class StreamEventProcessor:
         if self._completion_event.is_set():
             await self.observe_completion(logger)
         snapshot = self._diagnostics.snapshot(now=time.monotonic(), stream_open=False)
-        logger.info(
+        logger.debug(
             "Codex event stream closed task_id=%s session_id=%s completion_observed=%s "
             "emitted_chunk_count=%s suppressed_chunk_count=%s started_ms_ago=%s "
             "last_upstream_event_ms_ago=%s last_visible_chunk_ms_ago=%s idle_log_count=%s",

--- a/src/codex_a2a/execution/thread_lifecycle_runtime.py
+++ b/src/codex_a2a/execution/thread_lifecycle_runtime.py
@@ -334,7 +334,7 @@ class CodexThreadLifecycleRuntime:
         if subscription is None:
             return
         if subscription.connection_scope != self._client.connection_scope_id:
-            logger.info(
+            logger.debug(
                 "Skipping upstream thread/unsubscribe for subscription %s because "
                 "connection_scope changed from %s to %s",
                 subscription_key,
@@ -343,7 +343,7 @@ class CodexThreadLifecycleRuntime:
             )
             return
         if not subscription.thread_filter:
-            logger.info(
+            logger.debug(
                 "Skipping upstream thread/unsubscribe for subscription %s because "
                 "thread_filter is not concrete",
                 subscription_key,

--- a/src/codex_a2a/server/application.py
+++ b/src/codex_a2a/server/application.py
@@ -241,13 +241,13 @@ def _normalize_log_level(value: str) -> str:
     normalized = (value or "").strip().upper()
     if normalized in {"CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"}:
         return normalized
-    return "INFO"
+    return "WARNING"
 
 
 def _configure_logging(level: str) -> None:
     install_log_record_factory()
     logging.basicConfig(
-        level=getattr(logging, level, logging.INFO),
+        level=getattr(logging, level, logging.WARNING),
         format=(
             "%(asctime)s %(levelname)s %(name)s [correlation_id=%(correlation_id)s]: %(message)s"
         ),

--- a/src/codex_a2a/server/http_middlewares.py
+++ b/src/codex_a2a/server/http_middlewares.py
@@ -633,11 +633,11 @@ def install_http_middlewares(
         token = set_correlation_id(correlation_id)
         started_at = time.perf_counter()
         path = request.url.path
-        logger.info("A2A request started method=%s path=%s", request.method, path)
+        logger.debug("A2A request started method=%s path=%s", request.method, path)
         try:
             response = await call_next(request)
             response.headers[CORRELATION_ID_HEADER] = correlation_id
-            logger.info(
+            logger.debug(
                 "A2A request completed method=%s path=%s status=%s duration_ms=%.2f",
                 request.method,
                 path,

--- a/src/codex_a2a/server/request_handler.py
+++ b/src/codex_a2a/server/request_handler.py
@@ -386,7 +386,7 @@ class CodexRequestHandler(DefaultRequestHandler):
             ):
                 yield event
         except (asyncio.CancelledError, GeneratorExit):
-            logger.warning("Client disconnected. Cancelling producer task %s", task_id)
+            logger.debug("Client disconnected. Cancelling producer task %s", task_id)
             if producer_task is not None:
                 producer_task.cancel()
             if queue is not None:
@@ -472,7 +472,7 @@ class CodexRequestHandler(DefaultRequestHandler):
             else:
                 try:
                     if asyncio.current_task() and asyncio.current_task().cancelled():
-                        logger.warning(
+                        logger.debug(
                             "Client disconnected from message request. Cancelling task %s", task_id
                         )
                         producer_task.cancel()

--- a/tests/config/test_settings.py
+++ b/tests/config/test_settings.py
@@ -76,6 +76,7 @@ def test_settings_valid():
         assert settings.a2a_version == __version__
         assert settings.a2a_protocol_version == "0.3.0"
         assert settings.a2a_supported_protocol_versions == ["0.3", "1.0"]
+        assert settings.a2a_log_level == "WARNING"
 
 
 def test_settings_parse_a2a_supported_protocol_versions() -> None:

--- a/tests/execution/test_stream_chunks.py
+++ b/tests/execution/test_stream_chunks.py
@@ -142,3 +142,21 @@ def test_tool_delta_chunks_normalizes_payload_and_rejects_unstructured_payload(c
 
     assert rejected == []
     assert "Suppressing non-structured tool_call payload" in caplog.text
+    assert "payload_type=str" in caplog.text
+    assert "bad-payload" not in caplog.text
+
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        rejected = tool_delta_chunks(
+            state=state,
+            delta_value={"unexpected": "secret-value"},
+            message_id=None,
+            source="delta",
+            task_id="task-1",
+            session_id="ses-1",
+        )
+
+    assert rejected == []
+    assert "Suppressing unrecognized tool_call payload" in caplog.text
+    assert "payload_keys=['unexpected']" in caplog.text
+    assert "secret-value" not in caplog.text

--- a/tests/execution/test_streaming_output_contract.py
+++ b/tests/execution/test_streaming_output_contract.py
@@ -1899,7 +1899,7 @@ async def test_streaming_logs_idle_diagnostics_at_debug_when_only_transport_keep
 
 
 @pytest.mark.asyncio
-async def test_streaming_logs_completion_observed_in_close_diagnostics(
+async def test_streaming_logs_completion_observed_in_close_diagnostics_at_debug(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -1922,7 +1922,7 @@ async def test_streaming_logs_completion_observed_in_close_diagnostics(
     executor._should_stream = lambda context: True  # type: ignore[method-assign]
     queue = DummyEventQueue()
 
-    caplog.set_level(logging.INFO, logger="codex_a2a.execution.streaming")
+    caplog.set_level(logging.DEBUG, logger="codex_a2a.execution.streaming")
 
     await executor.execute(
         make_request_context(task_id="task-close-log", context_id="ctx-close-log", text="go"),

--- a/tests/server/test_cli.py
+++ b/tests/server/test_cli.py
@@ -9,6 +9,7 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 import codex_a2a.cli as cli
+import codex_a2a.server.application as app_module
 from codex_a2a import __version__
 
 
@@ -39,3 +40,8 @@ def test_cli_defaults_to_serve_when_no_subcommand() -> None:
         assert cli.main([]) == 0
 
     serve_mock.assert_called_once_with()
+
+
+def test_normalize_log_level_defaults_invalid_values_to_warning() -> None:
+    assert app_module._normalize_log_level("debug") == "DEBUG"
+    assert app_module._normalize_log_level("not-a-level") == "WARNING"


### PR DESCRIPTION
## 背景

处理 #256。本次变更面向当前较成熟的运行阶段，收敛默认日志噪音，避免默认 `INFO` 输出过多正常请求与生命周期日志，并继续收敛默认 `WARNING` 下的低价值或高敏感度输出。

Closes #256

## 按模块说明

### 配置与文档

- 将默认 `A2A_LOG_LEVEL` 从 `INFO` 调整为 `WARNING`。
- 将无效日志级别的回退值从 `INFO` 调整为 `WARNING`，避免配置错误时退回到更高噪音级别。
- 同步更新 `docs/guide.md` 中的默认日志级别说明。

### HTTP 与请求生命周期日志

- 将 HTTP 请求开始/完成日志从 `INFO` 降级为 `DEBUG`。
- 将客户端主动断开 streaming/message 请求的日志从 `WARNING` 降级为 `DEBUG`，把常见连接生命周期与真正异常区分开。

### 执行与流式诊断日志

- 将 Codex event stream 开始、完成观测、关闭诊断从 `INFO` 降级为 `DEBUG`。
- 将取消清理跳过、thread unsubscribe 跳过等正常控制流日志降级为 `DEBUG`。
- 将目录校验失败从 `WARNING` 降级为 `DEBUG`，该错误已通过 A2A 失败事件返回给调用方，默认日志不再重复暴露请求路径细节。
- 保留取消清理超时、授权拒绝、payload mismatch、持久化冲突、Codex RPC error/timeout、事件队列丢弃等 `WARNING`/`ERROR` 级别信号。

### Tool Call Payload 日志

- 保留 unsupported tool_call payload 被抑制时的 `WARNING` 信号，避免静默丢失诊断线索。
- 默认 `WARNING` 不再输出原始 tool_call payload 值，仅输出 payload 类型或 key 集合。
- 原始 payload 细节仅在 `DEBUG` 日志中保留，避免默认运行期绕过 payload logging 保护。

### 测试

- 更新默认设置与流诊断日志测试断言。
- 增加无效日志级别回退到 `WARNING` 的覆盖。
- 增加 tool_call payload 抑制日志在 `WARNING` 下不暴露原始 payload 值的覆盖。

## 验证

- `uv run ruff check ...`
- 相关局部 pytest：35 passed
- 第二轮局部 pytest：8 passed
- `bash ./scripts/validate_baseline.sh`：538 passed，coverage 84.00%，pip-audit 无已知漏洞，build/smoke 流程通过
