### PR TITLE
docs: add ecosystem cross-links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,18 +156,18 @@ The normative compatibility split and deployment model live in [Compatibility Gu
 
 ### Foundations (Upstream)
 
-- **[A2A Python SDK](https://github.com/Intelligent-Internet/a2a-python)**: The core protocol implementation and SDK used by this adapter.
+- **[Intelligent-Internet/a2a-python](https://github.com/Intelligent-Internet/a2a-python)**: The core protocol implementation and SDK used by this adapter.
 - **Codex**: The underlying local agent runtime (Proprietary).
 
 ### Gateways & Hubs (Vertical Integration)
 
-- **[a2a-gateway](https://github.com/jinyitao123/a2a-gateway)**: Operates at the protocol-bridging layer, sitting between agent platforms and the A2A/MCP ecosystem to handle discovery and routing.
-- **[a2a-client-hub](https://github.com/liujuanjuan1984/a2a-client-hub)**: An application-facing integration layer that consumes A2A-compliant instances (like `codex-a2a`) and provides higher-level normalization.
+- **[liujuanjuan1984/a2a-client-hub](https://github.com/liujuanjuan1984/a2a-client-hub)**: An application-facing integration layer that consumes A2A-compliant instances (like `codex-a2a`) and provides higher-level normalization.
+- **[jinyitao123/a2a-gateway](https://github.com/jinyitao123/a2a-gateway)**: Operates at the protocol-bridging layer, sitting between agent platforms and the A2A/MCP ecosystem to handle discovery and routing.
 
 ### Alternative Implementations & Runtimes (Horizontal Differences)
 
+- **[Intelligent-Internet/opencode-a2a](https://github.com/Intelligent-Internet/opencode-a2a)**: A complementary Python runtime implementation that shares similar protocol patterns and output negotiation practices.
 - **[MyPrototypeWhat/codex-a2a](https://github.com/MyPrototypeWhat/codex-a2a)**: A lightweight **TypeScript** Express middleware implementation. Ideal for developers looking for in-process SDK integration within a Node.js environment.
-- **[opencode-a2a](https://github.com/Intelligent-Internet/opencode-a2a)**: A complementary Python runtime implementation that shares similar protocol patterns and output negotiation practices.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -154,6 +154,20 @@ The normative compatibility split and deployment model live in [Compatibility Gu
 - [External Conformance Experiments](docs/conformance.md) Manual A2A TCK experiment entrypoint and triage workflow.
 - [Security Policy](SECURITY.md) Threat model, deployment caveats, and vulnerability disclosure guidance.
 
+## Ecosystem
+
+`codex-a2a` is part of a growing landscape of A2A-compliant projects. Depending on your architecture, you may find these related projects useful:
+
+### Gateways & Hubs (Vertical Integration)
+
+- **[a2a-gateway](https://github.com/jinyitao123/a2a-gateway)**: Operates at the protocol-bridging layer, sitting between agent platforms and the A2A/MCP ecosystem to handle discovery and routing.
+- **[a2a-client-hub](https://github.com/liujuanjuan1984/a2a-client-hub)**: An application-facing integration layer that consumes A2A-compliant instances (like `codex-a2a`) and provides higher-level normalization.
+
+### Alternative Implementations & Runtimes (Horizontal Differences)
+
+- **[MyPrototypeWhat/codex-a2a](https://github.com/MyPrototypeWhat/codex-a2a)**: A lightweight **TypeScript** Express middleware implementation. Ideal for developers looking for in-process SDK integration within a Node.js environment.
+- **[opencode-a2a](https://github.com/Intelligent-Internet/opencode-a2a)**: A complementary Python runtime implementation that shares similar protocol patterns and output negotiation practices.
+
 ## Development
 
 For contributor workflow, validation, release handling, and helper scripts, see [Contributing Guide](CONTRIBUTING.md) and [Scripts Reference](scripts/README.md). Use that workflow to create a PR from the working branch and merge into `main` after human review.

--- a/README.md
+++ b/README.md
@@ -110,11 +110,7 @@ Use this project when:
 - you want a thin service boundary instead of building your own adapter
 - you want inbound serving and outbound peer access in one deployable unit
 
-Prefer [a2a-client-hub](https://github.com/liujuanjuan1984/a2a-client-hub) when:
-
-- you need a broader application-facing client integration layer
-- you want higher-level A2A consumption and upstream adapter normalization
-- you want client-side integration concerns separated from the Codex runtime boundary
+Prefer **[a2a-client-hub](https://github.com/liujuanjuan1984/a2a-client-hub)** when you need a broader application-facing integration layer or higher-level A2A consumption (see [Ecosystem](#ecosystem) for details).
 
 Look elsewhere if:
 
@@ -157,6 +153,11 @@ The normative compatibility split and deployment model live in [Compatibility Gu
 ## Ecosystem
 
 `codex-a2a` is part of a growing landscape of A2A-compliant projects. Depending on your architecture, you may find these related projects useful:
+
+### Foundations (Upstream)
+
+- **[A2A Python SDK](https://github.com/Intelligent-Internet/a2a-python)**: The core protocol implementation and SDK used by this adapter.
+- **Codex**: The underlying local agent runtime (Proprietary).
 
 ### Gateways & Hubs (Vertical Integration)
 


### PR DESCRIPTION
## Summary
Adds an **Ecosystem** section to the root README to clarify vertical and horizontal project relationships, using `org/repo` naming convention.

- **Foundations**: Linked `Intelligent-Internet/a2a-python`.
- **Vertical Integration**: Linked `liujuanjuan1984/a2a-client-hub` and `jinyitao123/a2a-gateway`.
- **Horizontal Differences**: Linked `Intelligent-Internet/opencode-a2a` and `MyPrototypeWhat/codex-a2a` (TypeScript).

This helps users navigate the A2A landscape and positions `codex-a2a` as a standard production-grade Python runtime adapter.

### References
- Relates to #258
- Cross-linking with jinyitao123/a2a-gateway#1
- Cross-linking with MyPrototypeWhat/codex-a2a#3