### PR TITLE
fix: restore task lifecycle after interrupt resolution

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -438,7 +438,7 @@ This path is for contributors. End users should prefer the released CLI path des
 - `mention.path` and `skill.path` are forwarded verbatim. The service does not guess app or plugin identifiers from display names.
 - `local_image` is not part of the current declared stable rich-input contract.
 - Session query projections currently use the upstream Codex `session_id` as the A2A `contextId`. This is intentional for the current deployment model: `contextId` and `metadata.shared.session.id` refer to the same upstream session identity, and the contract declares that equality explicitly.
-- Task state defaults to `input-required` to support multi-turn interactions.
+- Completed chat turns are persisted as `completed`; `input-required` is reserved for active interrupt asks that still need a reply.
 - Non-streaming requests return a `Task` directly.
 - Non-streaming `message:send` responses may include normalized token usage at `Task.metadata.shared.usage` with the same field schema.
 - `tasks/resubscribe` remains part of the core A2A method baseline, but this deployment's terminal-task replay-once policy is a declared service-level behavior rather than a generic A2A guarantee.

--- a/src/codex_a2a/execution/response_emitter.py
+++ b/src/codex_a2a/execution/response_emitter.py
@@ -57,7 +57,7 @@ async def emit_streaming_completion(
         TaskStatusUpdateEvent(
             task_id=task_id,
             context_id=context_id,
-            status=TaskStatus(state=TaskState.input_required),
+            status=TaskStatus(state=TaskState.completed),
             final=True,
             metadata=build_output_metadata(
                 session_id=session_id,
@@ -98,7 +98,7 @@ async def emit_non_stream_completion(
     task = Task(
         id=task_id,
         context_id=context_id,
-        status=TaskStatus(state=TaskState.input_required),
+        status=TaskStatus(state=TaskState.completed),
         history=build_history(context),
         artifacts=[artifact],
         metadata=build_output_metadata(

--- a/src/codex_a2a/server/task_store.py
+++ b/src/codex_a2a/server/task_store.py
@@ -33,7 +33,6 @@ _TERMINAL_TASK_STATES = frozenset(
         TaskState.canceled,
         TaskState.failed,
         TaskState.rejected,
-        TaskState.input_required,
         TaskState.unknown,
     }
 )

--- a/tests/execution/test_codex_agent_session_binding.py
+++ b/tests/execution/test_codex_agent_session_binding.py
@@ -279,6 +279,7 @@ async def test_agent_uses_stable_fallback_message_id_when_upstream_missing_messa
     )
 
     task = next(event for event in q.events if isinstance(event, Task))
+    assert task.status.state == TaskState.completed
     assert task.metadata is not None
     assert task.status.message is not None
     assert "message_id" not in task.metadata["shared"]["session"]
@@ -326,6 +327,7 @@ async def test_agent_includes_usage_in_non_stream_task_metadata() -> None:
     )
 
     task = next(event for event in q.events if isinstance(event, Task))
+    assert task.status.state == TaskState.completed
     assert task.metadata is not None
     usage = task.metadata["shared"]["usage"]
     assert usage["input_tokens"] == 7

--- a/tests/execution/test_streaming_output_contract.py
+++ b/tests/execution/test_streaming_output_contract.py
@@ -513,6 +513,7 @@ async def test_streaming_emits_events_without_message_id_using_stable_fallback()
     final_status = [
         event for event in queue.events if isinstance(event, TaskStatusUpdateEvent) and event.final
     ][-1]
+    assert final_status.status.state == TaskState.completed
     assert _status_shared_meta(final_status)["stream"]["message_id"] == "task-6:ctx-6:assistant"
     assert (
         _status_shared_meta(final_status)["stream"]["event_id"]
@@ -558,6 +559,7 @@ async def test_streaming_includes_usage_in_final_status_metadata() -> None:
     final_status = [
         event for event in queue.events if isinstance(event, TaskStatusUpdateEvent) and event.final
     ][-1]
+    assert final_status.status.state == TaskState.completed
     usage = _status_shared_meta(final_status)["usage"]
     assert usage["input_tokens"] == 12
     assert usage["output_tokens"] == 4

--- a/tests/server/test_request_handler.py
+++ b/tests/server/test_request_handler.py
@@ -32,6 +32,7 @@ from a2a.types import (
 )
 from a2a.utils.errors import ServerError
 
+from codex_a2a.contracts.runtime_output import build_interrupt_metadata, build_output_metadata
 from codex_a2a.server.output_negotiation import (
     NegotiatingResultAggregator,
     merge_output_negotiation_metadata,
@@ -164,6 +165,82 @@ async def test_message_send_returns_failed_task_for_task_store_error() -> None:
             }
         }
     }
+
+
+@pytest.mark.asyncio
+async def test_background_interrupt_resolution_updates_task_snapshot_for_get_and_resubscribe() -> (
+    None
+):
+    async def _producer(queue: EventQueue) -> None:
+        await queue.enqueue_event(
+            TaskStatusUpdateEvent(
+                task_id="task-1",
+                context_id="ctx-1",
+                status=TaskStatus(state=TaskState.input_required),
+                final=False,
+                metadata=build_output_metadata(
+                    interrupt=build_interrupt_metadata(
+                        request_id="perm-1",
+                        interrupt_type="permission",
+                        phase="asked",
+                        details={"permission": "read"},
+                    )
+                ),
+            )
+        )
+        await queue.enqueue_event(
+            TaskStatusUpdateEvent(
+                task_id="task-1",
+                context_id="ctx-1",
+                status=TaskStatus(state=TaskState.working),
+                final=False,
+                metadata=build_output_metadata(
+                    interrupt=build_interrupt_metadata(
+                        request_id="perm-1",
+                        interrupt_type="permission",
+                        phase="resolved",
+                        resolution="replied",
+                    )
+                ),
+            )
+        )
+        await queue.enqueue_event(
+            TaskStatusUpdateEvent(
+                task_id="task-1",
+                context_id="ctx-1",
+                status=TaskStatus(state=TaskState.completed),
+                final=True,
+            )
+        )
+
+    async def _wait_for_completed(task_store: InMemoryTaskStore) -> Task:
+        for _ in range(100):
+            task = await task_store.get("task-1")
+            if task is not None and task.status.state == TaskState.completed:
+                return task
+            await asyncio.sleep(0.01)
+        pytest.fail("task snapshot did not reach completed state after interrupt resolution")
+
+    task_store = InMemoryTaskStore()
+    handler = CodexRequestHandler(agent_executor=MagicMock(), task_store=task_store)
+    task = Task(
+        id="task-1",
+        context_id="ctx-1",
+        status=TaskStatus(state=TaskState.working),
+    )
+
+    producer_task = await handler.start_background_task_stream(task=task, producer=_producer)
+    await producer_task
+    stored_task = await _wait_for_completed(task_store)
+
+    assert stored_task.status.state == TaskState.completed
+
+    fetched_task = await handler.on_get_task(TaskQueryParams(id="task-1"))
+    assert fetched_task is not None
+    assert fetched_task.status.state == TaskState.completed
+
+    replayed = [event async for event in handler.on_resubscribe_to_task(TaskIdParams(id="task-1"))]
+    assert replayed == [fetched_task]
 
 
 @pytest.mark.asyncio

--- a/tests/server/test_task_store.py
+++ b/tests/server/test_task_store.py
@@ -101,7 +101,7 @@ async def test_task_store_runtime_does_not_dispose_shared_engine(
 
 
 @pytest.mark.asyncio
-async def test_guarded_task_store_keeps_first_terminal_state() -> None:
+async def test_guarded_task_store_allows_input_required_to_resume_working() -> None:
     task_store = GuardedTaskStore(InMemoryTaskStore())
 
     await task_store.save(
@@ -122,14 +122,14 @@ async def test_guarded_task_store_keeps_first_terminal_state() -> None:
         Task(
             id="task-1",
             context_id="ctx-1",
-            status=TaskStatus(state=TaskState.failed),
+            status=TaskStatus(state=TaskState.working),
         )
     )
 
     restored = await task_store.get("task-1")
 
     assert restored is not None
-    assert restored.status.state == TaskState.input_required
+    assert restored.status.state == TaskState.working
 
 
 @pytest.mark.asyncio
@@ -138,12 +138,12 @@ async def test_guarded_task_store_drops_late_terminal_mutation() -> None:
     authoritative = Task(
         id="task-1",
         context_id="ctx-1",
-        status=TaskStatus(state=TaskState.input_required),
+        status=TaskStatus(state=TaskState.completed),
     )
     mutated = Task(
         id="task-1",
         context_id="ctx-1",
-        status=TaskStatus(state=TaskState.input_required),
+        status=TaskStatus(state=TaskState.completed),
         metadata={"codex": {"late_mutation": True}},
     )
 
@@ -157,7 +157,7 @@ async def test_guarded_task_store_drops_late_terminal_mutation() -> None:
 
 
 @pytest.mark.asyncio
-async def test_guarded_database_task_store_keeps_first_terminal_state_across_independent_runtimes(
+async def test_guarded_database_task_store_resumes_from_input_required(
     tmp_path: Path,
 ) -> None:
     database_url = f"sqlite+aiosqlite:///{(tmp_path / 'terminal-guard.db').resolve()}"
@@ -188,7 +188,7 @@ async def test_guarded_database_task_store_keeps_first_terminal_state_across_ind
             Task(
                 id="task-1",
                 context_id="ctx-1",
-                status=TaskStatus(state=TaskState.failed),
+                status=TaskStatus(state=TaskState.working),
             )
         )
 
@@ -198,7 +198,7 @@ async def test_guarded_database_task_store_keeps_first_terminal_state_across_ind
         await second_runtime.shutdown()
 
     assert restored is not None
-    assert restored.status.state == TaskState.input_required
+    assert restored.status.state == TaskState.working
 
 
 @pytest.mark.asyncio
@@ -214,12 +214,12 @@ async def test_guarded_database_task_store_does_not_depend_on_stale_read_before_
     authoritative = Task(
         id="task-1",
         context_id="ctx-1",
-        status=TaskStatus(state=TaskState.input_required),
+        status=TaskStatus(state=TaskState.completed),
     )
     late_mutation = Task(
         id="task-1",
         context_id="ctx-1",
-        status=TaskStatus(state=TaskState.input_required),
+        status=TaskStatus(state=TaskState.completed),
         metadata={"codex": {"late_mutation": True}},
     )
     stale_snapshot = Task(
@@ -256,7 +256,7 @@ async def test_guarded_database_task_store_does_not_depend_on_stale_read_before_
         await second_runtime.shutdown()
 
     assert restored is not None
-    assert restored.status.state == TaskState.input_required
+    assert restored.status.state == TaskState.completed
     assert restored.metadata is None
 
 


### PR DESCRIPTION
## 背景
- 修复 `interrupt resolved` 后任务快照仍停留在 `input_required` 的状态一致性问题。
- 同步纠正普通成功对话被错误持久化为 `input_required` 的语义偏差。

## 改动说明
### execution
- 将普通流式与非流式成功完成态统一持久化为 `completed`。
- 保持 interrupt asked 为 `input_required`、interrupt resolved 为 `working` 的生命周期投影。

### server / persistence
- 从 task store 的 terminal state 集合中移除 `input_required`，允许 interrupt 恢复后继续推进状态。
- 补齐 handler 层任务快照回归，覆盖 `tasks/get` 与 `tasks/resubscribe` 的最终可见状态。

### tests
- 更新 task store 回归测试，覆盖 `working -> input_required -> working` 的恢复路径。
- 补充普通完成态为 `completed` 的执行层断言。
- 新增 `tasks/get` / `tasks/resubscribe` 快照回归测试，确保 interrupt 恢复后不会残留旧的 `input_required`。

### docs
- 更新 guide 中关于任务状态语义的说明。

## 验证
- `uv run pytest --no-cov tests/server/test_request_handler.py -q`
- `bash ./scripts/validate_baseline.sh`

## 关联
- Closes #263
