### PR TITLE
refine cli help layout and branding

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ export A2A_STATIC_AUTH_CREDENTIALS='[{"id":"local-bearer","scheme":"bearer","tok
 4. Start this service from the source tree:
 
 ```bash
-CODEX_WORKSPACE_ROOT=/abs/path/to/workspace uv run codex-a2a
+CODEX_WORKSPACE_ROOT=/abs/path/to/workspace uv run codex-a2a serve
 ```
 
 5. Inspect the discovery surfaces:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,23 @@
 # codex-a2a
 
+```text
+               _                  ___
+              | |                |__ \
+  ___ ___   __| | _____  __   __ _   ) |__ _
+ / __/ _ \ / _` |/ _ \ \/ /  / _` | / // _` |
+| (_| (_) | (_| |  __/>  <  | (_| |/ /| (_| |
+ \___\___/ \__,_|\___/_/\_\  \__,_|____\__,_|
+```
+
 > Expose Codex through A2A.
+
+Repository: https://github.com/liujuanjuan1984/codex-a2a
+
+Install: `uv tool install --upgrade codex-a2a`
+
+Protocol: A2A `1.0` only.
+
+Start the runtime explicitly with `codex-a2a serve`.
 
 `codex-a2a` adds an A2A runtime layer to the local Codex runtime, with auth, streaming, session continuity, interrupt handling, a built-in outbound A2A client, and a clear deployment boundary.
 
@@ -74,7 +91,7 @@ A2A_PORT=8000 \
 A2A_PUBLIC_URL=http://127.0.0.1:8000 \
 A2A_DATABASE_URL=sqlite+aiosqlite:////abs/path/to/workspace/.codex-a2a/codex-a2a.db \
 CODEX_WORKSPACE_ROOT=/abs/path/to/workspace \
-codex-a2a
+codex-a2a serve
 ```
 
 For the full runtime configuration matrix, outbound client settings, and deployment notes, see [Usage Guide](docs/guide.md).

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -376,7 +376,7 @@ CODEX_SANDBOX_MODE=danger-full-access \
 CODEX_MODEL_REASONING_EFFORT=high \
 CODEX_WEB_SEARCH=live \
 CODEX_TIMEOUT=300 \
-codex-a2a
+codex-a2a serve
 ```
 
 Notes:
@@ -395,7 +395,7 @@ Use the source tree directly only for development, debugging, or validation of u
 uv sync --all-extras
 export DEMO_BEARER_TOKEN="$(python -c 'import secrets; print(secrets.token_hex(24))')"
 export A2A_STATIC_AUTH_CREDENTIALS='[{"id":"local-bearer","scheme":"bearer","token":"'"${DEMO_BEARER_TOKEN}"'","principal":"automation"}]'
-CODEX_WORKSPACE_ROOT=/abs/path/to/workspace uv run codex-a2a
+CODEX_WORKSPACE_ROOT=/abs/path/to/workspace uv run codex-a2a serve
 ```
 
 This path is for contributors. End users should prefer the released CLI path described first in [README.md](../README.md) and above in this guide.

--- a/scripts/smoke_test_built_cli.sh
+++ b/scripts/smoke_test_built_cli.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Validate that a locally built wheel can be installed as a uv tool and serves authenticated /health.
+# Validate that a locally built wheel can be installed as a uv tool, prints help, and serves authenticated /health via `serve`.
 set -euo pipefail
 
 if ! command -v uv >/dev/null 2>&1; then
@@ -122,12 +122,19 @@ PY
 
 bearer_token="smoke-test-token"
 
+help_output="$("${tool_bin_dir}/codex-a2a" -h)"
+if [[ "${help_output}" != *"repo: https://github.com/liujuanjuan1984/codex-a2a"* ]]; then
+  echo "CLI smoke test failed; default invocation did not print help" >&2
+  printf '%s\n' "${help_output}" >&2
+  exit 1
+fi
+
 A2A_STATIC_AUTH_CREDENTIALS='[{"id":"smoke-bearer","scheme":"bearer","token":"'"${bearer_token}"'","principal":"automation"}]' \
 A2A_DATABASE_URL="sqlite+aiosqlite:///${database_path}" \
 A2A_PORT="${port}" \
 A2A_HOST="127.0.0.1" \
 CODEX_CLI_BIN="${fake_codex_bin}" \
-"${tool_bin_dir}/codex-a2a" >"${server_log}" 2>&1 &
+"${tool_bin_dir}/codex-a2a" serve >"${server_log}" 2>&1 &
 server_pid="$!"
 
 health_url="http://127.0.0.1:${port}/health"

--- a/src/codex_a2a/cli.py
+++ b/src/codex_a2a/cli.py
@@ -14,6 +14,101 @@ from .a2a_proto import new_text_part
 from .client import A2AClient, A2AClientConfig
 from .client.request_context import build_default_headers
 
+CLI_REPOSITORY_URL = "https://github.com/liujuanjuan1984/codex-a2a"
+CLI_BRAND_BANNER = (
+    "               _                  ___       \n"
+    "              | |                |__ \\      \n"
+    "  ___ ___   __| | _____  __   __ _   ) |__ _ \n"
+    " / __/ _ \\ / _` |/ _ \\ \\/ /  / _` | / // _` |\n"
+    "| (_| (_) | (_| |  __/>  <  | (_| |/ /| (_| |\n"
+    " \\___\\___/ \\__,_|\\___/_/\\_\\  \\__,_|____\\__,_|"
+)
+ROOT_DESCRIPTION = (
+    "Codex A2A runtime for explicit service startup and peer calls. "
+    "A2A Protocol 1.0 only.\n"
+    "  codex-a2a <command> [arguments] [options]"
+)
+CODEX_SETUP_HELP = (
+    "Codex runtime quick start:\n"
+    "  codex --version\n"
+    "  codex app-server --help\n"
+    "\n"
+    "Codex note:\n"
+    "  Install and verify the local codex CLI before starting codex-a2a.\n"
+    "  Configure Codex with a working provider, model, and required credentials."
+)
+SERVE_ENVIRONMENT_HELP = (
+    "Serve required environment:\n"
+    "  A2A_STATIC_AUTH_CREDENTIALS\n"
+    "    JSON array with at least one enabled bearer/basic credential.\n"
+    "\n"
+    "Serve common environment:\n"
+    "  A2A_HOST\n"
+    "    Bind host. Default: 127.0.0.1\n"
+    "  A2A_PORT\n"
+    "    Bind port. Default: 8000\n"
+    "  A2A_PUBLIC_URL\n"
+    "    Public base URL advertised in the agent card. Default: http://127.0.0.1:8000\n"
+    "  A2A_DATABASE_URL\n"
+    "    Runtime state database. Defaults under ${CODEX_WORKSPACE_ROOT}/.codex-a2a/ when set.\n"
+    "  CODEX_WORKSPACE_ROOT\n"
+    "    Workspace root exposed to Codex tool execution.\n"
+    "  CODEX_CLI_BIN\n"
+    "    Codex CLI binary path. Default: codex\n"
+    "  CODEX_MODEL\n"
+    "    Default Codex model override.\n"
+    "  CODEX_APPROVAL_POLICY\n"
+    "    Default approval policy forwarded to codex app-server.\n"
+    "  CODEX_SANDBOX_MODE\n"
+    "    Default sandbox mode forwarded to codex app-server.\n"
+    "\n"
+    "Serve minimal example:\n"
+    "  DEMO_BEARER_TOKEN=\"$(python -c 'import secrets; print(secrets.token_hex(24))')\"\n"
+    '  A2A_STATIC_AUTH_CREDENTIALS=\'[{"id":"local-bearer","scheme":"bearer",'
+    '"token":"\'"${DEMO_BEARER_TOKEN}"\'","principal":"automation"}]\' \\\n'
+    "  CODEX_WORKSPACE_ROOT=/abs/path/to/workspace \\\n"
+    "  codex-a2a serve\n"
+    "\n"
+    "Serve durable SQLite example:\n"
+    "  DEMO_BEARER_TOKEN=\"$(python -c 'import secrets; print(secrets.token_hex(24))')\"\n"
+    '  A2A_STATIC_AUTH_CREDENTIALS=\'[{"id":"local-bearer","scheme":"bearer",'
+    '"token":"\'"${DEMO_BEARER_TOKEN}"\'","principal":"automation"}]\' \\\n'
+    "  A2A_DATABASE_URL=sqlite+aiosqlite:////abs/path/to/workspace/.codex-a2a/codex-a2a.db \\\n"
+    "  CODEX_WORKSPACE_ROOT=/abs/path/to/workspace \\\n"
+    "  codex-a2a serve"
+)
+CALL_HELP = (
+    "Call examples:\n"
+    "  A2A_CLIENT_BEARER_TOKEN=peer-token \\\n"
+    '  codex-a2a call http://other-agent:8000/.well-known/agent-card.json "How are you?"\n'
+    "\n"
+    '  A2A_CLIENT_BASIC_AUTH="user:pass" \\\n'
+    '  codex-a2a call http://other-agent:8000/.well-known/agent-card.json "How are you?"\n'
+    "\n"
+    "Call note:\n"
+    "  Outbound peer credentials are read from environment variables only.\n"
+    "  Service base URLs also work, but card URLs are the preferred example form."
+)
+ROOT_HELP_EPILOG = f"{CODEX_SETUP_HELP}\n\n{SERVE_ENVIRONMENT_HELP}\n\n{CALL_HELP}"
+
+
+class CliHelpFormatter(
+    argparse.RawDescriptionHelpFormatter,
+    argparse.ArgumentDefaultsHelpFormatter,
+):
+    """Preserve banner formatting while keeping argparse defaults."""
+
+
+class TopLevelArgumentParser(argparse.ArgumentParser):
+    """Trim generated top-level usage noise from root help output."""
+
+    def format_help(self) -> str:
+        help_text = super().format_help()
+        lines = help_text.splitlines(keepends=True)
+        if lines and lines[0].startswith("usage:"):
+            help_text = "".join(lines[1:]).lstrip("\n")
+        return help_text.replace("\ncommands:\n  command\n", "\ncommands:\n", 1)
+
 
 async def run_call(
     agent_url: str,
@@ -79,26 +174,39 @@ def _serve_main() -> None:
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
+    parser = TopLevelArgumentParser(
         prog="codex-a2a",
-        description="Codex A2A CLI.",
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        description=(
+            CLI_BRAND_BANNER
+            + "\n\n"
+            + f"repo: {CLI_REPOSITORY_URL}\n"
+            + "uv tool install --upgrade codex-a2a\n"
+            + ROOT_DESCRIPTION
+        ),
+        formatter_class=CliHelpFormatter,
+        epilog=ROOT_HELP_EPILOG,
     )
     parser.add_argument(
+        "-v",
         "--version",
         action="version",
         version=f"%(prog)s {__version__}",
     )
-    subparsers = parser.add_subparsers(dest="command")
+    subparsers = parser.add_subparsers(
+        dest="command",
+        title="commands",
+        metavar="command",
+        parser_class=argparse.ArgumentParser,
+    )
     subparsers.add_parser(
         "serve",
-        help="Start the Codex A2A runtime.",
+        help="Run the A2A service.",
     )
     call_parser = subparsers.add_parser(
         "call",
-        help="Call an A2A agent and print text responses.",
+        help="Call an A2A agent.",
     )
-    call_parser.add_argument("agent_url", help="A2A endpoint URL.")
+    call_parser.add_argument("agent_url", help="Agent Card URL or A2A endpoint URL.")
     call_parser.add_argument("text", help="Message text.")
     return parser
 
@@ -108,12 +216,16 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser = build_parser()
 
     if not args:
-        _serve_main()
+        parser.print_help()
         return 0
 
     namespace = parser.parse_args(args)
-    if namespace.command == "serve" or namespace.command is None:
+    if namespace.command == "serve":
         _serve_main()
+        return 0
+
+    if namespace.command is None:
+        parser.print_help()
         return 0
 
     if namespace.command == "call":

--- a/tests/client/test_cli.py
+++ b/tests/client/test_cli.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from codex_a2a.cli import build_parser, main
+from codex_a2a.cli import CLI_REPOSITORY_URL, build_parser, main
 
 
 def test_call_parser_no_longer_accepts_token_flag() -> None:
@@ -10,6 +10,48 @@ def test_call_parser_no_longer_accepts_token_flag() -> None:
 
     assert namespace.command == "call"
     assert not hasattr(namespace, "token")
+
+
+def test_root_help_includes_branding_and_compact_commands_section() -> None:
+    help_text = build_parser().format_help()
+
+    assert f"repo: {CLI_REPOSITORY_URL}" in help_text
+    assert "uv tool install --upgrade codex-a2a" in help_text
+    assert "A2A Protocol 1.0 only." in help_text
+    assert "codex-a2a <command> [arguments] [options]" in help_text
+    assert "commands:\n    serve        Run the A2A service." in help_text
+    assert "commands:\n  command" not in help_text
+    assert "Codex runtime quick start:" in help_text
+    assert "codex --version" in help_text
+    assert "codex app-server --help" in help_text
+    assert "Codex note:" in help_text
+    assert "Serve required environment:" in help_text
+    assert "A2A_STATIC_AUTH_CREDENTIALS" in help_text
+    assert "Serve common environment:" in help_text
+    assert "A2A_DATABASE_URL" in help_text
+    assert "CODEX_WORKSPACE_ROOT" in help_text
+    assert "Serve minimal example:" in help_text
+    assert "Serve durable SQLite example:" in help_text
+    assert "codex-a2a serve" in help_text
+    assert "Call examples:" in help_text
+    assert 'codex-a2a call http://other-agent:8000/.well-known/agent-card.json "How are you?"' in (
+        help_text
+    )
+    assert 'A2A_CLIENT_BASIC_AUTH="user:pass"' in help_text
+    assert "Call note:" in help_text
+    assert "card URLs are the preferred example form." in help_text
+    assert "usage:" not in help_text
+
+
+def test_call_help_stays_compact() -> None:
+    parser = build_parser()
+    call_parser = parser._subparsers._group_actions[0].choices["call"]
+
+    help_text = call_parser.format_help()
+
+    assert "usage: codex-a2a call" in help_text
+    assert "Example:" not in help_text
+    assert "Authenticated example:" not in help_text
 
 
 def test_call_command_reads_bearer_token_from_environment(monkeypatch) -> None:

--- a/tests/package/test_release_distribution_contract.py
+++ b/tests/package/test_release_distribution_contract.py
@@ -17,13 +17,17 @@ SYNC_CODEX_DOCS_TEXT = Path("scripts/sync_codex_docs.sh").read_text()
 
 
 def test_readme_documents_released_cli_installation_via_uv_tool() -> None:
+    assert "```text" in README_TEXT
+    assert "Repository: https://github.com/liujuanjuan1984/codex-a2a" in README_TEXT
     assert "uv tool install codex-a2a" in README_TEXT
     assert "uv tool upgrade codex-a2a" in README_TEXT
     assert 'uv tool install "codex-a2a==<version>"' in README_TEXT
     assert "Self-start the released CLI against a workspace root:" in README_TEXT
     assert "## Development From Source" not in README_TEXT
     assert "## Development From Source" in CONTRIBUTING_TEXT
-    assert "CODEX_WORKSPACE_ROOT=/abs/path/to/workspace uv run codex-a2a" in CONTRIBUTING_TEXT
+    assert "CODEX_WORKSPACE_ROOT=/abs/path/to/workspace uv run codex-a2a serve" in (
+        CONTRIBUTING_TEXT
+    )
     assert "http://127.0.0.1:8000/.well-known/agent-card.json" in CONTRIBUTING_TEXT
     assert "Install and verify the local `codex` CLI itself." in README_TEXT
     assert "does not provision Codex providers, login state, or API keys for you" in README_TEXT
@@ -38,7 +42,7 @@ def test_readme_documents_released_cli_installation_via_uv_tool() -> None:
         '"token":"\'"${DEMO_BEARER_TOKEN}"\'","principal":"automation"}]\' \\'
     )
     assert static_auth_example in README_TEXT
-    assert "CODEX_WORKSPACE_ROOT=/abs/path/to/workspace \\\ncodex-a2a" in README_TEXT
+    assert "CODEX_WORKSPACE_ROOT=/abs/path/to/workspace \\\ncodex-a2a serve" in README_TEXT
     assert "export A2A_HOST=127.0.0.1" not in README_TEXT
     assert "A2A_CLIENT_BASIC_AUTH" in README_TEXT
     assert "--token your-outbound-token" not in README_TEXT
@@ -154,6 +158,8 @@ def test_repository_wrappers_only_keep_remaining_user_or_maintainer_entrypoints(
     assert '"${installed_python}" -c "import codex_a2a; print(codex_a2a.__version__)"' in (
         SMOKE_TEST_SCRIPT_TEXT
     )
+    assert 'help_output="$("${tool_bin_dir}/codex-a2a" -h)"' in SMOKE_TEST_SCRIPT_TEXT
+    assert '"${tool_bin_dir}/codex-a2a" serve >"${server_log}" 2>&1 &' in (SMOKE_TEST_SCRIPT_TEXT)
     assert "uv run pytest --no-cov" in RUNTIME_MATRIX_SCRIPT_TEXT
     assert 'CODEX_CLI_BIN="${fake_codex_bin}"' in SMOKE_TEST_SCRIPT_TEXT
     assert 'A2A_DATABASE_URL="sqlite+aiosqlite:///${database_path}"' in SMOKE_TEST_SCRIPT_TEXT

--- a/tests/server/test_cli.py
+++ b/tests/server/test_cli.py
@@ -19,27 +19,35 @@ def test_cli_help_does_not_require_runtime_settings(capsys: pytest.CaptureFixtur
             cli.main(["--help"])
 
     assert excinfo.value.code == 0
-    assert "Codex A2A CLI." in capsys.readouterr().out
+    output = capsys.readouterr().out
+    assert "uv tool install --upgrade codex-a2a" in output
+    assert "A2A Protocol 1.0 only." in output
+    assert "codex-a2a <command> [arguments] [options]" in output
+    assert "A2A_STATIC_AUTH_CREDENTIALS" in output
     serve_mock.assert_not_called()
 
 
+@pytest.mark.parametrize("version_flag", ["--version", "-v"])
 def test_cli_version_does_not_require_runtime_settings(
+    version_flag: str,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     with mock.patch("codex_a2a.cli._serve_main") as serve_mock:
         with pytest.raises(SystemExit) as excinfo:
-            cli.main(["--version"])
+            cli.main([version_flag])
 
     assert excinfo.value.code == 0
     assert __version__ in capsys.readouterr().out
     serve_mock.assert_not_called()
 
 
-def test_cli_defaults_to_serve_when_no_subcommand() -> None:
+def test_cli_prints_help_when_no_subcommand(capsys: pytest.CaptureFixture[str]) -> None:
     with mock.patch("codex_a2a.cli._serve_main") as serve_mock:
         assert cli.main([]) == 0
 
-    serve_mock.assert_called_once_with()
+    output = capsys.readouterr().out
+    assert "codex-a2a serve" in output
+    serve_mock.assert_not_called()
 
 
 def test_normalize_log_level_defaults_invalid_values_to_warning() -> None:


### PR DESCRIPTION
## 概述
本 PR 聚焦 `codex-a2a` 根 CLI 帮助信息、启动入口与品牌展示的一致性收口，主要围绕无参行为、`serve` 显式入口、`call` 示例、ASCII logo、README/guide/脚本/测试契约同步展开。

## 按模块说明
### CLI
- 根命令无参数时改为直接输出 help，不再误触发运行时启动
- 保留 `serve` 作为显式服务启动入口，避免帮助模式与启动模式混淆
- 新增 `-v` 作为 `--version` 的简称
- 重排根 help 层次，对齐 `opencode-a2a` 的结构：顶部展示 repo、安装方式、摘要与命令语法，后续下放运行前说明、环境变量与示例
- `call` 示例优先使用 Agent Card URL，并在说明中保留 service base URL 兼容提示
- 调整 ASCII logo 展示样式，使 CLI 与 README 顶部 branding 保持一致

### 文档
- 更新根 `README.md` 顶部 branding、repo、安装方式、协议说明与显式 `serve` 启动示例
- 更新 `docs/guide.md` 与 `CONTRIBUTING.md` 中的 CLI 启动命令，统一为 `codex-a2a serve`
- 保持文档内容为英文，避免与仓库既有文档风格偏离

### 脚本与测试
- 更新 `scripts/smoke_test_built_cli.sh`：先验证根 help，再通过 `serve` 启动服务
- 更新 CLI 与发布契约测试，覆盖：
  - 根 help 内容与层次
  - `-v` 简写
  - 无参输出 help
  - `serve` 显式启动入口
  - README / CONTRIBUTING / smoke test 与发布契约一致性

## 验证
- `uv run pytest --no-cov tests/server/test_cli.py tests/client/test_cli.py tests/package/test_release_distribution_contract.py`
- `bash ./scripts/validate_baseline.sh`

## 相关 commits
- `d0fd184` `refine cli help layout and branding`

## Issue 关联
- 本 PR 无直接对应 issue
- 当前 open issue `#258` 与本次 CLI/help/logo 调整无直接关系，因此未使用 `Closes #258` 或 `Relates to #258`，以避免误关联
