### PR TITLE
chore: absorb safe dependency bumps and tame shallow build warnings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,22 @@ updates:
       prefix: "deps"
     labels:
       - "dependencies"
+    ignore:
+      - dependency-name: "fastapi"
+        update-types:
+          - "version-update:semver-minor"
+      - dependency-name: "httpx"
+        update-types:
+          - "version-update:semver-minor"
+      - dependency-name: "protobuf"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "setuptools-scm"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "uvicorn"
+        update-types:
+          - "version-update:semver-minor"
     groups:
       uv-all-updates:
         patterns:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Setup Python
         uses: actions/setup-python@v6

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,8 +69,7 @@ jobs:
       - name: Build package artifacts
         env:
           PYTHONWARNINGS: >-
-            ignore::UserWarning:vcs_versioning._backends._git,
-            ignore::UserWarning:vcs_versioning.overrides
+            ignore::UserWarning:vcs_versioning._backends._git
         run: uv build --no-sources
 
       - name: Capture built wheel path

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -67,9 +67,6 @@ jobs:
           RELEASE_TAG: ${{ steps.release_tag.outputs.tag }}
 
       - name: Build package artifacts
-        env:
-          PYTHONWARNINGS: >-
-            ignore::UserWarning:vcs_versioning._backends._git
         run: uv build --no-sources
 
       - name: Capture built wheel path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=77", "setuptools-scm[toml]>=8"]
+requires = ["setuptools>=80", "setuptools-scm[toml]>=8,<10"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/scripts/validate_baseline.sh
+++ b/scripts/validate_baseline.sh
@@ -24,7 +24,7 @@ uv export \
 uv run pip-audit --requirement "${runtime_requirements}"
 
 rm -f dist/codex_a2a-*.whl dist/codex_a2a-*.tar.gz
-build_warning_filters="ignore::UserWarning:vcs_versioning._backends._git,ignore::UserWarning:vcs_versioning.overrides"
+build_warning_filters="ignore::UserWarning:vcs_versioning._backends._git"
 PYTHONWARNINGS="${build_warning_filters}${PYTHONWARNINGS:+,${PYTHONWARNINGS}}" uv build --no-sources
 
 shopt -s nullglob

--- a/scripts/validate_baseline.sh
+++ b/scripts/validate_baseline.sh
@@ -24,8 +24,18 @@ uv export \
 uv run pip-audit --requirement "${runtime_requirements}"
 
 rm -f dist/codex_a2a-*.whl dist/codex_a2a-*.tar.gz
-build_warning_filters="ignore::UserWarning:vcs_versioning._backends._git"
-PYTHONWARNINGS="${build_warning_filters}${PYTHONWARNINGS:+,${PYTHONWARNINGS}}" uv build --no-sources
+
+if [[ "$(git rev-parse --is-shallow-repository)" == "true" ]]; then
+  git fetch --quiet --update-shallow --tags origin '+refs/heads/*:refs/remotes/origin/*' || true
+fi
+
+if [[ "$(git rev-parse --is-shallow-repository)" == "true" ]]; then
+  build_warning_filters="ignore::UserWarning:setuptools_scm.git"
+  PYTHONWARNINGS="${build_warning_filters}${PYTHONWARNINGS:+,${PYTHONWARNINGS}}" \
+    uv build --no-sources
+else
+  uv build --no-sources
+fi
 
 shopt -s nullglob
 wheel_paths=(dist/codex_a2a-*.whl)

--- a/scripts/validate_baseline.sh
+++ b/scripts/validate_baseline.sh
@@ -24,18 +24,7 @@ uv export \
 uv run pip-audit --requirement "${runtime_requirements}"
 
 rm -f dist/codex_a2a-*.whl dist/codex_a2a-*.tar.gz
-
-if [[ "$(git rev-parse --is-shallow-repository)" == "true" ]]; then
-  git fetch --quiet --update-shallow --tags origin '+refs/heads/*:refs/remotes/origin/*' || true
-fi
-
-if [[ "$(git rev-parse --is-shallow-repository)" == "true" ]]; then
-  build_warning_filters="ignore::UserWarning:setuptools_scm.git"
-  PYTHONWARNINGS="${build_warning_filters}${PYTHONWARNINGS:+,${PYTHONWARNINGS}}" \
-    uv build --no-sources
-else
-  uv build --no-sources
-fi
+uv build --no-sources
 
 shopt -s nullglob
 wheel_paths=(dist/codex_a2a-*.whl)

--- a/tests/package/test_release_distribution_contract.py
+++ b/tests/package/test_release_distribution_contract.py
@@ -69,6 +69,7 @@ def test_publish_workflow_builds_and_smoke_tests_release_artifacts() -> None:
     assert "Run runtime dependency vulnerability audit" in PUBLISH_WORKFLOW_TEXT
     assert "uv run pip-audit --requirement /tmp/runtime-requirements.txt" in PUBLISH_WORKFLOW_TEXT
     assert "uv build --no-sources" in PUBLISH_WORKFLOW_TEXT
+    assert "PYTHONWARNINGS" not in PUBLISH_WORKFLOW_TEXT
     assert "bash ./scripts/smoke_test_built_cli.sh" in PUBLISH_WORKFLOW_TEXT
     assert "gh-action-pypi-publish" in PUBLISH_WORKFLOW_TEXT
 
@@ -170,9 +171,9 @@ def test_repository_wrappers_only_keep_remaining_user_or_maintainer_entrypoints(
 
 def test_validation_and_publish_paths_filter_known_build_warnings() -> None:
     validate_baseline_text = Path("scripts/validate_baseline.sh").read_text()
-    assert "vcs_versioning._backends._git" in validate_baseline_text
     assert "uv run pip-audit --requirement" in validate_baseline_text
-    assert "vcs_versioning._backends._git" in PUBLISH_WORKFLOW_TEXT
+    assert "setuptools_scm.git" in validate_baseline_text
+    assert "vcs_versioning._backends._git" not in PUBLISH_WORKFLOW_TEXT
     assert "vcs_versioning.overrides" not in validate_baseline_text
     assert "vcs_versioning.overrides" not in PUBLISH_WORKFLOW_TEXT
 

--- a/tests/package/test_release_distribution_contract.py
+++ b/tests/package/test_release_distribution_contract.py
@@ -171,10 +171,10 @@ def test_repository_wrappers_only_keep_remaining_user_or_maintainer_entrypoints(
 def test_validation_and_publish_paths_filter_known_build_warnings() -> None:
     validate_baseline_text = Path("scripts/validate_baseline.sh").read_text()
     assert "vcs_versioning._backends._git" in validate_baseline_text
-    assert "vcs_versioning.overrides" in validate_baseline_text
     assert "uv run pip-audit --requirement" in validate_baseline_text
     assert "vcs_versioning._backends._git" in PUBLISH_WORKFLOW_TEXT
-    assert "vcs_versioning.overrides" in PUBLISH_WORKFLOW_TEXT
+    assert "vcs_versioning.overrides" not in validate_baseline_text
+    assert "vcs_versioning.overrides" not in PUBLISH_WORKFLOW_TEXT
 
 
 def test_gitignore_keeps_python_sources_without_unignoring_runtime_caches() -> None:

--- a/tests/package/test_release_distribution_contract.py
+++ b/tests/package/test_release_distribution_contract.py
@@ -69,6 +69,7 @@ def test_publish_workflow_builds_and_smoke_tests_release_artifacts() -> None:
     assert "Run runtime dependency vulnerability audit" in PUBLISH_WORKFLOW_TEXT
     assert "uv run pip-audit --requirement /tmp/runtime-requirements.txt" in PUBLISH_WORKFLOW_TEXT
     assert "uv build --no-sources" in PUBLISH_WORKFLOW_TEXT
+    assert "fetch-depth: 0" in PUBLISH_WORKFLOW_TEXT
     assert "PYTHONWARNINGS" not in PUBLISH_WORKFLOW_TEXT
     assert "bash ./scripts/smoke_test_built_cli.sh" in PUBLISH_WORKFLOW_TEXT
     assert "gh-action-pypi-publish" in PUBLISH_WORKFLOW_TEXT
@@ -79,6 +80,7 @@ def test_ci_workflow_deduplicates_full_gate_and_runtime_matrix() -> None:
     assert "quality-gate:" in CI_WORKFLOW_TEXT
     assert "name: Validation Baseline" in CI_WORKFLOW_TEXT
     assert 'python-version: "3.13"' in CI_WORKFLOW_TEXT
+    assert "fetch-depth: 0" in CI_WORKFLOW_TEXT
     assert "bash ./scripts/validate_baseline.sh" in CI_WORKFLOW_TEXT
     assert "runtime-matrix:" in CI_WORKFLOW_TEXT
     assert "name: Runtime Matrix (Python ${{ matrix.python-version }})" in CI_WORKFLOW_TEXT
@@ -172,8 +174,9 @@ def test_repository_wrappers_only_keep_remaining_user_or_maintainer_entrypoints(
 def test_validation_and_publish_paths_filter_known_build_warnings() -> None:
     validate_baseline_text = Path("scripts/validate_baseline.sh").read_text()
     assert "uv run pip-audit --requirement" in validate_baseline_text
-    assert "setuptools_scm.git" in validate_baseline_text
+    assert "fetch-depth: 0" in CI_WORKFLOW_TEXT
     assert "vcs_versioning._backends._git" not in PUBLISH_WORKFLOW_TEXT
+    assert "PYTHONWARNINGS" not in validate_baseline_text
     assert "vcs_versioning.overrides" not in validate_baseline_text
     assert "vcs_versioning.overrides" not in PUBLISH_WORKFLOW_TEXT
 

--- a/tests/package/test_typing_contract.py
+++ b/tests/package/test_typing_contract.py
@@ -11,3 +11,4 @@ def test_package_declares_py_typed_marker() -> None:
 
 def test_build_backend_pins_setuptools_scm_below_warning_major_version() -> None:
     assert 'requires = ["setuptools>=80", "setuptools-scm[toml]>=8,<10"]' in PYPROJECT_TEXT
+    assert "[tool.setuptools_scm.scm.git]" not in PYPROJECT_TEXT

--- a/tests/package/test_typing_contract.py
+++ b/tests/package/test_typing_contract.py
@@ -7,3 +7,7 @@ def test_package_declares_py_typed_marker() -> None:
     assert Path("src/codex_a2a/py.typed").is_file()
     assert "[tool.setuptools.package-data]" in PYPROJECT_TEXT
     assert 'codex_a2a = ["py.typed"]' in PYPROJECT_TEXT
+
+
+def test_build_backend_pins_setuptools_scm_below_warning_major_version() -> None:
+    assert 'requires = ["setuptools>=80", "setuptools-scm[toml]>=8,<10"]' in PYPROJECT_TEXT

--- a/tests/scripts/test_script_health_contract.py
+++ b/tests/scripts/test_script_health_contract.py
@@ -74,3 +74,6 @@ def test_dependabot_configuration_prefers_a_single_grouped_uv_pr() -> None:
     assert 'package-ecosystem: "github-actions"' not in DEPENDABOT_TEXT
     assert "open-pull-requests-limit: 1" in DEPENDABOT_TEXT
     assert "uv-all-updates" in DEPENDABOT_TEXT
+    assert 'dependency-name: "protobuf"' in DEPENDABOT_TEXT
+    assert 'dependency-name: "uvicorn"' in DEPENDABOT_TEXT
+    assert 'dependency-name: "setuptools-scm"' in DEPENDABOT_TEXT

--- a/tests/scripts/test_script_health_contract.py
+++ b/tests/scripts/test_script_health_contract.py
@@ -23,6 +23,8 @@ def test_validate_baseline_keeps_local_regression_scope() -> None:
     assert "uv run pytest" in VALIDATE_BASELINE_TEXT
     assert "uv export" in VALIDATE_BASELINE_TEXT
     assert "uv run pip-audit" in VALIDATE_BASELINE_TEXT
+    assert "uv build --no-sources" in VALIDATE_BASELINE_TEXT
+    assert "git fetch --quiet --update-shallow" not in VALIDATE_BASELINE_TEXT
     assert "uv pip list --outdated" not in VALIDATE_BASELINE_TEXT
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -430,7 +430,7 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.136.0"
+version = "0.136.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -439,9 +439,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4e/d9/e66315807e41e69e7f6a1b42a162dada2f249c5f06ad3f1a95f84ab336ef/fastapi-0.136.0.tar.gz", hash = "sha256:cf08e067cc66e106e102d9ba659463abfac245200752f8a5b7b1e813de4ff73e", size = 396607, upload-time = "2026-04-16T11:47:13.623Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5d/45/c130091c2dfa061bbfe3150f2a5091ef1adf149f2a8d2ae769ecaf6e99a2/fastapi-0.136.1.tar.gz", hash = "sha256:7af665ad7acfa0a3baf8983d393b6b471b9da10ede59c60045f49fbc89a0fa7f", size = 397448, upload-time = "2026-04-23T16:49:44.046Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/26/a3/0bd5f0cdb0bbc92650e8dc457e9250358411ee5d1b65e42b6632387daf81/fastapi-0.136.0-py3-none-any.whl", hash = "sha256:8793d44ec7378e2be07f8a013cf7f7aa47d6327d0dfe9804862688ec4541a6b4", size = 117556, upload-time = "2026-04-16T11:47:11.922Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/ff/2e4eca3ade2c22fe1dea7043b8ee9dabe47753349eb1b56a202de8af6349/fastapi-0.136.1-py3-none-any.whl", hash = "sha256:a6e9d7eeada96c93a4d69cb03836b44fa34e2854accb7244a1ece36cd4781c3f", size = 117683, upload-time = "2026-04-23T16:49:42.437Z" },
 ]
 
 [[package]]
@@ -1324,27 +1324,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.11"
+version = "0.15.12"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e4/8d/192f3d7103816158dfd5ea50d098ef2aec19194e6cbccd4b3485bdb2eb2d/ruff-0.15.11.tar.gz", hash = "sha256:f092b21708bf0e7437ce9ada249dfe688ff9a0954fc94abab05dcea7dcd29c33", size = 4637264, upload-time = "2026-04-16T18:46:26.58Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/43/3291f1cc9106f4c63bdce7a8d0df5047fe8422a75b091c16b5e9355e0b11/ruff-0.15.12.tar.gz", hash = "sha256:ecea26adb26b4232c0c2ca19ccbc0083a68344180bba2a600605538ce51a40a6", size = 4643852, upload-time = "2026-04-24T18:17:14.305Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/02/1e/6aca3427f751295ab011828e15e9bf452200ac74484f1db4be0197b8170b/ruff-0.15.11-py3-none-linux_armv6l.whl", hash = "sha256:e927cfff503135c558eb581a0c9792264aae9507904eb27809cdcff2f2c847b7", size = 10607943, upload-time = "2026-04-16T18:46:05.967Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/26/1341c262e74f36d4e84f3d6f4df0ac68cd53331a66bfc5080daa17c84c0b/ruff-0.15.11-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:7a1b5b2938d8f890b76084d4fa843604d787a912541eae85fd7e233398bbb73e", size = 10988592, upload-time = "2026-04-16T18:46:00.742Z" },
-    { url = "https://files.pythonhosted.org/packages/03/71/850b1d6ffa9564fbb6740429bad53df1094082fe515c8c1e74b6d8d05f18/ruff-0.15.11-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d4176f3d194afbdaee6e41b9ccb1a2c287dba8700047df474abfbe773825d1cb", size = 10338501, upload-time = "2026-04-16T18:46:03.723Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/11/cc1284d3e298c45a817a6aadb6c3e1d70b45c9b36d8d9cce3387b495a03a/ruff-0.15.11-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3b17c886fb88203ced3afe7f14e8d5ae96e9d2f4ccc0ee66aa19f2c2675a27e4", size = 10670693, upload-time = "2026-04-16T18:46:41.941Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/9e/f8288b034ab72b371513c13f9a41d9ba3effac54e24bfb467b007daee2ca/ruff-0.15.11-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:49fafa220220afe7758a487b048de4c8f9f767f37dfefad46b9dd06759d003eb", size = 10416177, upload-time = "2026-04-16T18:46:21.717Z" },
-    { url = "https://files.pythonhosted.org/packages/85/71/504d79abfd3d92532ba6bbe3d1c19fada03e494332a59e37c7c2dabae427/ruff-0.15.11-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f2ab8427e74a00d93b8bda1307b1e60970d40f304af38bccb218e056c220120d", size = 11221886, upload-time = "2026-04-16T18:46:15.086Z" },
-    { url = "https://files.pythonhosted.org/packages/43/5a/947e6ab7a5ad603d65b474be15a4cbc6d29832db5d762cd142e4e3a74164/ruff-0.15.11-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:195072c0c8e1fc8f940652073df082e37a5d9cb43b4ab1e4d0566ab8977a13b7", size = 12075183, upload-time = "2026-04-16T18:46:07.944Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/a1/0b7bb6268775fdd3a0818aee8efd8f5b4e231d24dd4d528ced2534023182/ruff-0.15.11-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a3a0996d486af3920dec930a2e7daed4847dfc12649b537a9335585ada163e9e", size = 11516575, upload-time = "2026-04-16T18:46:31.687Z" },
-    { url = "https://files.pythonhosted.org/packages/30/c3/bb5168fc4d233cc06e95f482770d0f3c87945a0cd9f614b90ea8dc2f2833/ruff-0.15.11-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1bef2cb556d509259f1fe440bb9cd33c756222cf0a7afe90d15edf0866702431", size = 11306537, upload-time = "2026-04-16T18:46:36.988Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/92/4cfae6441f3967317946f3b788136eecf093729b94d6561f963ed810c82e/ruff-0.15.11-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:030d921a836d7d4a12cf6e8d984a88b66094ccb0e0f17ddd55067c331191bf19", size = 11296813, upload-time = "2026-04-16T18:46:24.182Z" },
-    { url = "https://files.pythonhosted.org/packages/43/26/972784c5dde8313acde8ac71ba8ac65475b85db4a2352a76c9934361f9bc/ruff-0.15.11-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:0e783b599b4577788dbbb66b9addcef87e9a8832f4ce0c19e34bf55543a2f890", size = 10633136, upload-time = "2026-04-16T18:46:39.802Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/53/3985a4f185020c2f367f2e08a103032e12564829742a1b417980ce1514a0/ruff-0.15.11-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:ae90592246625ba4a34349d68ec28d4400d75182b71baa196ddb9f82db025ef5", size = 10424701, upload-time = "2026-04-16T18:46:10.381Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/57/bf0dfb32241b56c83bb663a826133da4bf17f682ba8c096973065f6e6a68/ruff-0.15.11-py3-none-musllinux_1_2_i686.whl", hash = "sha256:1f111d62e3c983ed20e0ca2e800f8d77433a5b1161947df99a5c2a3fb60514f0", size = 10873887, upload-time = "2026-04-16T18:46:29.157Z" },
-    { url = "https://files.pythonhosted.org/packages/02/05/e48076b2a57dc33ee8c7a957296f97c744ca891a8ffb4ffb1aaa3b3f517d/ruff-0.15.11-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:06f483d6646f59eaffba9ae30956370d3a886625f511a3108994000480621d1c", size = 11404316, upload-time = "2026-04-16T18:46:19.462Z" },
-    { url = "https://files.pythonhosted.org/packages/88/27/0195d15fe7a897cbcba0904792c4b7c9fdd958456c3a17d2ea6093716a9a/ruff-0.15.11-py3-none-win32.whl", hash = "sha256:476a2aa56b7da0b73a3ee80b6b2f0e19cce544245479adde7baa65466664d5f3", size = 10655535, upload-time = "2026-04-16T18:46:12.47Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/5e/c927b325bd4c1d3620211a4b96f47864633199feed60fa936025ab27e090/ruff-0.15.11-py3-none-win_amd64.whl", hash = "sha256:8b6756d88d7e234fb0c98c91511aae3cd519d5e3ed271cae31b20f39cb2a12a3", size = 11779692, upload-time = "2026-04-16T18:46:17.268Z" },
-    { url = "https://files.pythonhosted.org/packages/63/b6/aeadee5443e49baa2facd51131159fd6301cc4ccfc1541e4df7b021c37dd/ruff-0.15.11-py3-none-win_arm64.whl", hash = "sha256:063fed18cc1bbe0ee7393957284a6fe8b588c6a406a285af3ee3f46da2391ee4", size = 11032614, upload-time = "2026-04-16T18:46:34.487Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/6e/e78ffb61d4686f3d96ba3df2c801161843746dcbcbb17a1e927d4829312b/ruff-0.15.12-py3-none-linux_armv6l.whl", hash = "sha256:f86f176e188e94d6bdbc09f09bfd9dc729059ad93d0e7390b5a73efe19f8861c", size = 10640713, upload-time = "2026-04-24T18:17:22.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/08/a317bc231fb9e7b93e4ef3089501e51922ff88d6936ce5cf870c4fe55419/ruff-0.15.12-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e3bcd123364c3770b8e1b7baaf343cc99a35f197c5c6e8af79015c666c423a6c", size = 11069267, upload-time = "2026-04-24T18:17:30.105Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/a4/f828e9718d3dce1f5f11c39c4f65afd32783c8b2aebb2e3d259e492c47bd/ruff-0.15.12-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fe87510d000220aa1ed530d4448a7c696a0cae1213e5ec30e5874287b66557b5", size = 10397182, upload-time = "2026-04-24T18:17:07.177Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/3310fc6d1b5e1fdea22bf3b1b807c7e187b581021b0d7d4514cccdb5fb71/ruff-0.15.12-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84a1630093121375a3e2a95b4a6dc7b59e2b4ee76216e32d81aae550a832d002", size = 10758012, upload-time = "2026-04-24T18:16:55.759Z" },
+    { url = "https://files.pythonhosted.org/packages/11/c1/a606911aee04c324ddaa883ae418f3569792fd3c4a10c50e0dd0a2311e1e/ruff-0.15.12-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fb129f40f114f089ebe0ca56c0d251cf2061b17651d464bb6478dc01e69f11f5", size = 10447479, upload-time = "2026-04-24T18:16:51.677Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/68/4201e8444f0894f21ab4aeeaee68aa4f10b51613514a20d80bd628d57e88/ruff-0.15.12-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b0c862b172d695db7598426b8af465e7e9ac00a3ea2a3630ee67eb82e366aaa6", size = 11234040, upload-time = "2026-04-24T18:17:16.529Z" },
+    { url = "https://files.pythonhosted.org/packages/34/ff/8a6d6cf4ccc23fd67060874e832c18919d1557a0611ebef03fdb01fff11e/ruff-0.15.12-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2849ea9f3484c3aca43a82f484210370319e7170df4dfe4843395ddf6c57bc33", size = 12087377, upload-time = "2026-04-24T18:17:04.944Z" },
+    { url = "https://files.pythonhosted.org/packages/85/f6/c669cf73f5152f623d34e69866a46d5e6185816b19fcd5b6dd8a2d299922/ruff-0.15.12-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e77c7e51c07fe396826d5969a5b846d9cd4c402535835fb6e21ce8b28fef847", size = 11367784, upload-time = "2026-04-24T18:17:25.409Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/39/c61d193b8a1daaa8977f7dea9e8d8ba866e02ea7b65d32f6861693aa4c12/ruff-0.15.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83b2f4f2f3b1026b5fb449b467d9264bf22067b600f7b6f41fc5958909f449d0", size = 11344088, upload-time = "2026-04-24T18:17:12.258Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/8d/49afab3645e31e12c590acb6d3b5b69d7aab5b81926dbaf7461f9441f37a/ruff-0.15.12-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9ba3b8f1afd7e2e43d8943e55f249e13f9682fde09711644a6e7290eb4f3e339", size = 11271770, upload-time = "2026-04-24T18:17:02.457Z" },
+    { url = "https://files.pythonhosted.org/packages/46/06/33f41fe94403e2b755481cdfb9b7ef3e4e0ed031c4581124658d935d52b4/ruff-0.15.12-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e852ba9fdc890655e1d78f2df1499efbe0e54126bd405362154a75e2bde159c5", size = 10719355, upload-time = "2026-04-24T18:17:27.648Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/59/18aa4e014debbf559670e4048e39260a85c7fcee84acfd761ac01e7b8d35/ruff-0.15.12-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:dd8aed930da53780d22fc70bdf84452c843cf64f8cb4eb38984319c24c5cd5fd", size = 10462758, upload-time = "2026-04-24T18:17:32.347Z" },
+    { url = "https://files.pythonhosted.org/packages/25/e7/cc9f16fd0f3b5fddcbd7ec3d6ae30c8f3fde1047f32a4093a98d633c6570/ruff-0.15.12-py3-none-musllinux_1_2_i686.whl", hash = "sha256:01da3988d225628b709493d7dc67c3b9b12c0210016b08690ef9bd27970b262b", size = 10953498, upload-time = "2026-04-24T18:17:20.674Z" },
+    { url = "https://files.pythonhosted.org/packages/72/7a/a9ba7f98c7a575978698f4230c5e8cc54bbc761af34f560818f933dafa0c/ruff-0.15.12-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9cae0f92bd5700d1213188b31cd3bdd2b315361296d10b96b8e2337d3d11f53e", size = 11447765, upload-time = "2026-04-24T18:17:09.755Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f9/0ae446942c846b8266059ad8a30702a35afae55f5cdc54c5adf8d7afdc27/ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20", size = 10657277, upload-time = "2026-04-24T18:17:18.591Z" },
+    { url = "https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d", size = 11837758, upload-time = "2026-04-24T18:17:00.113Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/98/6beb4b351e472e5f4c4613f7c35a5290b8be2497e183825310c4c3a3984b/ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f", size = 11120821, upload-time = "2026-04-24T18:16:57.979Z" },
 ]
 
 [[package]]
@@ -1420,15 +1420,15 @@ wheels = [
 
 [[package]]
 name = "sse-starlette"
-version = "3.3.4"
+version = "3.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "starlette" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/26/8c/f9290339ef6d79badbc010f067cd769d6601ec11a57d78569c683fb4dd87/sse_starlette-3.3.4.tar.gz", hash = "sha256:aaf92fc067af8a5427192895ac028e947b484ac01edbc3caf00e7e7137c7bef1", size = 32427, upload-time = "2026-03-29T09:00:23.307Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/9a/f35932a8c0eb6b2287b66fa65a0321df8c84e4e355a659c1841a37c39fdb/sse_starlette-3.4.1.tar.gz", hash = "sha256:f780bebcf6c8997fe514e3bd8e8c648d8284976b391c8bed0bcb1f611632b555", size = 35127, upload-time = "2026-04-26T13:32:32.292Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/7f/3de5402f39890ac5660b86bcf5c03f9d855dad5c4ed764866d7b592b46fd/sse_starlette-3.3.4-py3-none-any.whl", hash = "sha256:84bb06e58939a8b38d8341f1bc9792f06c2b53f48c608dd207582b664fc8f3c1", size = 14330, upload-time = "2026-03-29T09:00:21.846Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/07/45c21ed03d708c477367305726b89919b020a3a2a01f72aaf5ad941caf35/sse_starlette-3.4.1-py3-none-any.whl", hash = "sha256:6b43cf21f1d574d582a6e1b0cfbde1c94dc86a32a701a7168c99c4475c6bd1d0", size = 16487, upload-time = "2026-04-26T13:32:30.819Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 摘要
- 将 build backend 依赖收紧为 `setuptools>=80` 与 `setuptools-scm[toml]>=8,<10`，从根因上避开 `vcs_versioning.overrides` warning。
- 将会执行 `uv build --no-sources` 的 CI 路径显式收敛到 full clone：`publish.yml` 维持 `fetch-depth: 0`，`ci.yml` 的 validation baseline 也改为 `fetch-depth: 0`。
- 让 `scripts/validate_baseline.sh` 回归直接构建，不再内置 shallow-repo fetch/suppress 特判；本地若仍使用 shallow clone，会看到 `setuptools_scm.git` warning，但不会影响 CI/release 的干净语义。
- 吸收 `PR #268` 中值得保留的版本升级，仅更新锁文件中的 `fastapi 0.136.1`、`sse-starlette 3.4.1`、`ruff 0.15.12`。
- 保留 `protobuf<7` 与 `uvicorn<0.46` 的兼容边界，并为受上限保护的依赖增加 Dependabot ignore 规则，避免机器人反复提交仅用于放宽上限的 PR。

## 背景
- `PR #275` 最初只处理了 `setuptools-scm 10.x` 带来的 `GlobalOverrides` warning，但本地 shallow clone 仍会触发 `_git` warning，处理方式还不够收敛。
- 参考 `opencode-a2a-serve` 后，当前仓库改为同一思路：对依赖 Git metadata 的构建路径，直接要求 CI/release 使用 full clone，而不是在仓库脚本里长期保留 warning suppress。
- `PR #268` 试图同时升级 `fastapi`、`protobuf`、`sse-starlette`、`uvicorn`、`ruff`；其中 `protobuf 7.x` 与当前 `a2a-sdk 1.0.2` 已知不兼容，`uvicorn 0.46.x` 也没有现阶段必须采用的新能力。
- 上游 `a2aproject/a2a-python#1019` 已明确将 `protobuf` 限定回 `<7`，本仓独立复核也确认当前仍需要该上限。

## 验证
- `bash -n scripts/validate_baseline.sh scripts/smoke_test_built_cli.sh scripts/publish_github_release.sh`
- `uv run pytest --no-cov tests/package/test_release_distribution_contract.py tests/package/test_typing_contract.py tests/scripts/test_script_health_contract.py -q`
- `bash ./scripts/validate_baseline.sh`

Relates to #268
Closes #274
