### PR TITLE
refactor: collapse jsonrpc param validation dispatch

### DIFF
--- a/src/codex_a2a/jsonrpc/exec_control.py
+++ b/src/codex_a2a/jsonrpc/exec_control.py
@@ -114,21 +114,21 @@ async def handle_exec_control_request(
     )
 
     try:
-        if base_request.method == app._method_exec_start:
+        if isinstance(parsed_params, ExecStartControlParams):
             result = await app._exec_runtime.start(
                 request=request_payload,
                 directory=directory,
                 context=call_context,
                 owner_identity=owner_identity,
             )
-        elif base_request.method == app._method_exec_write:
+        elif isinstance(parsed_params, ExecWriteControlParams):
             result = await app._exec_runtime.write(
                 process_id=str(request_payload["process_id"]).strip(),
                 delta_base64=request_payload.get("delta_base64"),
                 close_stdin=request_payload.get("close_stdin"),
                 owner_identity=owner_identity,
             )
-        elif base_request.method == app._method_exec_resize:
+        elif isinstance(parsed_params, ExecResizeControlParams):
             result = await app._exec_runtime.resize(
                 process_id=str(request_payload["process_id"]).strip(),
                 rows=int(request_payload["rows"]),

--- a/src/codex_a2a/jsonrpc/exec_control.py
+++ b/src/codex_a2a/jsonrpc/exec_control.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import httpx
 from a2a.server.jsonrpc_models import InternalError, JSONRPCError
@@ -25,12 +25,12 @@ from codex_a2a.jsonrpc.exec_control_params import (
     ExecStartControlParams,
     ExecTerminateControlParams,
     ExecWriteControlParams,
-    parse_exec_resize_params,
-    parse_exec_start_params,
-    parse_exec_terminate_params,
-    parse_exec_write_params,
 )
-from codex_a2a.jsonrpc.params_common import JsonRpcParamsValidationError
+from codex_a2a.jsonrpc.params_common import (
+    JsonRpcParamsValidationError,
+    raise_control_validation_error,
+    validate_params_model,
+)
 from codex_a2a.jsonrpc.request_models import JSONRPCRequestModel as JSONRPCRequest
 
 if TYPE_CHECKING:
@@ -56,15 +56,27 @@ async def handle_exec_control_request(
         | ExecResizeControlParams
         | ExecTerminateControlParams
     )
+    model_type = (
+        ExecStartControlParams
+        if base_request.method == app._method_exec_start
+        else ExecWriteControlParams
+        if base_request.method == app._method_exec_write
+        else ExecResizeControlParams
+        if base_request.method == app._method_exec_resize
+        else ExecTerminateControlParams
+    )
     try:
-        if base_request.method == app._method_exec_start:
-            parsed_params = parse_exec_start_params(params)
-        elif base_request.method == app._method_exec_write:
-            parsed_params = parse_exec_write_params(params)
-        elif base_request.method == app._method_exec_resize:
-            parsed_params = parse_exec_resize_params(params)
-        else:
-            parsed_params = parse_exec_terminate_params(params)
+        parsed_params = cast(
+            ExecStartControlParams
+            | ExecWriteControlParams
+            | ExecResizeControlParams
+            | ExecTerminateControlParams,
+            validate_params_model(
+                model_type,
+                params,
+                on_error=raise_control_validation_error,
+            ),
+        )
     except JsonRpcParamsValidationError as exc:
         return invalid_params_response(app, base_request.id, exc)
 

--- a/src/codex_a2a/jsonrpc/exec_control_params.py
+++ b/src/codex_a2a/jsonrpc/exec_control_params.py
@@ -7,9 +7,7 @@ from pydantic import field_validator, model_validator
 from codex_a2a.jsonrpc.params_common import (
     MetadataParams,
     _StrictModel,
-    raise_control_validation_error,
     strip_optional_string,
-    validate_params_model,
     validate_request_command,
     validate_required_process_id,
 )
@@ -132,35 +130,3 @@ class ExecResizeControlParams(_StrictModel):
 class ExecTerminateControlParams(_StrictModel):
     request: ExecTerminateRequestParams
     metadata: MetadataParams | None = None
-
-
-def parse_exec_start_params(params: dict[str, Any]) -> ExecStartControlParams:
-    return validate_params_model(
-        ExecStartControlParams,
-        params,
-        on_error=raise_control_validation_error,
-    )
-
-
-def parse_exec_write_params(params: dict[str, Any]) -> ExecWriteControlParams:
-    return validate_params_model(
-        ExecWriteControlParams,
-        params,
-        on_error=raise_control_validation_error,
-    )
-
-
-def parse_exec_resize_params(params: dict[str, Any]) -> ExecResizeControlParams:
-    return validate_params_model(
-        ExecResizeControlParams,
-        params,
-        on_error=raise_control_validation_error,
-    )
-
-
-def parse_exec_terminate_params(params: dict[str, Any]) -> ExecTerminateControlParams:
-    return validate_params_model(
-        ExecTerminateControlParams,
-        params,
-        on_error=raise_control_validation_error,
-    )

--- a/src/codex_a2a/jsonrpc/interrupt_recovery.py
+++ b/src/codex_a2a/jsonrpc/interrupt_recovery.py
@@ -8,9 +8,9 @@ from starlette.responses import Response
 from codex_a2a.jsonrpc.errors import invalid_params_response
 from codex_a2a.jsonrpc.interrupt_recovery_params import (
     InterruptRecoveryListParams,
-    parse_interrupt_recovery_list_params,
+    raise_interrupt_recovery_validation_error,
 )
-from codex_a2a.jsonrpc.params_common import JsonRpcParamsValidationError
+from codex_a2a.jsonrpc.params_common import JsonRpcParamsValidationError, validate_params_model
 from codex_a2a.jsonrpc.request_models import JSONRPCRequestModel as JSONRPCRequest
 
 if TYPE_CHECKING:
@@ -25,7 +25,11 @@ async def handle_interrupt_recovery_request(
     request: Request,
 ) -> Response:
     try:
-        parsed_params: InterruptRecoveryListParams = parse_interrupt_recovery_list_params(params)
+        parsed_params = validate_params_model(
+            InterruptRecoveryListParams,
+            params,
+            on_error=raise_interrupt_recovery_validation_error,
+        )
     except JsonRpcParamsValidationError as exc:
         return invalid_params_response(app, base_request.id, exc)
 

--- a/src/codex_a2a/jsonrpc/interrupt_recovery_params.py
+++ b/src/codex_a2a/jsonrpc/interrupt_recovery_params.py
@@ -10,7 +10,6 @@ from codex_a2a.jsonrpc.params_common import (
     format_loc,
     map_extra_forbidden,
     strip_optional_string,
-    validate_params_model,
 )
 
 InterruptRecoveryType = Literal["permission", "question", "permissions", "elicitation"]
@@ -30,7 +29,7 @@ class InterruptRecoveryListParams(_StrictModel):
         return normalized
 
 
-def _raise_interrupt_recovery_validation_error(exc: ValidationError) -> None:
+def raise_interrupt_recovery_validation_error(exc: ValidationError) -> None:
     errors = exc.errors(include_url=False)
     if errors and all(err.get("type") == "extra_forbidden" for err in errors):
         raise map_extra_forbidden(errors)
@@ -42,12 +41,4 @@ def _raise_interrupt_recovery_validation_error(exc: ValidationError) -> None:
     raise JsonRpcParamsValidationError(
         message=message_text,
         data={"type": "INVALID_FIELD", "field": field},
-    )
-
-
-def parse_interrupt_recovery_list_params(params: dict[str, Any]) -> InterruptRecoveryListParams:
-    return validate_params_model(
-        InterruptRecoveryListParams,
-        params,
-        on_error=_raise_interrupt_recovery_validation_error,
     )

--- a/src/codex_a2a/jsonrpc/interrupts.py
+++ b/src/codex_a2a/jsonrpc/interrupts.py
@@ -78,13 +78,14 @@ async def handle_interrupt_callback_request(
     if metadata_error is not None:
         return metadata_error
 
-    if base_request.method == app._method_reject_question:
-        expected_interrupt_type = "question"
-    else:
-        expected_interrupt_type = interrupt_expected_type(
+    expected_interrupt_type = (
+        "question"
+        if isinstance(parsed_params, QuestionRejectParams)
+        else interrupt_expected_type(
             base_request.method,
             interrupt_methods_by_type=app._interrupt_methods_by_type,
         )
+    )
     binding, binding_error = await resolve_interrupt_binding(
         app,
         request_id=request_id,
@@ -105,10 +106,9 @@ async def handle_interrupt_callback_request(
         return owner_error
 
     try:
-        if base_request.method == app._method_reply_permission:
-            permission_params = cast(PermissionReplyParams, parsed_params)
-            reply = permission_params.reply
-            message = permission_params.message
+        if isinstance(parsed_params, PermissionReplyParams):
+            reply = parsed_params.reply
+            message = parsed_params.message
             await app._codex_client.permission_reply(
                 request_id,
                 reply=reply,
@@ -116,22 +116,20 @@ async def handle_interrupt_callback_request(
                 directory=directory,
             )
             result: dict[str, object] = {"ok": True, "request_id": request_id, "reply": reply}
-        elif base_request.method == app._method_reply_question:
-            question_params = cast(QuestionReplyParams, parsed_params)
-            answers = question_params.answers
+        elif isinstance(parsed_params, QuestionReplyParams):
+            answers = parsed_params.answers
             await app._codex_client.question_reply(
                 request_id,
                 answers=answers,
                 directory=directory,
             )
             result = {"ok": True, "request_id": request_id, "answers": answers}
-        elif base_request.method == app._method_reject_question:
+        elif isinstance(parsed_params, QuestionRejectParams):
             await app._codex_client.question_reject(request_id, directory=directory)
             result = {"ok": True, "request_id": request_id}
-        elif base_request.method == app._method_reply_permissions:
-            permissions_params = cast(PermissionsReplyParams, parsed_params)
-            permissions = permissions_params.permissions
-            scope = permissions_params.scope
+        elif isinstance(parsed_params, PermissionsReplyParams):
+            permissions = parsed_params.permissions
+            scope = parsed_params.scope
             await app._codex_client.permissions_reply(
                 request_id,
                 permissions=permissions,

--- a/src/codex_a2a/jsonrpc/params.py
+++ b/src/codex_a2a/jsonrpc/params.py
@@ -15,10 +15,6 @@ from codex_a2a.jsonrpc.exec_control_params import (
     ExecStartControlParams,
     ExecTerminateControlParams,
     ExecWriteControlParams,
-    parse_exec_resize_params,
-    parse_exec_start_params,
-    parse_exec_terminate_params,
-    parse_exec_write_params,
 )
 from codex_a2a.jsonrpc.interrupt_params import (
     ElicitationReplyParams,
@@ -29,7 +25,6 @@ from codex_a2a.jsonrpc.interrupt_params import (
 )
 from codex_a2a.jsonrpc.interrupt_recovery_params import (
     InterruptRecoveryListParams,
-    parse_interrupt_recovery_list_params,
 )
 from codex_a2a.jsonrpc.params_common import JsonRpcParamsValidationError, MetadataParams
 from codex_a2a.jsonrpc.query_params import (
@@ -39,8 +34,6 @@ from codex_a2a.jsonrpc.query_params import (
 from codex_a2a.jsonrpc.review_control_params import (
     ReviewStartControlParams,
     ReviewWatchControlParams,
-    parse_review_start_params,
-    parse_review_watch_params,
 )
 from codex_a2a.jsonrpc.thread_lifecycle_params import (
     ThreadArchiveControlParams,
@@ -49,16 +42,9 @@ from codex_a2a.jsonrpc.thread_lifecycle_params import (
     ThreadUnarchiveControlParams,
     ThreadWatchControlParams,
     ThreadWatchReleaseControlParams,
-    parse_thread_archive_params,
-    parse_thread_fork_params,
-    parse_thread_metadata_update_params,
-    parse_thread_unarchive_params,
-    parse_thread_watch_params,
-    parse_thread_watch_release_params,
 )
 from codex_a2a.jsonrpc.turn_control_params import (
     TurnSteerControlParams,
-    parse_turn_steer_params,
 )
 
 __all__ = [
@@ -93,20 +79,6 @@ __all__ = [
     "parse_discovery_plugins_list_params",
     "parse_discovery_skills_list_params",
     "parse_discovery_watch_params",
-    "parse_exec_resize_params",
-    "parse_exec_start_params",
-    "parse_exec_terminate_params",
-    "parse_exec_write_params",
     "parse_get_session_messages_params",
-    "parse_interrupt_recovery_list_params",
     "parse_list_sessions_params",
-    "parse_review_start_params",
-    "parse_review_watch_params",
-    "parse_thread_archive_params",
-    "parse_thread_fork_params",
-    "parse_thread_metadata_update_params",
-    "parse_thread_unarchive_params",
-    "parse_thread_watch_params",
-    "parse_thread_watch_release_params",
-    "parse_turn_steer_params",
 ]

--- a/src/codex_a2a/jsonrpc/review_control.py
+++ b/src/codex_a2a/jsonrpc/review_control.py
@@ -65,32 +65,24 @@ async def handle_review_control_request(
         return owner_error
 
     try:
-        if base_request.method == app._method_review_watch:
-            watch_params = (
-                parsed_params if isinstance(parsed_params, ReviewWatchControlParams) else None
-            )
-            assert watch_params is not None
+        if isinstance(parsed_params, ReviewWatchControlParams):
             call_context = app._context_builder.build(request)
             result = await app._review_runtime.start(
-                thread_id=watch_params.thread_id,
-                review_thread_id=watch_params.review_thread_id,
-                turn_id=watch_params.turn_id,
+                thread_id=parsed_params.thread_id,
+                review_thread_id=parsed_params.review_thread_id,
+                turn_id=parsed_params.turn_id,
                 request=(
                     None
-                    if watch_params.request is None
-                    else watch_params.request.model_dump(exclude_none=True)
+                    if parsed_params.request is None
+                    else parsed_params.request.model_dump(exclude_none=True)
                 ),
                 context=call_context,
             )
         else:
-            start_params = (
-                parsed_params if isinstance(parsed_params, ReviewStartControlParams) else None
-            )
-            assert start_params is not None
             result = await app._codex_client.review_start(
                 thread_id,
-                target=start_params.target.model_dump(exclude_none=True),
-                delivery=start_params.delivery,
+                target=parsed_params.target.model_dump(exclude_none=True),
+                delivery=parsed_params.delivery,
             )
     except PermissionError:
         return app._generate_error_response(

--- a/src/codex_a2a/jsonrpc/review_control.py
+++ b/src/codex_a2a/jsonrpc/review_control.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from a2a.server.jsonrpc_models import InternalError, InvalidParamsError, JSONRPCError
 from starlette.requests import Request
@@ -9,13 +9,12 @@ from starlette.responses import Response
 
 from codex_a2a.jsonrpc.errors import invalid_params_response
 from codex_a2a.jsonrpc.owner_guard import validate_thread_owner
-from codex_a2a.jsonrpc.params_common import JsonRpcParamsValidationError
+from codex_a2a.jsonrpc.params_common import JsonRpcParamsValidationError, validate_params_model
 from codex_a2a.jsonrpc.request_models import JSONRPCRequestModel as JSONRPCRequest
 from codex_a2a.jsonrpc.review_control_params import (
     ReviewStartControlParams,
     ReviewWatchControlParams,
-    parse_review_start_params,
-    parse_review_watch_params,
+    raise_review_control_validation_error,
 )
 from codex_a2a.upstream.models import CodexRPCError
 
@@ -35,13 +34,20 @@ async def handle_review_control_request(
     *,
     request: Request,
 ) -> Response:
+    model_type = (
+        ReviewWatchControlParams
+        if base_request.method == app._method_review_watch
+        else ReviewStartControlParams
+    )
     try:
-        if base_request.method == app._method_review_watch:
-            parsed_params: ReviewStartControlParams | ReviewWatchControlParams = (
-                parse_review_watch_params(params)
-            )
-        else:
-            parsed_params = parse_review_start_params(params)
+        parsed_params: ReviewStartControlParams | ReviewWatchControlParams = cast(
+            ReviewStartControlParams | ReviewWatchControlParams,
+            validate_params_model(
+                model_type,
+                params,
+                on_error=raise_review_control_validation_error,
+            ),
+        )
     except JsonRpcParamsValidationError as exc:
         return invalid_params_response(app, base_request.id, exc)
 

--- a/src/codex_a2a/jsonrpc/review_control_params.py
+++ b/src/codex_a2a/jsonrpc/review_control_params.py
@@ -12,7 +12,6 @@ from codex_a2a.jsonrpc.params_common import (
     map_extra_forbidden,
     normalize_non_empty_string,
     strip_optional_string,
-    validate_params_model,
     validate_required_thread_id,
 )
 
@@ -113,7 +112,7 @@ class ReviewWatchControlParams(_StrictModel):
         return normalize_non_empty_string(value, message=f"Missing required params.{field_name}")
 
 
-def _raise_review_control_validation_error(exc: ValidationError) -> None:
+def raise_review_control_validation_error(exc: ValidationError) -> None:
     errors = exc.errors(include_url=False)
     if errors and all(err.get("type") == "extra_forbidden" for err in errors):
         raise map_extra_forbidden(errors)
@@ -183,19 +182,3 @@ def _raise_review_control_validation_error(exc: ValidationError) -> None:
             data={"type": "INVALID_FIELD", "field": field},
         )
     raise JsonRpcParamsValidationError(message=message_text, data={"type": "INVALID_FIELD"})
-
-
-def parse_review_start_params(params: dict[str, Any]) -> ReviewStartControlParams:
-    return validate_params_model(
-        ReviewStartControlParams,
-        params,
-        on_error=_raise_review_control_validation_error,
-    )
-
-
-def parse_review_watch_params(params: dict[str, Any]) -> ReviewWatchControlParams:
-    return validate_params_model(
-        ReviewWatchControlParams,
-        params,
-        on_error=_raise_review_control_validation_error,
-    )

--- a/src/codex_a2a/jsonrpc/session_query.py
+++ b/src/codex_a2a/jsonrpc/session_query.py
@@ -39,8 +39,9 @@ async def handle_session_query_request(
     base_request: JSONRPCRequest,
     params: dict[str, Any],
 ) -> Response:
+    is_list_sessions = base_request.method == app._method_list_sessions
     try:
-        if base_request.method == app._method_list_sessions:
+        if is_list_sessions:
             query = parse_list_sessions_params(params)
             session_id: str | None = None
         else:
@@ -55,7 +56,7 @@ async def handle_session_query_request(
             raw_result = await app._codex_client.list_messages(session_id, params=query)
     except httpx.HTTPStatusError as exc:
         upstream_status = exc.response.status_code
-        if upstream_status == 404 and base_request.method == app._method_get_session_messages:
+        if upstream_status == 404 and not is_list_sessions:
             return app._generate_error_response(
                 base_request.id,
                 JSONRPCError(
@@ -97,7 +98,7 @@ async def handle_session_query_request(
         )
 
     try:
-        if base_request.method == app._method_list_sessions:
+        if is_list_sessions:
             raw_items = extract_raw_items(raw_result, kind="sessions")
         else:
             raw_items = extract_raw_items(raw_result, kind="messages")
@@ -112,7 +113,7 @@ async def handle_session_query_request(
             ),
         )
 
-    if base_request.method == app._method_list_sessions:
+    if is_list_sessions:
         items = [task for item in raw_items if (task := as_a2a_session_task(item)) is not None]
     else:
         assert session_id is not None

--- a/src/codex_a2a/jsonrpc/thread_lifecycle_control.py
+++ b/src/codex_a2a/jsonrpc/thread_lifecycle_control.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import httpx
 from a2a.server.jsonrpc_models import InternalError, JSONRPCError
@@ -14,7 +14,7 @@ from codex_a2a.jsonrpc.errors import (
     upstream_unreachable_response,
 )
 from codex_a2a.jsonrpc.owner_guard import validate_thread_owner
-from codex_a2a.jsonrpc.params_common import JsonRpcParamsValidationError
+from codex_a2a.jsonrpc.params_common import JsonRpcParamsValidationError, validate_params_model
 from codex_a2a.jsonrpc.request_models import JSONRPCRequestModel as JSONRPCRequest
 from codex_a2a.jsonrpc.thread_lifecycle_params import (
     ThreadArchiveControlParams,
@@ -23,12 +23,7 @@ from codex_a2a.jsonrpc.thread_lifecycle_params import (
     ThreadUnarchiveControlParams,
     ThreadWatchControlParams,
     ThreadWatchReleaseControlParams,
-    parse_thread_archive_params,
-    parse_thread_fork_params,
-    parse_thread_metadata_update_params,
-    parse_thread_unarchive_params,
-    parse_thread_watch_params,
-    parse_thread_watch_release_params,
+    raise_thread_lifecycle_validation_error,
 )
 
 if TYPE_CHECKING:
@@ -60,24 +55,43 @@ async def handle_thread_lifecycle_control_request(
     thread_id: str | None = None
     task_id: str | None = None
 
+    model_type = (
+        ThreadForkControlParams
+        if base_request.method == app._method_thread_fork
+        else ThreadArchiveControlParams
+        if base_request.method == app._method_thread_archive
+        else ThreadUnarchiveControlParams
+        if base_request.method == app._method_thread_unarchive
+        else ThreadMetadataUpdateControlParams
+        if base_request.method == app._method_thread_metadata_update
+        else ThreadWatchReleaseControlParams
+        if base_request.method == app._method_thread_watch_release
+        else ThreadWatchControlParams
+    )
     try:
+        parsed_params = cast(
+            ThreadForkControlParams
+            | ThreadArchiveControlParams
+            | ThreadUnarchiveControlParams
+            | ThreadMetadataUpdateControlParams
+            | ThreadWatchControlParams
+            | ThreadWatchReleaseControlParams,
+            validate_params_model(
+                model_type,
+                params,
+                on_error=raise_thread_lifecycle_validation_error,
+            ),
+        )
         if base_request.method == app._method_thread_fork:
-            parsed_params = parse_thread_fork_params(params)
-            thread_id = parsed_params.thread_id
+            thread_id = cast(ThreadForkControlParams, parsed_params).thread_id
         elif base_request.method == app._method_thread_archive:
-            parsed_params = parse_thread_archive_params(params)
-            thread_id = parsed_params.thread_id
+            thread_id = cast(ThreadArchiveControlParams, parsed_params).thread_id
         elif base_request.method == app._method_thread_unarchive:
-            parsed_params = parse_thread_unarchive_params(params)
-            thread_id = parsed_params.thread_id
+            thread_id = cast(ThreadUnarchiveControlParams, parsed_params).thread_id
         elif base_request.method == app._method_thread_metadata_update:
-            parsed_params = parse_thread_metadata_update_params(params)
-            thread_id = parsed_params.thread_id
+            thread_id = cast(ThreadMetadataUpdateControlParams, parsed_params).thread_id
         elif base_request.method == app._method_thread_watch_release:
-            parsed_params = parse_thread_watch_release_params(params)
-            task_id = parsed_params.task_id
-        else:
-            parsed_params = parse_thread_watch_params(params)
+            task_id = cast(ThreadWatchReleaseControlParams, parsed_params).task_id
     except JsonRpcParamsValidationError as exc:
         return invalid_params_response(app, base_request.id, exc)
 

--- a/src/codex_a2a/jsonrpc/thread_lifecycle_control.py
+++ b/src/codex_a2a/jsonrpc/thread_lifecycle_control.py
@@ -82,16 +82,18 @@ async def handle_thread_lifecycle_control_request(
                 on_error=raise_thread_lifecycle_validation_error,
             ),
         )
-        if base_request.method == app._method_thread_fork:
-            thread_id = cast(ThreadForkControlParams, parsed_params).thread_id
-        elif base_request.method == app._method_thread_archive:
-            thread_id = cast(ThreadArchiveControlParams, parsed_params).thread_id
-        elif base_request.method == app._method_thread_unarchive:
-            thread_id = cast(ThreadUnarchiveControlParams, parsed_params).thread_id
-        elif base_request.method == app._method_thread_metadata_update:
-            thread_id = cast(ThreadMetadataUpdateControlParams, parsed_params).thread_id
-        elif base_request.method == app._method_thread_watch_release:
-            task_id = cast(ThreadWatchReleaseControlParams, parsed_params).task_id
+        if isinstance(
+            parsed_params,
+            (
+                ThreadForkControlParams,
+                ThreadArchiveControlParams,
+                ThreadUnarchiveControlParams,
+                ThreadMetadataUpdateControlParams,
+            ),
+        ):
+            thread_id = parsed_params.thread_id
+        elif isinstance(parsed_params, ThreadWatchReleaseControlParams):
+            task_id = parsed_params.task_id
     except JsonRpcParamsValidationError as exc:
         return invalid_params_response(app, base_request.id, exc)
 
@@ -109,72 +111,45 @@ async def handle_thread_lifecycle_control_request(
             return owner_error
 
     try:
-        if base_request.method == app._method_thread_watch:
+        if isinstance(parsed_params, ThreadWatchControlParams):
             call_context = app._context_builder.build(request)
-            watch_params = (
-                parsed_params if isinstance(parsed_params, ThreadWatchControlParams) else None
-            )
             result = await app._thread_lifecycle_runtime.start(
                 request=(
                     None
-                    if watch_params is None or watch_params.request is None
-                    else watch_params.request.model_dump(
+                    if parsed_params.request is None
+                    else parsed_params.request.model_dump(
                         by_alias=False,
                         exclude_none=True,
                     )
                 ),
                 context=call_context,
             )
-        elif base_request.method == app._method_thread_watch_release:
+        elif isinstance(parsed_params, ThreadWatchReleaseControlParams):
             call_context = app._context_builder.build(request)
-            watch_release_params = (
-                parsed_params
-                if isinstance(parsed_params, ThreadWatchReleaseControlParams)
-                else None
-            )
-            assert watch_release_params is not None
             result = await app._thread_lifecycle_runtime.release(
-                task_id=watch_release_params.task_id,
+                task_id=parsed_params.task_id,
                 context=call_context,
             )
-        elif base_request.method == app._method_thread_fork:
-            fork_params = (
-                parsed_params if isinstance(parsed_params, ThreadForkControlParams) else None
-            )
-            assert fork_params is not None
+        elif isinstance(parsed_params, ThreadForkControlParams):
             thread = await app._codex_client.thread_fork(
-                fork_params.thread_id,
+                parsed_params.thread_id,
                 params=(
                     None
-                    if fork_params.request is None
-                    else fork_params.request.model_dump(exclude_none=True)
+                    if parsed_params.request is None
+                    else parsed_params.request.model_dump(exclude_none=True)
                 ),
             )
             result = {"ok": True, "thread_id": thread["id"], "thread": thread}
-        elif base_request.method == app._method_thread_archive:
-            archive_params = (
-                parsed_params if isinstance(parsed_params, ThreadArchiveControlParams) else None
-            )
-            assert archive_params is not None
-            await app._codex_client.thread_archive(archive_params.thread_id)
-            result = {"ok": True, "thread_id": archive_params.thread_id}
-        elif base_request.method == app._method_thread_unarchive:
-            unarchive_params = (
-                parsed_params if isinstance(parsed_params, ThreadUnarchiveControlParams) else None
-            )
-            assert unarchive_params is not None
-            thread = await app._codex_client.thread_unarchive(unarchive_params.thread_id)
+        elif isinstance(parsed_params, ThreadArchiveControlParams):
+            await app._codex_client.thread_archive(parsed_params.thread_id)
+            result = {"ok": True, "thread_id": parsed_params.thread_id}
+        elif isinstance(parsed_params, ThreadUnarchiveControlParams):
+            thread = await app._codex_client.thread_unarchive(parsed_params.thread_id)
             result = {"ok": True, "thread_id": thread["id"], "thread": thread}
         else:
-            metadata_params = (
-                parsed_params
-                if isinstance(parsed_params, ThreadMetadataUpdateControlParams)
-                else None
-            )
-            assert metadata_params is not None
             thread = await app._codex_client.thread_metadata_update(
-                metadata_params.thread_id,
-                params=metadata_params.request.model_dump(
+                parsed_params.thread_id,
+                params=parsed_params.request.model_dump(
                     by_alias=False,
                     exclude_none=False,
                     exclude_unset=True,

--- a/src/codex_a2a/jsonrpc/thread_lifecycle_params.py
+++ b/src/codex_a2a/jsonrpc/thread_lifecycle_params.py
@@ -14,7 +14,6 @@ from codex_a2a.jsonrpc.params_common import (
     metadata_validation_error,
     normalize_non_empty_string,
     strip_optional_string,
-    validate_params_model,
     validate_required_thread_id,
 )
 
@@ -140,7 +139,7 @@ class ThreadWatchReleaseControlParams(_StrictModel):
         return normalize_non_empty_string(value, message="Missing required params.task_id")
 
 
-def _raise_thread_lifecycle_validation_error(exc: ValidationError) -> None:
+def raise_thread_lifecycle_validation_error(exc: ValidationError) -> None:
     errors = exc.errors(include_url=False)
     if errors and all(err.get("type") == "extra_forbidden" for err in errors):
         raise map_extra_forbidden(errors)
@@ -217,53 +216,3 @@ def _raise_thread_lifecycle_validation_error(exc: ValidationError) -> None:
             data={"type": "INVALID_FIELD", "field": field},
         )
     raise JsonRpcParamsValidationError(message=message_text, data={"type": "INVALID_FIELD"})
-
-
-def parse_thread_fork_params(params: dict[str, Any]) -> ThreadForkControlParams:
-    return validate_params_model(
-        ThreadForkControlParams,
-        params,
-        on_error=_raise_thread_lifecycle_validation_error,
-    )
-
-
-def parse_thread_archive_params(params: dict[str, Any]) -> ThreadArchiveControlParams:
-    return validate_params_model(
-        ThreadArchiveControlParams,
-        params,
-        on_error=_raise_thread_lifecycle_validation_error,
-    )
-
-
-def parse_thread_unarchive_params(params: dict[str, Any]) -> ThreadUnarchiveControlParams:
-    return validate_params_model(
-        ThreadUnarchiveControlParams,
-        params,
-        on_error=_raise_thread_lifecycle_validation_error,
-    )
-
-
-def parse_thread_metadata_update_params(
-    params: dict[str, Any],
-) -> ThreadMetadataUpdateControlParams:
-    return validate_params_model(
-        ThreadMetadataUpdateControlParams,
-        params,
-        on_error=_raise_thread_lifecycle_validation_error,
-    )
-
-
-def parse_thread_watch_params(params: dict[str, Any]) -> ThreadWatchControlParams:
-    return validate_params_model(
-        ThreadWatchControlParams,
-        params,
-        on_error=_raise_thread_lifecycle_validation_error,
-    )
-
-
-def parse_thread_watch_release_params(params: dict[str, Any]) -> ThreadWatchReleaseControlParams:
-    return validate_params_model(
-        ThreadWatchReleaseControlParams,
-        params,
-        on_error=_raise_thread_lifecycle_validation_error,
-    )

--- a/src/codex_a2a/jsonrpc/turn_control.py
+++ b/src/codex_a2a/jsonrpc/turn_control.py
@@ -17,11 +17,14 @@ from codex_a2a.jsonrpc.errors import (
     invalid_params_response,
 )
 from codex_a2a.jsonrpc.owner_guard import validate_thread_owner
-from codex_a2a.jsonrpc.params_common import JsonRpcParamsValidationError
+from codex_a2a.jsonrpc.params_common import (
+    JsonRpcParamsValidationError,
+    validate_params_model,
+)
 from codex_a2a.jsonrpc.request_models import JSONRPCRequestModel as JSONRPCRequest
 from codex_a2a.jsonrpc.turn_control_params import (
     TurnSteerControlParams,
-    parse_turn_steer_params,
+    raise_turn_control_validation_error,
 )
 from codex_a2a.upstream.models import CodexRPCError
 
@@ -42,7 +45,11 @@ async def handle_turn_control_request(
     request: Request,
 ) -> Response:
     try:
-        parsed_params: TurnSteerControlParams = parse_turn_steer_params(params)
+        parsed_params = validate_params_model(
+            TurnSteerControlParams,
+            params,
+            on_error=raise_turn_control_validation_error,
+        )
     except JsonRpcParamsValidationError as exc:
         return invalid_params_response(app, base_request.id, exc)
 

--- a/src/codex_a2a/jsonrpc/turn_control_params.py
+++ b/src/codex_a2a/jsonrpc/turn_control_params.py
@@ -12,7 +12,6 @@ from codex_a2a.jsonrpc.params_common import (
     normalize_non_empty_string,
     strip_optional_string,
     validate_non_empty_parts,
-    validate_params_model,
     validate_required_thread_id,
 )
 
@@ -100,7 +99,7 @@ class TurnSteerControlParams(_StrictModel):
         )
 
 
-def _raise_turn_control_validation_error(exc: ValidationError) -> None:
+def raise_turn_control_validation_error(exc: ValidationError) -> None:
     errors = exc.errors(include_url=False)
     if errors and all(err.get("type") == "extra_forbidden" for err in errors):
         raise map_extra_forbidden(errors)
@@ -146,11 +145,3 @@ def _raise_turn_control_validation_error(exc: ValidationError) -> None:
             data={"type": "INVALID_FIELD", "field": field},
         )
     raise JsonRpcParamsValidationError(message=message_text, data={"type": "INVALID_FIELD"})
-
-
-def parse_turn_steer_params(params: dict[str, Any]) -> TurnSteerControlParams:
-    return validate_params_model(
-        TurnSteerControlParams,
-        params,
-        on_error=_raise_turn_control_validation_error,
-    )

--- a/tests/jsonrpc/test_jsonrpc_models.py
+++ b/tests/jsonrpc/test_jsonrpc_models.py
@@ -13,6 +13,10 @@ from codex_a2a.jsonrpc.interrupt_params import (
     PermissionsReplyParams,
     raise_interrupt_validation_error,
 )
+from codex_a2a.jsonrpc.interrupt_recovery_params import (
+    InterruptRecoveryListParams,
+    raise_interrupt_recovery_validation_error,
+)
 from codex_a2a.jsonrpc.params import (
     JsonRpcParamsValidationError,
     parse_discovery_apps_list_params,
@@ -21,18 +25,26 @@ from codex_a2a.jsonrpc.params import (
     parse_discovery_skills_list_params,
     parse_discovery_watch_params,
     parse_get_session_messages_params,
-    parse_interrupt_recovery_list_params,
     parse_list_sessions_params,
-    parse_review_start_params,
-    parse_review_watch_params,
-    parse_thread_archive_params,
-    parse_thread_fork_params,
-    parse_thread_metadata_update_params,
-    parse_thread_watch_params,
-    parse_thread_watch_release_params,
-    parse_turn_steer_params,
 )
 from codex_a2a.jsonrpc.params_common import validate_params_model
+from codex_a2a.jsonrpc.review_control_params import (
+    ReviewStartControlParams,
+    ReviewWatchControlParams,
+    raise_review_control_validation_error,
+)
+from codex_a2a.jsonrpc.thread_lifecycle_params import (
+    ThreadArchiveControlParams,
+    ThreadForkControlParams,
+    ThreadMetadataUpdateControlParams,
+    ThreadWatchControlParams,
+    ThreadWatchReleaseControlParams,
+    raise_thread_lifecycle_validation_error,
+)
+from codex_a2a.jsonrpc.turn_control_params import (
+    TurnSteerControlParams,
+    raise_turn_control_validation_error,
+)
 
 ModelT = TypeVar("ModelT", bound=A2ABaseModel)
 
@@ -45,6 +57,44 @@ def _parse_interrupt_reply_params(
         model_type,
         payload,
         on_error=raise_interrupt_validation_error,
+    )
+
+
+def _parse_interrupt_recovery_params(payload: dict[str, object]) -> InterruptRecoveryListParams:
+    return validate_params_model(
+        InterruptRecoveryListParams,
+        payload,
+        on_error=raise_interrupt_recovery_validation_error,
+    )
+
+
+def _parse_thread_lifecycle_params(
+    model_type: type[ModelT],
+    payload: dict[str, object],
+) -> ModelT:
+    return validate_params_model(
+        model_type,
+        payload,
+        on_error=raise_thread_lifecycle_validation_error,
+    )
+
+
+def _parse_turn_control_params(payload: dict[str, object]) -> TurnSteerControlParams:
+    return validate_params_model(
+        TurnSteerControlParams,
+        payload,
+        on_error=raise_turn_control_validation_error,
+    )
+
+
+def _parse_review_control_params(
+    model_type: type[ModelT],
+    payload: dict[str, object],
+) -> ModelT:
+    return validate_params_model(
+        model_type,
+        payload,
+        on_error=raise_review_control_validation_error,
     )
 
 
@@ -104,14 +154,14 @@ def test_parse_list_sessions_params_rejects_non_integer_limit() -> None:
 
 
 def test_parse_interrupt_recovery_list_params_accepts_type_aliases() -> None:
-    payload = parse_interrupt_recovery_list_params({"interrupt_type": "permissions"})
+    payload = _parse_interrupt_recovery_params({"interrupt_type": "permissions"})
 
     assert payload.interrupt_type == "permissions"
 
 
 def test_parse_interrupt_recovery_list_params_rejects_invalid_type() -> None:
     with pytest.raises(JsonRpcParamsValidationError) as exc_info:
-        parse_interrupt_recovery_list_params({"interrupt_type": "unknown"})
+        _parse_interrupt_recovery_params({"interrupt_type": "unknown"})
 
     assert str(exc_info.value) == (
         "type must be one of: permission, question, permissions, elicitation"
@@ -154,28 +204,34 @@ def test_parse_get_session_messages_params_applies_default_limit() -> None:
 
 
 def test_parse_thread_lifecycle_params_preserve_aliases() -> None:
-    fork = parse_thread_fork_params(
+    fork = _parse_thread_lifecycle_params(
+        ThreadForkControlParams,
         {
             "thread_id": "thr-1",
             "request": {"ephemeral": True},
             "metadata": {"codex": {"directory": "/workspace"}},
-        }
+        },
     )
-    metadata_update = parse_thread_metadata_update_params(
+    metadata_update = _parse_thread_lifecycle_params(
+        ThreadMetadataUpdateControlParams,
         {
             "thread_id": "thr-1",
             "request": {"git_info": {"branch": "feat/thread-lifecycle", "origin_url": "https://x"}},
-        }
+        },
     )
-    watch = parse_thread_watch_params(
+    watch = _parse_thread_lifecycle_params(
+        ThreadWatchControlParams,
         {
             "request": {
                 "events": ["thread.started", "thread.status.changed", "thread.started"],
                 "thread_ids": ["thr-1", "thr-2", "thr-1"],
             }
-        }
+        },
     )
-    watch_release = parse_thread_watch_release_params({"task_id": "task-watch-1"})
+    watch_release = _parse_thread_lifecycle_params(
+        ThreadWatchReleaseControlParams,
+        {"task_id": "task-watch-1"},
+    )
 
     assert fork.thread_id == "thr-1"
     assert fork.request is not None
@@ -198,7 +254,7 @@ def test_parse_thread_lifecycle_params_preserve_aliases() -> None:
 
 
 def test_parse_turn_and_review_control_params_use_canonical_shapes() -> None:
-    steer = parse_turn_steer_params(
+    steer = _parse_turn_control_params(
         {
             "thread_id": "thr-1",
             "expected_turn_id": "turn-1",
@@ -208,9 +264,10 @@ def test_parse_turn_and_review_control_params_use_canonical_shapes() -> None:
                     {"type": "mention", "name": "Demo App", "path": "app://demo-app"},
                 ]
             },
-        }
+        },
     )
-    review = parse_review_start_params(
+    review = _parse_review_control_params(
+        ReviewStartControlParams,
         {
             "thread_id": "thr-1",
             "delivery": "detached",
@@ -219,15 +276,16 @@ def test_parse_turn_and_review_control_params_use_canonical_shapes() -> None:
                 "sha": "commit-demo-123",
                 "title": "Polish tui colors",
             },
-        }
+        },
     )
-    review_watch = parse_review_watch_params(
+    review_watch = _parse_review_control_params(
+        ReviewWatchControlParams,
         {
             "thread_id": "thr-1",
             "review_thread_id": "thr-1-review",
             "turn_id": "turn-review-1",
             "request": {"events": ["review.started", "review.completed", "review.started"]},
-        }
+        },
     )
 
     assert steer.thread_id == "thr-1"
@@ -258,25 +316,28 @@ def test_parse_turn_and_review_control_params_use_canonical_shapes() -> None:
     ("parser", "payload", "message", "field"),
     [
         (
-            parse_thread_archive_params,
+            lambda payload: _parse_thread_lifecycle_params(ThreadArchiveControlParams, payload),
             {"thread_id": "   "},
             "Missing required params.thread_id",
             "thread_id",
         ),
         (
-            parse_thread_fork_params,
+            lambda payload: _parse_thread_lifecycle_params(ThreadForkControlParams, payload),
             {"thread_id": "thr-1", "request": {"ephemeral": "yes"}},
             "request.ephemeral must be a boolean",
             "request.ephemeral",
         ),
         (
-            parse_thread_metadata_update_params,
+            lambda payload: _parse_thread_lifecycle_params(
+                ThreadMetadataUpdateControlParams,
+                payload,
+            ),
             {"thread_id": "thr-1", "request": {"git_info": {}}},
             "request.git_info must include at least one field",
             "request.git_info",
         ),
         (
-            parse_thread_watch_params,
+            lambda payload: _parse_thread_lifecycle_params(ThreadWatchControlParams, payload),
             {"request": {"events": ["thread.deleted"]}},
             (
                 "request.events entries must be one of: thread.started, "
@@ -285,13 +346,16 @@ def test_parse_turn_and_review_control_params_use_canonical_shapes() -> None:
             "request.events",
         ),
         (
-            parse_thread_watch_params,
+            lambda payload: _parse_thread_lifecycle_params(ThreadWatchControlParams, payload),
             {"request": {"thread_ids": ["thr-1", "  "]}},
             "request.thread_ids[] must be a non-empty string",
             "request.thread_ids",
         ),
         (
-            parse_thread_watch_release_params,
+            lambda payload: _parse_thread_lifecycle_params(
+                ThreadWatchReleaseControlParams,
+                payload,
+            ),
             {"task_id": "   "},
             "Missing required params.task_id",
             "task_id",
@@ -316,7 +380,7 @@ def test_parse_thread_lifecycle_params_reject_invalid_fields(
     ("parser", "payload", "message", "field"),
     [
         (
-            parse_turn_steer_params,
+            _parse_turn_control_params,
             {
                 "thread_id": "thr-1",
                 "expected_turn_id": "turn-1",
@@ -326,7 +390,7 @@ def test_parse_thread_lifecycle_params_reject_invalid_fields(
             "request.parts",
         ),
         (
-            parse_turn_steer_params,
+            _parse_turn_control_params,
             {
                 "thread_id": "thr-1",
                 "expected_turn_id": "turn-1",
@@ -336,25 +400,25 @@ def test_parse_thread_lifecycle_params_reject_invalid_fields(
             "request.parts[0].type",
         ),
         (
-            parse_review_start_params,
+            lambda payload: _parse_review_control_params(ReviewStartControlParams, payload),
             {"thread_id": "thr-1", "delivery": "queued", "target": {"type": "commit", "sha": "a"}},
             "delivery must be one of: inline, detached",
             "delivery",
         ),
         (
-            parse_review_start_params,
+            lambda payload: _parse_review_control_params(ReviewStartControlParams, payload),
             {"thread_id": "thr-1", "target": {"type": "baseBranch"}},
             "target.branch must be a non-empty string",
             "target.branch",
         ),
         (
-            parse_review_start_params,
+            lambda payload: _parse_review_control_params(ReviewStartControlParams, payload),
             {"thread_id": "thr-1", "target": {"type": "custom", "instructions": "   "}},
             "target.instructions must be a non-empty string",
             "target.instructions",
         ),
         (
-            parse_review_watch_params,
+            lambda payload: _parse_review_control_params(ReviewWatchControlParams, payload),
             {
                 "thread_id": "thr-1",
                 "review_thread_id": "thr-1-review",
@@ -368,7 +432,7 @@ def test_parse_thread_lifecycle_params_reject_invalid_fields(
             "request.events",
         ),
         (
-            parse_review_watch_params,
+            lambda payload: _parse_review_control_params(ReviewWatchControlParams, payload),
             {
                 "thread_id": "thr-1",
                 "review_thread_id": "thr-1-review",


### PR DESCRIPTION
## 背景
本 PR 基于 `#282`，继续审查并收敛 `jsonrpc` 参数解析与控制层中的非必要套壳、纯透传 parser、重复 method 分发和多层跳转。

Closes #282

## 变更说明
### jsonrpc params
- 移除 `interrupt_recovery`、`exec_control`、`review_control`、`thread_lifecycle`、`turn_control` 参数模块中的纯透传 `parse_*` 包装层。
- 保留各模块的模型类型与模块级错误语义，并将错误映射函数提升为控制层可直接复用的验证入口。
- 收口 `codex_a2a.jsonrpc.params` 的导出面，去掉上述已删除 parser 的聚合导出。

### jsonrpc control
- `exec_control.py`、`review_control.py`、`thread_lifecycle_control.py`、`interrupt_recovery.py`、`turn_control.py` 改为直接执行 `validate_params_model(...)`，不再通过 `*_params.py` 中的薄壳 parser 中转。
- `exec_control.py`、`review_control.py`、`thread_lifecycle_control.py`、`interrupts.py` 将后续执行分发从重复的 method 判断进一步收敛为按已解析参数类型分发。
- `session_query.py` 收口重复的 `list_sessions` 分支判断，避免在解析、错误处理和结果映射中重复判断同一 method。

### tests
- `tests/jsonrpc/test_jsonrpc_models.py` 改为直接验证“模型 + 模块级错误映射”的组合，不再依赖已删除的纯透传 parser。
- 保留 discovery/query 相关 parser 的测试路径，因为这些入口仍承担 shape 归一化和返回结构转换，不属于空壳。

## 兼容性说明
### Breaking changes
- 删除了一批仅做透传的 `parse_*` 入口及其在 `codex_a2a.jsonrpc.params` 中的聚合导出。
- 本次调整假设当前版本允许直接升级，不保留这批旧兼容入口。

## 验证
- `bash ./scripts/validate_baseline.sh`

## 审查结论
- 本次收敛后，`jsonrpc` 参数层的高确信纯壳和控制层双重分发已基本清理完成。
- `discovery_params.py` 与 `query_params.py` 中仍保留的 parser 具备真实 shape 转换职责，当前保留是有意的，不属于遗漏。
