### PR TITLE
fix: align persistence integration with a2a-sdk

### DIFF
--- a/src/codex_a2a/server/application.py
+++ b/src/codex_a2a/server/application.py
@@ -34,7 +34,7 @@ from codex_a2a.server.openapi import patch_openapi_contract
 from codex_a2a.server.push_config_store import build_push_config_store_runtime
 from codex_a2a.server.request_handler import CodexRequestHandler
 from codex_a2a.server.runtime_state import build_runtime_state_runtime
-from codex_a2a.server.task_store import build_task_store_runtime
+from codex_a2a.server.task_store import build_task_store_runtime, describe_persistence_backend
 from codex_a2a.upstream.client import CodexClient
 
 from .http_middlewares import (
@@ -42,6 +42,8 @@ from .http_middlewares import (
     PathScopedGZipMiddleware,
     install_http_middlewares,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def create_app(settings: Settings) -> FastAPI:
@@ -71,6 +73,7 @@ def create_app(settings: Settings) -> FastAPI:
         engine=shared_database_engine,
     )
     task_store = task_store_runtime.task_store
+    persistence_summary = describe_persistence_backend(settings)
     runtime_profile = build_runtime_profile(settings)
     capability_snapshot = extension_contracts.build_capability_snapshot(
         runtime_profile=runtime_profile
@@ -107,6 +110,16 @@ def create_app(settings: Settings) -> FastAPI:
 
     @asynccontextmanager
     async def lifespan(_app: FastAPI):
+        logger.info(
+            "A2A persistence configured backend=%s task_store=%s push_config_store=%s "
+            "runtime_state=%s database_url=%s sqlite_tuning=%s",
+            persistence_summary["backend"],
+            persistence_summary["task_store"],
+            persistence_summary["push_config_store"],
+            persistence_summary["runtime_state"],
+            persistence_summary["database_url"],
+            persistence_summary["sqlite_tuning"],
+        )
         await task_store_runtime.startup()
         await push_config_store_runtime.startup()
         await runtime_state_runtime.startup()

--- a/src/codex_a2a/server/application.py
+++ b/src/codex_a2a/server/application.py
@@ -31,6 +31,7 @@ from codex_a2a.server.agent_card import (
 from codex_a2a.server.call_context import IdentityAwareCallContextBuilder
 from codex_a2a.server.database import build_database_engine
 from codex_a2a.server.openapi import patch_openapi_contract
+from codex_a2a.server.push_config_store import build_push_config_store_runtime
 from codex_a2a.server.request_handler import CodexRequestHandler
 from codex_a2a.server.runtime_state import build_runtime_state_runtime
 from codex_a2a.server.task_store import build_task_store_runtime
@@ -65,6 +66,10 @@ def create_app(settings: Settings) -> FastAPI:
         session_state_store=runtime_state_runtime.state_store,
     )
     task_store_runtime = build_task_store_runtime(settings, engine=shared_database_engine)
+    push_config_store_runtime = build_push_config_store_runtime(
+        settings,
+        engine=shared_database_engine,
+    )
     task_store = task_store_runtime.task_store
     runtime_profile = build_runtime_profile(settings)
     capability_snapshot = extension_contracts.build_capability_snapshot(
@@ -78,6 +83,7 @@ def create_app(settings: Settings) -> FastAPI:
     handler = CodexRequestHandler(
         agent_executor=executor,
         task_store=task_store,
+        push_config_store=push_config_store_runtime.push_config_store,
         agent_card=agent_card,
         extended_agent_card=extended_agent_card,
     )
@@ -102,6 +108,7 @@ def create_app(settings: Settings) -> FastAPI:
     @asynccontextmanager
     async def lifespan(_app: FastAPI):
         await task_store_runtime.startup()
+        await push_config_store_runtime.startup()
         await runtime_state_runtime.startup()
         try:
             await client.restore_persisted_interrupt_requests()
@@ -112,6 +119,7 @@ def create_app(settings: Settings) -> FastAPI:
             await a2a_client_manager.close_all()
             await client.close()
             await runtime_state_runtime.shutdown()
+            await push_config_store_runtime.shutdown()
             await task_store_runtime.shutdown()
             if shared_database_engine is not None:
                 await shared_database_engine.dispose()
@@ -187,6 +195,7 @@ def create_app(settings: Settings) -> FastAPI:
     app.state.codex_thread_lifecycle_runtime = thread_lifecycle_runtime
     app.state.a2a_client_manager = a2a_client_manager
     app.state.task_store = task_store
+    app.state.push_config_store = push_config_store_runtime.push_config_store
 
     if settings.a2a_enable_health_endpoint:
 

--- a/src/codex_a2a/server/call_context.py
+++ b/src/codex_a2a/server/call_context.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from a2a.server.routes.common import DefaultServerCallContextBuilder
+from a2a.server.routes.common import DefaultServerCallContextBuilder, StarletteUser
 from fastapi import Request
+from starlette.authentication import SimpleUser
 
 if TYPE_CHECKING:
     from a2a.server.context import ServerCallContext
@@ -39,6 +40,8 @@ class IdentityAwareCallContextBuilder(DefaultServerCallContextBuilder):
         identity = getattr(request.state, "user_identity", None)
         if identity:
             context.state["identity"] = identity
+            if not context.user.user_name:
+                context.user = StarletteUser(SimpleUser(identity))
         credential_id = getattr(request.state, "user_credential_id", None)
         if isinstance(credential_id, str) and credential_id:
             context.state["credential_id"] = credential_id

--- a/src/codex_a2a/server/push_config_store.py
+++ b/src/codex_a2a/server/push_config_store.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+
+from a2a.server.tasks.database_push_notification_config_store import (
+    DatabasePushNotificationConfigStore,
+)
+from a2a.server.tasks.inmemory_push_notification_config_store import (
+    InMemoryPushNotificationConfigStore,
+)
+from a2a.server.tasks.push_notification_config_store import PushNotificationConfigStore
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from codex_a2a.config import Settings
+
+from .database import build_database_engine
+
+
+@dataclass(slots=True)
+class PushConfigStoreRuntime:
+    push_config_store: PushNotificationConfigStore
+    startup: Callable[[], Awaitable[None]]
+    shutdown: Callable[[], Awaitable[None]]
+
+
+async def _noop() -> None:
+    return None
+
+
+def push_config_store_uses_database(settings: Settings) -> bool:
+    return settings.a2a_database_url is not None
+
+
+def build_push_config_store_runtime(
+    settings: Settings,
+    *,
+    engine: AsyncEngine | None = None,
+) -> PushConfigStoreRuntime:
+    if not push_config_store_uses_database(settings):
+        return PushConfigStoreRuntime(
+            push_config_store=InMemoryPushNotificationConfigStore(),
+            startup=_noop,
+            shutdown=_noop,
+        )
+
+    resolved_engine = engine or build_database_engine(settings)
+    raw_push_config_store = DatabasePushNotificationConfigStore(
+        engine=resolved_engine,
+        create_table=True,
+        table_name="push_notification_configs",
+    )
+
+    async def _startup() -> None:
+        await raw_push_config_store.initialize()
+
+    async def _shutdown() -> None:
+        if engine is None:
+            await resolved_engine.dispose()
+
+    return PushConfigStoreRuntime(
+        push_config_store=raw_push_config_store,
+        startup=_startup,
+        shutdown=_shutdown,
+    )

--- a/src/codex_a2a/server/task_store.py
+++ b/src/codex_a2a/server/task_store.py
@@ -544,7 +544,9 @@ def build_task_store_runtime(
 
 
 async def _ensure_sdk_task_store_schema_compatible(task_store: DatabaseTaskStore) -> None:
-    database_url = task_store.engine.url.render_as_string(hide_password=True)
+    database_url = _render_database_url_for_logs(
+        task_store.engine.url.render_as_string(hide_password=True)
+    )
     async with task_store.engine.begin() as conn:
         await conn.run_sync(
             lambda sync_conn: _validate_sdk_task_table_schema(

--- a/src/codex_a2a/server/task_store.py
+++ b/src/codex_a2a/server/task_store.py
@@ -307,7 +307,7 @@ class PolicyAwareTaskStore(TaskStoreDecorator):
         task: Task,
         context: ServerCallContext | None = None,
     ) -> bool:
-        await task_store._ensure_initialized()
+        await task_store.initialize()
         owner = task_store.owner_resolver(
             context if isinstance(context, ServerCallContext) else ServerCallContext()
         )
@@ -328,7 +328,7 @@ class PolicyAwareTaskStore(TaskStoreDecorator):
         task_id: str,
         context: ServerCallContext | None = None,
     ) -> Task | None:
-        await task_store._ensure_initialized()
+        await task_store.initialize()
         owner = task_store.owner_resolver(
             context if isinstance(context, ServerCallContext) else ServerCallContext()
         )

--- a/src/codex_a2a/server/task_store.py
+++ b/src/codex_a2a/server/task_store.py
@@ -5,7 +5,8 @@ import logging
 from abc import ABC, abstractmethod
 from collections.abc import Awaitable, Callable, MutableMapping
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, cast
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 from a2a.auth.user import UnauthenticatedUser, User
 from a2a.server.context import ServerCallContext
@@ -14,9 +15,10 @@ from a2a.server.tasks.database_task_store import DatabaseTaskStore
 from a2a.server.tasks.inmemory_task_store import InMemoryTaskStore
 from a2a.server.tasks.task_store import TaskStore
 from a2a.types import ListTasksRequest, ListTasksResponse, Task, TaskState, a2a_pb2
-from sqlalchemy import or_, select
+from sqlalchemy import inspect, or_, select
 from sqlalchemy.dialects.postgresql import insert as postgresql_insert
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+from sqlalchemy.engine import make_url
 from sqlalchemy.ext.asyncio import AsyncEngine
 from sqlalchemy.orm import class_mapper
 from starlette.authentication import SimpleUser
@@ -43,6 +45,12 @@ _TERMINAL_TASK_STATE_VALUES = tuple(
     a2a_pb2.TaskState.Name(state) for state in _TERMINAL_TASK_STATES
 )
 _ATOMIC_TERMINAL_GUARD_DIALECTS = frozenset({"postgresql", "sqlite"})
+_SDK_TASKS_TABLE_NAME = "tasks"
+_SDK_TASKS_REQUIRED_COLUMNS = frozenset({"owner", "last_updated", "protocol_version"})
+_SDK_TASKS_REQUIRED_INDEXES = frozenset({"idx_tasks_owner_last_updated"})
+_SENSITIVE_DATABASE_QUERY_KEYS = frozenset(
+    {"password", "passwd", "pwd", "token", "secret", "api_key", "apikey", "access_token"}
+)
 
 
 def _normalize_context(context: ServerCallContext | None) -> ServerCallContext:
@@ -96,6 +104,10 @@ class TaskStoreOperationError(RuntimeError):
         self.task_id = task_id
         target = task_id or "unknown"
         super().__init__(f"Task store {operation} failed for task_id={target}")
+
+
+class TaskStoreSchemaCompatibilityError(RuntimeError):
+    pass
 
 
 @dataclass(frozen=True)
@@ -456,6 +468,50 @@ def task_store_uses_database(settings: Settings) -> bool:
     return settings.a2a_database_url is not None
 
 
+def describe_persistence_backend(settings: Settings) -> dict[str, str]:
+    summary = {
+        "backend": "memory",
+        "task_store": "memory",
+        "push_config_store": "memory",
+        "runtime_state": "disabled",
+        "database_url": "n/a",
+        "sqlite_tuning": "not_applicable",
+    }
+    if not task_store_uses_database(settings):
+        return summary
+
+    url = make_url(cast(str, settings.a2a_database_url))
+    summary.update(
+        {
+            "backend": "database",
+            "task_store": "sdk_database",
+            "push_config_store": "sdk_database",
+            "runtime_state": "database",
+            "database_url": _render_database_url_for_logs(url.render_as_string(hide_password=True)),
+            "sqlite_tuning": (
+                "local_durability_defaults"
+                if url.drivername.startswith("sqlite")
+                else "not_applicable"
+            ),
+        }
+    )
+    return summary
+
+
+def _render_database_url_for_logs(database_url: str) -> str:
+    parts = urlsplit(database_url)
+    if not parts.query:
+        return database_url
+
+    redacted_query = []
+    for key, value in parse_qsl(parts.query, keep_blank_values=True):
+        if key.lower() in _SENSITIVE_DATABASE_QUERY_KEYS:
+            redacted_query.append((key, "***"))
+            continue
+        redacted_query.append((key, value))
+    return urlunsplit(parts._replace(query=urlencode(redacted_query)))
+
+
 def build_task_store_runtime(
     settings: Settings,
     *,
@@ -477,6 +533,7 @@ def build_task_store_runtime(
     task_store = GuardedTaskStore(raw_task_store)
 
     async def _startup() -> None:
+        await _ensure_sdk_task_store_schema_compatible(raw_task_store)
         await raw_task_store.initialize()
 
     async def _shutdown() -> None:
@@ -484,3 +541,44 @@ def build_task_store_runtime(
             await resolved_engine.dispose()
 
     return TaskStoreRuntime(task_store=task_store, startup=_startup, shutdown=_shutdown)
+
+
+async def _ensure_sdk_task_store_schema_compatible(task_store: DatabaseTaskStore) -> None:
+    database_url = task_store.engine.url.render_as_string(hide_password=True)
+    async with task_store.engine.begin() as conn:
+        await conn.run_sync(
+            lambda sync_conn: _validate_sdk_task_table_schema(
+                sync_conn,
+                database_url=database_url,
+            )
+        )
+
+
+def _validate_sdk_task_table_schema(
+    connection: Any,
+    *,
+    database_url: str,
+) -> None:
+    inspector = inspect(connection)
+    if _SDK_TASKS_TABLE_NAME not in inspector.get_table_names():
+        return
+
+    existing_columns = {column["name"] for column in inspector.get_columns(_SDK_TASKS_TABLE_NAME)}
+    existing_indexes = {index["name"] for index in inspector.get_indexes(_SDK_TASKS_TABLE_NAME)}
+    missing_columns = sorted(_SDK_TASKS_REQUIRED_COLUMNS - existing_columns)
+    missing_indexes = sorted(_SDK_TASKS_REQUIRED_INDEXES - existing_indexes)
+    if not missing_columns and not missing_indexes:
+        return
+
+    details: list[str] = []
+    if missing_columns:
+        details.append(f"missing columns: {', '.join(missing_columns)}")
+    if missing_indexes:
+        details.append(f"missing indexes: {', '.join(missing_indexes)}")
+
+    raise TaskStoreSchemaCompatibilityError(
+        "Legacy SDK task table schema detected for 'tasks' "
+        f"({'; '.join(details)}). Run "
+        f"`a2a-db --database-url {database_url}` before starting the service. "
+        "If `a2a-db` is unavailable, install the `a2a-sdk[db-cli]` extra first."
+    )

--- a/src/codex_a2a/server/task_store.py
+++ b/src/codex_a2a/server/task_store.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 import asyncio
 import logging
 from abc import ABC, abstractmethod
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, MutableMapping
 from dataclasses import dataclass
 from typing import Any
 
+from a2a.auth.user import UnauthenticatedUser, User
 from a2a.server.context import ServerCallContext
+from a2a.server.routes.common import StarletteUser
 from a2a.server.tasks.database_task_store import DatabaseTaskStore
 from a2a.server.tasks.inmemory_task_store import InMemoryTaskStore
 from a2a.server.tasks.task_store import TaskStore
@@ -17,6 +19,7 @@ from sqlalchemy.dialects.postgresql import insert as postgresql_insert
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.ext.asyncio import AsyncEngine
 from sqlalchemy.orm import class_mapper
+from starlette.authentication import SimpleUser
 
 from codex_a2a.a2a_proto import proto_to_python
 from codex_a2a.config import Settings
@@ -43,7 +46,48 @@ _ATOMIC_TERMINAL_GUARD_DIALECTS = frozenset({"postgresql", "sqlite"})
 
 
 def _normalize_context(context: ServerCallContext | None) -> ServerCallContext:
-    return context if isinstance(context, ServerCallContext) else ServerCallContext()
+    if not isinstance(context, ServerCallContext):
+        return ServerCallContext()
+    state = _normalized_context_state(getattr(context, "state", None))
+    identity = _context_identity(state)
+    normalized_user = _normalized_context_user(getattr(context, "user", None), identity=identity)
+    tenant = getattr(context, "tenant", "")
+    requested_extensions = getattr(context, "requested_extensions", ())
+    return ServerCallContext(
+        state=state,
+        user=normalized_user,
+        tenant=tenant if isinstance(tenant, str) else "",
+        requested_extensions={
+            value for value in requested_extensions if isinstance(value, str) and value
+        },
+    )
+
+
+def _normalized_context_state(state: Any) -> MutableMapping[str, Any]:
+    if isinstance(state, MutableMapping):
+        return dict(state)
+    return {}
+
+
+def _context_identity(state: MutableMapping[str, Any]) -> str | None:
+    identity = state.get("identity")
+    if not isinstance(identity, str):
+        return None
+    normalized = identity.strip()
+    return normalized or None
+
+
+def _normalized_context_user(user: Any, *, identity: str | None) -> User:
+    if isinstance(user, User):
+        try:
+            user_name = user.user_name
+        except Exception:
+            user_name = ""
+        if isinstance(user_name, str) and user_name:
+            return user
+    if identity:
+        return StarletteUser(SimpleUser(identity))
+    return UnauthenticatedUser()
 
 
 class TaskStoreOperationError(RuntimeError):

--- a/tests/server/test_call_context_builder.py
+++ b/tests/server/test_call_context_builder.py
@@ -28,6 +28,7 @@ def test_builder_sets_identity_for_non_stream_request():
     builder = IdentityAwareCallContextBuilder()
     context = builder.build(_request("/"))
     assert context.state.get("identity") == "opaque:test-id"
+    assert context.user.user_name == "opaque:test-id"
     assert context.state.get("correlation_id") == "corr-123"
     assert context.state.get("a2a_streaming_request") is None
 

--- a/tests/server/test_database_app_persistence.py
+++ b/tests/server/test_database_app_persistence.py
@@ -6,7 +6,10 @@ from pathlib import Path
 
 import httpx
 import pytest
-from a2a.types import Task, TaskState, TaskStatus
+from a2a.server.context import ServerCallContext
+from a2a.server.routes.common import StarletteUser
+from a2a.types import Task, TaskPushNotificationConfig, TaskState, TaskStatus
+from starlette.authentication import SimpleUser
 
 from codex_a2a.contracts.extensions import EXTENSION_JSONRPC_PATH
 from tests.support.settings import make_settings
@@ -28,148 +31,157 @@ def _executor_from_app(app):  # noqa: ANN001
     return app.state.codex_executor
 
 
+def _push_config_store_from_app(app):  # noqa: ANN001
+    return app.state.push_config_store
+
+
+def _authenticated_context(identity: str) -> ServerCallContext:
+    return ServerCallContext(user=StarletteUser(SimpleUser(identity)))
+
+
+class PersistentStateDummyClient:
+    created_sessions = 0
+    permission_reply_calls: list[dict[str, str | None]] = []
+
+    def __init__(self, settings, *, interrupt_request_store=None) -> None:  # noqa: ANN001
+        self.settings = settings
+        self.directory = settings.codex_workspace_root
+        self.stream_timeout = None
+        self._interrupt_request_store = interrupt_request_store
+        self._pending_requests: dict[str, object] = {}
+
+    async def close(self) -> None:
+        return None
+
+    async def startup_preflight(self) -> None:
+        return None
+
+    async def restore_persisted_interrupt_requests(self) -> None:
+        if self._interrupt_request_store is None:
+            return
+        restored = await self._interrupt_request_store.load_interrupt_requests()
+        self._pending_requests = {entry.request_id: entry.binding for entry in restored}
+
+    async def create_session(
+        self,
+        title: str | None = None,
+        *,
+        directory: str | None = None,
+        execution_options=None,  # noqa: ANN001
+    ) -> str:
+        del title, directory, execution_options
+        type(self).created_sessions += 1
+        return f"ses-{type(self).created_sessions}"
+
+    async def send_message(
+        self,
+        session_id: str,
+        text: str,
+        *,
+        directory: str | None = None,
+        execution_options=None,  # noqa: ANN001
+        timeout_override=None,  # noqa: ANN001
+    ):
+        del text, directory, execution_options, timeout_override
+        from codex_a2a.upstream.models import CodexMessage
+
+        return CodexMessage(
+            text="ok",
+            session_id=session_id,
+            message_id="m-1",
+            raw={},
+        )
+
+    async def remember_interrupt_request(
+        self,
+        *,
+        request_id: str,
+        session_id: str,
+        interrupt_type: str,
+        task_id: str | None = None,
+        context_id: str | None = None,
+        identity: str | None = None,
+        ttl_seconds: float | None = None,
+    ) -> None:
+        assert self._interrupt_request_store is not None
+        from codex_a2a.upstream.interrupts import InterruptRequestBinding
+
+        created_at = time.time()
+        resolved_ttl_seconds = (
+            float(ttl_seconds)
+            if ttl_seconds is not None
+            else float(self.settings.a2a_interrupt_request_ttl_seconds)
+        )
+        binding = InterruptRequestBinding(
+            request_id=request_id,
+            interrupt_type=interrupt_type,
+            session_id=session_id,
+            created_at=created_at,
+            expires_at=created_at + resolved_ttl_seconds,
+            identity=identity,
+            task_id=task_id,
+            context_id=context_id,
+        )
+        await self._interrupt_request_store.save_interrupt_request(
+            request_id=request_id,
+            interrupt_type=interrupt_type,
+            session_id=session_id,
+            identity=identity,
+            credential_id=None,
+            task_id=task_id,
+            context_id=context_id,
+            created_at=binding.created_at,
+            expires_at=binding.expires_at or binding.created_at,
+            rpc_request_id=request_id,
+            params={},
+        )
+        self._pending_requests[request_id] = binding
+
+    async def resolve_interrupt_request(self, request_id: str):
+        if self._interrupt_request_store is None:
+            binding = self._pending_requests.get(request_id)
+            if binding is None:
+                return "missing", None
+            return "active", binding
+        status, persisted = await self._interrupt_request_store.resolve_interrupt_request(
+            request_id=request_id
+        )
+        if status != "active" or persisted is None:
+            return status, None
+        self._pending_requests[request_id] = persisted.binding
+        return "active", persisted.binding
+
+    async def discard_interrupt_request(self, request_id: str) -> None:
+        self._pending_requests.pop(request_id, None)
+
+    async def permission_reply(
+        self,
+        request_id: str,
+        *,
+        reply: str,
+        message: str | None = None,
+        directory: str | None = None,
+    ) -> bool:
+        type(self).permission_reply_calls.append(
+            {
+                "request_id": request_id,
+                "reply": reply,
+                "message": message,
+                "directory": directory,
+            }
+        )
+        await self.discard_interrupt_request(request_id)
+        if self._interrupt_request_store is not None:
+            await self._interrupt_request_store.delete_interrupt_request(request_id=request_id)
+        return True
+
+
 @pytest.mark.asyncio
 async def test_database_backend_persists_task_session_and_interrupt_state_across_app_restart(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
     import codex_a2a.server.application as app_module
-
-    class PersistentStateDummyClient:
-        created_sessions = 0
-        permission_reply_calls: list[dict[str, str | None]] = []
-
-        def __init__(self, settings, *, interrupt_request_store=None) -> None:  # noqa: ANN001
-            self.settings = settings
-            self.directory = settings.codex_workspace_root
-            self.stream_timeout = None
-            self._interrupt_request_store = interrupt_request_store
-            self._pending_requests: dict[str, object] = {}
-
-        async def close(self) -> None:
-            return None
-
-        async def startup_preflight(self) -> None:
-            return None
-
-        async def restore_persisted_interrupt_requests(self) -> None:
-            if self._interrupt_request_store is None:
-                return
-            restored = await self._interrupt_request_store.load_interrupt_requests()
-            self._pending_requests = {entry.request_id: entry.binding for entry in restored}
-
-        async def create_session(
-            self,
-            title: str | None = None,
-            *,
-            directory: str | None = None,
-            execution_options=None,  # noqa: ANN001
-        ) -> str:
-            del title, directory, execution_options
-            type(self).created_sessions += 1
-            return f"ses-{type(self).created_sessions}"
-
-        async def send_message(
-            self,
-            session_id: str,
-            text: str,
-            *,
-            directory: str | None = None,
-            execution_options=None,  # noqa: ANN001
-            timeout_override=None,  # noqa: ANN001
-        ):
-            del text, directory, execution_options, timeout_override
-            from codex_a2a.upstream.models import CodexMessage
-
-            return CodexMessage(
-                text="ok",
-                session_id=session_id,
-                message_id="m-1",
-                raw={},
-            )
-
-        async def remember_interrupt_request(
-            self,
-            *,
-            request_id: str,
-            session_id: str,
-            interrupt_type: str,
-            task_id: str | None = None,
-            context_id: str | None = None,
-            identity: str | None = None,
-            ttl_seconds: float | None = None,
-        ) -> None:
-            assert self._interrupt_request_store is not None
-            from codex_a2a.upstream.interrupts import InterruptRequestBinding
-
-            created_at = time.time()
-            resolved_ttl_seconds = (
-                float(ttl_seconds)
-                if ttl_seconds is not None
-                else float(self.settings.a2a_interrupt_request_ttl_seconds)
-            )
-            binding = InterruptRequestBinding(
-                request_id=request_id,
-                interrupt_type=interrupt_type,
-                session_id=session_id,
-                created_at=created_at,
-                expires_at=created_at + resolved_ttl_seconds,
-                identity=identity,
-                task_id=task_id,
-                context_id=context_id,
-            )
-            await self._interrupt_request_store.save_interrupt_request(
-                request_id=request_id,
-                interrupt_type=interrupt_type,
-                session_id=session_id,
-                identity=identity,
-                credential_id=None,
-                task_id=task_id,
-                context_id=context_id,
-                created_at=binding.created_at,
-                expires_at=binding.expires_at or binding.created_at,
-                rpc_request_id=request_id,
-                params={},
-            )
-            self._pending_requests[request_id] = binding
-
-        async def resolve_interrupt_request(self, request_id: str):
-            if self._interrupt_request_store is None:
-                binding = self._pending_requests.get(request_id)
-                if binding is None:
-                    return "missing", None
-                return "active", binding
-            status, persisted = await self._interrupt_request_store.resolve_interrupt_request(
-                request_id=request_id
-            )
-            if status != "active" or persisted is None:
-                return status, None
-            self._pending_requests[request_id] = persisted.binding
-            return "active", persisted.binding
-
-        async def discard_interrupt_request(self, request_id: str) -> None:
-            self._pending_requests.pop(request_id, None)
-
-        async def permission_reply(
-            self,
-            request_id: str,
-            *,
-            reply: str,
-            message: str | None = None,
-            directory: str | None = None,
-        ) -> bool:
-            type(self).permission_reply_calls.append(
-                {
-                    "request_id": request_id,
-                    "reply": reply,
-                    "message": message,
-                    "directory": directory,
-                }
-            )
-            await self.discard_interrupt_request(request_id)
-            if self._interrupt_request_store is not None:
-                await self._interrupt_request_store.delete_interrupt_request(request_id=request_id)
-            return True
 
     PersistentStateDummyClient.created_sessions = 0
     PersistentStateDummyClient.permission_reply_calls = []
@@ -267,6 +279,50 @@ async def test_database_backend_persists_task_session_and_interrupt_state_across
                 "directory": None,
             }
         ]
+
+
+@pytest.mark.asyncio
+async def test_database_backend_persists_push_notification_configs_across_app_restart(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    import codex_a2a.server.application as app_module
+
+    monkeypatch.setattr(app_module, "CodexClient", PersistentStateDummyClient)
+
+    database_url = f"sqlite+aiosqlite:///{(tmp_path / 'push-config-state.db').resolve()}"
+    settings = make_settings(
+        a2a_bearer_token="test-token",
+        a2a_database_url=database_url,
+    )
+    context = _authenticated_context("automation")
+
+    app1 = app_module.create_app(settings)
+    async with app1.router.lifespan_context(app1):
+        task_store = _task_store_from_app(app1)
+        push_config_store = _push_config_store_from_app(app1)
+
+        await task_store.save(_task("task-1"), context)
+        await push_config_store.set_info(
+            "task-1",
+            TaskPushNotificationConfig(
+                task_id="task-1",
+                id="cfg-1",
+                url="https://example.invalid/webhook",
+                token="secret-token",
+            ),
+            context,
+        )
+
+    app2 = app_module.create_app(settings)
+    async with app2.router.lifespan_context(app2):
+        push_config_store = _push_config_store_from_app(app2)
+        configs = await push_config_store.get_info("task-1", context)
+
+    assert len(configs) == 1
+    assert configs[0].id == "cfg-1"
+    assert configs[0].task_id == "task-1"
+    assert configs[0].url == "https://example.invalid/webhook"
 
 
 def _sqlite_schema_version(database_path: Path, scope: str) -> int | None:

--- a/tests/server/test_push_config_store.py
+++ b/tests/server/test_push_config_store.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+from a2a.server.tasks.database_push_notification_config_store import (
+    DatabasePushNotificationConfigStore,
+)
+from a2a.server.tasks.inmemory_push_notification_config_store import (
+    InMemoryPushNotificationConfigStore,
+)
+
+from codex_a2a.server.database import build_database_engine
+from codex_a2a.server.push_config_store import build_push_config_store_runtime
+from tests.support.settings import make_settings
+
+
+def test_build_push_config_store_runtime_uses_memory_backend_when_database_disabled() -> None:
+    runtime = build_push_config_store_runtime(
+        make_settings(
+            a2a_bearer_token="test-token",
+            a2a_database_url=None,
+        )
+    )
+
+    assert isinstance(runtime.push_config_store, InMemoryPushNotificationConfigStore)
+
+
+def test_build_push_config_store_runtime_uses_database_backend_when_database_enabled(
+    tmp_path: Path,
+) -> None:
+    runtime = build_push_config_store_runtime(
+        make_settings(
+            a2a_bearer_token="test-token",
+            a2a_database_url=f"sqlite+aiosqlite:///{(tmp_path / 'push-configs.db').resolve()}",
+        )
+    )
+
+    assert isinstance(runtime.push_config_store, DatabasePushNotificationConfigStore)
+
+
+@pytest.mark.asyncio
+async def test_push_config_store_runtime_does_not_dispose_shared_engine(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    database_url = f"sqlite+aiosqlite:///{(tmp_path / 'push-configs-shared.db').resolve()}"
+    settings = make_settings(
+        a2a_bearer_token="test-token",
+        a2a_database_url=database_url,
+    )
+    engine = build_database_engine(settings)
+    dispose_spy = AsyncMock()
+    monkeypatch.setattr(type(engine), "dispose", dispose_spy)
+
+    runtime = build_push_config_store_runtime(settings, engine=engine)
+    await runtime.shutdown()
+
+    dispose_spy.assert_not_awaited()

--- a/tests/server/test_task_store.py
+++ b/tests/server/test_task_store.py
@@ -145,7 +145,7 @@ async def test_task_store_runtime_does_not_dispose_shared_engine(
 @pytest.mark.asyncio
 async def test_task_store_runtime_rejects_legacy_sdk_task_table_schema(tmp_path: Path) -> None:
     database_path = (tmp_path / "legacy-tasks.db").resolve()
-    database_url = f"sqlite+aiosqlite:///{database_path}"
+    database_url = f"sqlite+aiosqlite:///{database_path}?password=secret"
     settings = make_settings(
         a2a_bearer_token="test-token",
         a2a_database_url=database_url,
@@ -159,10 +159,16 @@ async def test_task_store_runtime_rejects_legacy_sdk_task_table_schema(tmp_path:
 
     runtime = build_task_store_runtime(settings)
     try:
-        with pytest.raises(TaskStoreSchemaCompatibilityError, match="Legacy SDK task table schema"):
+        with pytest.raises(
+            TaskStoreSchemaCompatibilityError,
+            match="Legacy SDK task table schema",
+        ) as exc_info:
             await runtime.startup()
     finally:
         await runtime.shutdown()
+
+    assert "secret" not in str(exc_info.value)
+    assert "password=%2A%2A%2A" in str(exc_info.value)
 
 
 @pytest.mark.asyncio

--- a/tests/server/test_task_store.py
+++ b/tests/server/test_task_store.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from a2a.server.context import ServerCallContext
 from a2a.server.tasks.database_task_store import DatabaseTaskStore
 from a2a.server.tasks.inmemory_task_store import InMemoryTaskStore
 from a2a.server.tasks.task_store import TaskStore
@@ -259,6 +260,46 @@ async def test_guarded_database_task_store_does_not_depend_on_stale_read_before_
     assert restored is not None
     assert restored.status.state == TaskState.TASK_STATE_COMPLETED
     assert proto_to_python(restored.metadata) == {}
+
+
+@pytest.mark.asyncio
+async def test_guarded_database_task_store_normalizes_context_with_identity_only(
+    tmp_path: Path,
+) -> None:
+    database_url = f"sqlite+aiosqlite:///{(tmp_path / 'identity-only-context.db').resolve()}"
+    settings = make_settings(
+        a2a_bearer_token="test-token",
+        a2a_database_url=database_url,
+    )
+    runtime = build_task_store_runtime(settings)
+    await runtime.startup()
+    try:
+        context_user_a = MagicMock(spec=ServerCallContext)
+        context_user_a.state = {"identity": "user-a"}
+        context_user_a.tenant = ""
+        context_user_a.requested_extensions = set()
+
+        context_user_b = MagicMock(spec=ServerCallContext)
+        context_user_b.state = {"identity": "user-b"}
+        context_user_b.tenant = ""
+        context_user_b.requested_extensions = set()
+
+        task = Task(
+            id="task-1",
+            context_id="ctx-1",
+            status=TaskStatus(state=TaskState.TASK_STATE_WORKING),
+        )
+
+        await runtime.task_store.save(task, context_user_a)
+
+        restored = await runtime.task_store.get("task-1", context_user_a)
+        other_identity = await runtime.task_store.get("task-1", context_user_b)
+    finally:
+        await runtime.shutdown()
+
+    assert restored is not None
+    assert restored.id == "task-1"
+    assert other_identity is None
 
 
 class _BrokenTaskStore(TaskStore):

--- a/tests/server/test_task_store.py
+++ b/tests/server/test_task_store.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sqlite3
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
@@ -15,7 +16,9 @@ from codex_a2a.server.database import build_database_engine
 from codex_a2a.server.task_store import (
     GuardedTaskStore,
     TaskStoreOperationError,
+    TaskStoreSchemaCompatibilityError,
     build_task_store_runtime,
+    describe_persistence_backend,
     unwrap_task_store,
 )
 from tests.support.settings import make_settings
@@ -45,6 +48,43 @@ def test_build_task_store_runtime_uses_database_backend_when_database_enabled(
 
     assert isinstance(runtime.task_store, GuardedTaskStore)
     assert isinstance(unwrap_task_store(runtime.task_store), DatabaseTaskStore)
+
+
+def test_describe_persistence_backend_reports_memory_defaults() -> None:
+    summary = describe_persistence_backend(
+        make_settings(
+            a2a_bearer_token="test-token",
+            a2a_database_url=None,
+        )
+    )
+
+    assert summary == {
+        "backend": "memory",
+        "task_store": "memory",
+        "push_config_store": "memory",
+        "runtime_state": "disabled",
+        "database_url": "n/a",
+        "sqlite_tuning": "not_applicable",
+    }
+
+
+def test_describe_persistence_backend_reports_database_configuration(tmp_path: Path) -> None:
+    summary = describe_persistence_backend(
+        make_settings(
+            a2a_bearer_token="test-token",
+            a2a_database_url=(
+                f"sqlite+aiosqlite:///{(tmp_path / 'summary.db').resolve()}?password=secret"
+            ),
+        )
+    )
+
+    assert summary["backend"] == "database"
+    assert summary["task_store"] == "sdk_database"
+    assert summary["push_config_store"] == "sdk_database"
+    assert summary["runtime_state"] == "database"
+    assert summary["database_url"].startswith("sqlite+aiosqlite:///")
+    assert "secret" not in summary["database_url"]
+    assert summary["sqlite_tuning"] == "local_durability_defaults"
 
 
 @pytest.mark.asyncio
@@ -100,6 +140,29 @@ async def test_task_store_runtime_does_not_dispose_shared_engine(
     await runtime.shutdown()
 
     dispose_spy.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_task_store_runtime_rejects_legacy_sdk_task_table_schema(tmp_path: Path) -> None:
+    database_path = (tmp_path / "legacy-tasks.db").resolve()
+    database_url = f"sqlite+aiosqlite:///{database_path}"
+    settings = make_settings(
+        a2a_bearer_token="test-token",
+        a2a_database_url=database_url,
+    )
+    connection = sqlite3.connect(database_path)
+    try:
+        connection.execute("CREATE TABLE tasks (id TEXT PRIMARY KEY, context_id TEXT, kind TEXT)")
+        connection.commit()
+    finally:
+        connection.close()
+
+    runtime = build_task_store_runtime(settings)
+    try:
+        with pytest.raises(TaskStoreSchemaCompatibilityError, match="Legacy SDK task table schema"):
+            await runtime.startup()
+    finally:
+        await runtime.shutdown()
 
 
 @pytest.mark.asyncio

--- a/tests/server/test_transport_contract.py
+++ b/tests/server/test_transport_contract.py
@@ -264,14 +264,18 @@ async def test_create_app_shares_database_engine_across_runtime_components(monke
     shared_engine = SimpleNamespace(dispose=AsyncMock())
     state_store = object()
     task_store = object()
+    push_config_store = object()
     runtime_startup = AsyncMock()
     runtime_shutdown = AsyncMock()
     task_startup = AsyncMock()
     task_shutdown = AsyncMock()
+    push_config_startup = AsyncMock()
+    push_config_shutdown = AsyncMock()
     captured: dict[str, object | None] = {
         "database_engine_settings": None,
         "runtime_engine": None,
         "task_engine": None,
+        "push_config_engine": None,
     }
 
     monkeypatch.setattr(
@@ -296,8 +300,19 @@ async def test_create_app_shares_database_engine_across_runtime_components(monke
             shutdown=task_shutdown,
         )
 
+    def _build_push_config_store_runtime(_settings, *, engine=None):  # noqa: ANN001
+        captured["push_config_engine"] = engine
+        return SimpleNamespace(
+            push_config_store=push_config_store,
+            startup=push_config_startup,
+            shutdown=push_config_shutdown,
+        )
+
     monkeypatch.setattr(app_module, "build_runtime_state_runtime", _build_runtime_state_runtime)
     monkeypatch.setattr(app_module, "build_task_store_runtime", _build_task_store_runtime)
+    monkeypatch.setattr(
+        app_module, "build_push_config_store_runtime", _build_push_config_store_runtime
+    )
     monkeypatch.setattr(app_module, "CodexClient", DummyChatCodexClient)
 
     app = app_module.create_app(settings)
@@ -305,14 +320,17 @@ async def test_create_app_shares_database_engine_across_runtime_components(monke
     assert captured["database_engine_settings"] is settings
     assert captured["runtime_engine"] is shared_engine
     assert captured["task_engine"] is shared_engine
+    assert captured["push_config_engine"] is shared_engine
 
     async with app.router.lifespan_context(app):
         pass
 
     runtime_startup.assert_awaited_once()
     task_startup.assert_awaited_once()
+    push_config_startup.assert_awaited_once()
     runtime_shutdown.assert_awaited_once()
     task_shutdown.assert_awaited_once()
+    push_config_shutdown.assert_awaited_once()
     shared_engine.dispose.assert_awaited_once()
 
 

--- a/tests/server/test_transport_contract.py
+++ b/tests/server/test_transport_contract.py
@@ -334,6 +334,42 @@ async def test_create_app_shares_database_engine_across_runtime_components(monke
     shared_engine.dispose.assert_awaited_once()
 
 
+@pytest.mark.asyncio
+async def test_create_app_logs_persistence_summary_at_startup(
+    monkeypatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    import codex_a2a.server.application as app_module
+
+    settings = make_settings(a2a_bearer_token="test-token", a2a_database_url=None)
+    monkeypatch.setattr(app_module, "CodexClient", DummyChatCodexClient)
+    monkeypatch.setattr(
+        app_module,
+        "describe_persistence_backend",
+        lambda _settings: {
+            "backend": "memory",
+            "task_store": "memory",
+            "push_config_store": "memory",
+            "runtime_state": "disabled",
+            "database_url": "n/a",
+            "sqlite_tuning": "not_applicable",
+        },
+    )
+
+    app = app_module.create_app(settings)
+
+    with caplog.at_level(logging.INFO, logger="codex_a2a.server.application"):
+        async with app.router.lifespan_context(app):
+            pass
+
+    assert any(
+        "A2A persistence configured backend=memory task_store=memory "
+        "push_config_store=memory runtime_state=disabled database_url=n/a "
+        "sqlite_tuning=not_applicable" in record.getMessage()
+        for record in caplog.records
+    )
+
+
 def test_openapi_rest_message_routes_include_schema_examples_and_extension_contracts() -> None:
     app = create_app(make_settings(a2a_bearer_token="test-token"))
     openapi = app.openapi()


### PR DESCRIPTION
## 概要

- 修复 A2A 1.0.2 下任务持久化链路的上下文兼容性问题
- 将 push notification config 持久化直接接回 `a2a-sdk`
- 增加 `tasks` 表启动前兼容性预检与持久化摘要日志

## 模块变更

### 请求上下文与任务存储
- 在 `IdentityAwareCallContextBuilder` 中，当请求已识别 `identity` 但 `context.user` 不可用时，回填 `context.user`
- 在 `task_store` 中统一规范化 `ServerCallContext`，兼容仅携带 `identity` 的上下文对象
- 保留终态写入保护语义，同时把可安全替换的初始化路径切回 SDK 公共接口

### SDK 持久化对齐
- 新增 push config runtime，直接接入 `DatabasePushNotificationConfigStore`
- 让 `task_store`、`push_config_store`、`runtime_state` 共享同一数据库引擎与生命周期接线

### 启动诊断
- 服务启动前检查 SDK `tasks` 表是否缺少当前版本所需列或索引
- 启动日志输出持久化后端摘要，便于确认当前 backend 与 SQLite 调优状态
- 对日志和启动期异常中的 `database_url` 做脱敏，包括 query string 敏感参数

## 测试

- 补充 context identity-only 场景的任务存储回归测试
- 补充 push config 持久化与共享 engine 测试
- 补充 `tasks` 表兼容性预检与启动摘要日志测试

## 验证

- `uv run pytest --no-cov tests/server/test_task_store.py tests/server/test_transport_contract.py`
- `uv run pre-commit run --all-files`
- `bash ./scripts/validate_baseline.sh`

Closes #284
Relates to #286
