### PR TITLE
test: strengthen jsonrpc protocol boundary coverage

### DIFF
--- a/tests/jsonrpc/test_interrupt_protocol_handlers.py
+++ b/tests/jsonrpc/test_interrupt_protocol_handlers.py
@@ -1,0 +1,258 @@
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+from a2a.server.jsonrpc_models import JSONRPCError
+from a2a.utils.errors import A2AError
+from fastapi.responses import JSONResponse
+
+from codex_a2a.jsonrpc.errors import adapt_jsonrpc_error
+from codex_a2a.jsonrpc.interrupt_recovery import handle_interrupt_recovery_request
+from codex_a2a.jsonrpc.interrupts import handle_interrupt_callback_request
+from codex_a2a.jsonrpc.request_models import JSONRPCRequestModel
+from codex_a2a.upstream.interrupts import InterruptRequestBinding
+from tests.support.dummy_clients import DummySessionQueryCodexClient
+from tests.support.jsonrpc_errors import error_context, error_reason
+from tests.support.settings import make_settings
+
+
+def _json_body(response) -> dict[str, object]:
+    return json.loads(response.body.decode("utf-8"))
+
+
+def _build_app(
+    codex_client,
+    *,
+    directory_resolver=None,
+    session_owner_matcher=None,
+):
+    def generate_error_response(request_id, error):
+        adapted = (
+            adapt_jsonrpc_error(error)
+            if isinstance(error, (JSONRPCError, A2AError))
+            else error
+        )
+        payload = {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "error": {
+                "code": adapted.code,
+                "message": adapted.message,
+            },
+        }
+        if getattr(adapted, "data", None) is not None:
+            payload["error"]["data"] = adapted.data
+        return JSONResponse(payload)
+
+    def success_response(request_id, result):
+        return JSONResponse({"jsonrpc": "2.0", "id": request_id, "result": result})
+
+    method_reply_permission = "a2a.interrupt.permission.reply"
+    method_reply_question = "a2a.interrupt.question.reply"
+    method_reject_question = "a2a.interrupt.question.reject"
+    method_reply_permissions = "a2a.interrupt.permissions.reply"
+    method_reply_elicitation = "a2a.interrupt.elicitation.reply"
+    return SimpleNamespace(
+        _codex_client=codex_client,
+        _generate_error_response=generate_error_response,
+        _jsonrpc_success_response=success_response,
+        _method_reply_permission=method_reply_permission,
+        _method_reply_question=method_reply_question,
+        _method_reject_question=method_reject_question,
+        _method_reply_permissions=method_reply_permissions,
+        _method_reply_elicitation=method_reply_elicitation,
+        _interrupt_methods_by_type={
+            "permission": method_reply_permission,
+            "question": method_reply_question,
+            "permissions": method_reply_permissions,
+            "elicitation": method_reply_elicitation,
+        },
+        _guard_hooks=SimpleNamespace(
+            directory_resolver=directory_resolver,
+            session_owner_matcher=session_owner_matcher,
+        ),
+    )
+
+
+def _build_request(*, user_identity=None, user_credential_id=None):
+    return SimpleNamespace(
+        state=SimpleNamespace(
+            user_identity=user_identity,
+            user_credential_id=user_credential_id,
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_interrupt_callback_permission_reply_returns_success_contract() -> None:
+    client = DummySessionQueryCodexClient(make_settings(a2a_bearer_token="test"))
+    client._interrupt_requests["perm-1"] = InterruptRequestBinding(
+        request_id="perm-1",
+        interrupt_type="permission",
+        session_id="sess-1",
+        created_at=0.0,
+    )
+    app = _build_app(client, directory_resolver=lambda directory: f"{directory}/resolved")
+
+    response = await handle_interrupt_callback_request(
+        app,
+        JSONRPCRequestModel(jsonrpc="2.0", id=11, method=app._method_reply_permission),
+        {
+            "request_id": "perm-1",
+            "reply": "always",
+            "message": "approved",
+            "metadata": {"codex": {"directory": "/workspace/demo"}},
+        },
+        request=_build_request(),
+    )
+
+    assert response.status_code == 200
+    assert _json_body(response) == {
+        "jsonrpc": "2.0",
+        "id": 11,
+        "result": {
+            "ok": True,
+            "request_id": "perm-1",
+            "reply": "always",
+        },
+    }
+    assert client.permission_reply_calls == [
+        {
+            "request_id": "perm-1",
+            "reply": "always",
+            "message": "approved",
+            "directory": "/workspace/demo/resolved",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_handle_interrupt_callback_elicitation_reply_preserves_explicit_content() -> None:
+    client = DummySessionQueryCodexClient(make_settings(a2a_bearer_token="test"))
+    client._interrupt_requests["eli-1"] = InterruptRequestBinding(
+        request_id="eli-1",
+        interrupt_type="elicitation",
+        session_id="sess-2",
+        created_at=0.0,
+    )
+    app = _build_app(client)
+
+    response = await handle_interrupt_callback_request(
+        app,
+        JSONRPCRequestModel(jsonrpc="2.0", id="rpc-eli", method=app._method_reply_elicitation),
+        {
+            "request_id": "eli-1",
+            "action": "accept",
+            "content": {"selection": "yes"},
+        },
+        request=_build_request(),
+    )
+
+    assert response.status_code == 200
+    assert _json_body(response)["result"] == {
+        "ok": True,
+        "request_id": "eli-1",
+        "action": "accept",
+        "content": {"selection": "yes"},
+    }
+    assert client.elicitation_reply_calls == [
+        {
+            "request_id": "eli-1",
+            "action": "accept",
+            "content": {"selection": "yes"},
+            "directory": None,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_handle_interrupt_callback_404_discards_request_and_uses_not_found_shape() -> None:
+    binding = InterruptRequestBinding(
+        request_id="perm-404",
+        interrupt_type="permission",
+        session_id="sess-404",
+        created_at=0.0,
+    )
+    request = httpx.Request("POST", "http://test/interrupt")
+    response_404 = httpx.Response(404, request=request)
+    client = SimpleNamespace(
+        resolve_interrupt_request=AsyncMock(return_value=("active", binding)),
+        permission_reply=AsyncMock(
+            side_effect=httpx.HTTPStatusError(
+                "missing interrupt",
+                request=request,
+                response=response_404,
+            )
+        ),
+        discard_interrupt_request=AsyncMock(),
+    )
+    app = _build_app(client)
+
+    response = await handle_interrupt_callback_request(
+        app,
+        JSONRPCRequestModel(jsonrpc="2.0", id=404, method=app._method_reply_permission),
+        {
+            "request_id": "perm-404",
+            "reply": "once",
+        },
+        request=_build_request(),
+    )
+
+    payload = _json_body(response)
+    assert response.status_code == 200
+    assert payload["error"]["code"] == -32004
+    assert error_reason(payload) == "INTERRUPT_REQUEST_NOT_FOUND"
+    assert error_context(payload)["request_id"] == "perm-404"
+    client.discard_interrupt_request.assert_awaited_once_with("perm-404")
+
+
+@pytest.mark.asyncio
+async def test_handle_interrupt_recovery_filters_identity_inputs_and_returns_items() -> None:
+    client = SimpleNamespace(
+        list_interrupt_requests=AsyncMock(return_value=[{"request_id": "req-1"}])
+    )
+    app = _build_app(client)
+
+    response = await handle_interrupt_recovery_request(
+        app,
+        JSONRPCRequestModel(jsonrpc="2.0", id=21, method="codex.interrupts.list"),
+        {"interrupt_type": "question"},
+        request=_build_request(user_identity=123, user_credential_id="cred-1"),
+    )
+
+    assert response.status_code == 200
+    assert _json_body(response) == {
+        "jsonrpc": "2.0",
+        "id": 21,
+        "result": {"items": [{"request_id": "req-1"}]},
+    }
+    client.list_interrupt_requests.assert_awaited_once_with(
+        identity=None,
+        credential_id="cred-1",
+        interrupt_type="question",
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_interrupt_recovery_notification_returns_no_content() -> None:
+    client = SimpleNamespace(
+        list_interrupt_requests=AsyncMock(return_value=[{"request_id": "req-2"}])
+    )
+    app = _build_app(client)
+
+    response = await handle_interrupt_recovery_request(
+        app,
+        JSONRPCRequestModel(jsonrpc="2.0", id=None, method="codex.interrupts.list"),
+        {},
+        request=_build_request(user_identity="user-1", user_credential_id="cred-2"),
+    )
+
+    assert response.status_code == 204
+    assert response.body == b""
+    client.list_interrupt_requests.assert_awaited_once_with(
+        identity="user-1",
+        credential_id="cred-2",
+        interrupt_type=None,
+    )

--- a/tests/jsonrpc/test_interrupt_protocol_handlers.py
+++ b/tests/jsonrpc/test_interrupt_protocol_handlers.py
@@ -30,9 +30,7 @@ def _build_app(
 ):
     def generate_error_response(request_id, error):
         adapted = (
-            adapt_jsonrpc_error(error)
-            if isinstance(error, (JSONRPCError, A2AError))
-            else error
+            adapt_jsonrpc_error(error) if isinstance(error, (JSONRPCError, A2AError)) else error
         )
         payload = {
             "jsonrpc": "2.0",
@@ -209,6 +207,25 @@ async def test_handle_interrupt_callback_404_discards_request_and_uses_not_found
 
 
 @pytest.mark.asyncio
+async def test_handle_interrupt_callback_invalid_params_use_jsonrpc_error_shape() -> None:
+    client = DummySessionQueryCodexClient(make_settings(a2a_bearer_token="test"))
+    app = _build_app(client)
+
+    response = await handle_interrupt_callback_request(
+        app,
+        JSONRPCRequestModel(jsonrpc="2.0", id=422, method=app._method_reply_permission),
+        {"request_id": "perm-invalid"},
+        request=_build_request(),
+    )
+
+    payload = _json_body(response)
+    assert response.status_code == 200
+    assert payload["error"]["code"] == -32602
+    assert payload["error"]["message"] == "Invalid parameters"
+    assert payload["error"]["data"] == {"field": "reply"}
+
+
+@pytest.mark.asyncio
 async def test_handle_interrupt_recovery_filters_identity_inputs_and_returns_items() -> None:
     client = SimpleNamespace(
         list_interrupt_requests=AsyncMock(return_value=[{"request_id": "req-1"}])
@@ -233,6 +250,26 @@ async def test_handle_interrupt_recovery_filters_identity_inputs_and_returns_ite
         credential_id="cred-1",
         interrupt_type="question",
     )
+
+
+@pytest.mark.asyncio
+async def test_handle_interrupt_recovery_invalid_params_use_jsonrpc_error_shape() -> None:
+    client = SimpleNamespace(list_interrupt_requests=AsyncMock())
+    app = _build_app(client)
+
+    response = await handle_interrupt_recovery_request(
+        app,
+        JSONRPCRequestModel(jsonrpc="2.0", id=423, method="codex.interrupts.list"),
+        {"interrupt_type": "unknown"},
+        request=_build_request(user_identity="user-1"),
+    )
+
+    payload = _json_body(response)
+    assert response.status_code == 200
+    assert payload["error"]["code"] == -32602
+    assert payload["error"]["message"] == "Invalid parameters"
+    assert payload["error"]["data"] == {"field": "interrupt_type"}
+    client.list_interrupt_requests.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/jsonrpc/test_protocol_payload_mapping.py
+++ b/tests/jsonrpc/test_protocol_payload_mapping.py
@@ -156,6 +156,14 @@ def test_map_plugin_marketplaces_filters_plugin_metadata_and_keeps_sync_state() 
     }
 
 
+def test_discovery_payload_mapping_rejects_invalid_top_level_shapes() -> None:
+    with pytest.raises(ValueError, match="app/list payload must be an object"):
+        map_apps_list([])
+
+    with pytest.raises(ValueError, match="plugin/list payload missing marketplaces array"):
+        map_plugin_marketplaces({"marketplaces": None})
+
+
 def test_map_plugin_detail_requires_core_fields_and_filters_collections() -> None:
     result = map_plugin_detail(
         {

--- a/tests/jsonrpc/test_protocol_payload_mapping.py
+++ b/tests/jsonrpc/test_protocol_payload_mapping.py
@@ -1,0 +1,228 @@
+import pytest
+from a2a.types import Role
+
+from codex_a2a.jsonrpc.discovery_payload_mapping import (
+    map_apps_list,
+    map_plugin_detail,
+    map_plugin_marketplaces,
+    map_skill_scopes,
+)
+from codex_a2a.jsonrpc.payload_mapping import (
+    as_a2a_message,
+    as_a2a_session_task,
+    extract_raw_items,
+)
+
+
+def test_map_skill_scopes_filters_invalid_entries_and_normalizes_strings() -> None:
+    raw_scope = {
+        "cwd": " /workspace/repo ",
+        "skills": [
+            {
+                "name": " demo-skill ",
+                "path": " /workspace/repo/.codex/skills/demo/SKILL.md ",
+                "description": " Demo skill ",
+                "enabled": True,
+                "scope": " repo ",
+                "interface": {"displayName": "Demo Skill"},
+            },
+            {
+                "name": "missing-path",
+                "path": " ",
+                "description": "skip me",
+                "enabled": True,
+                "scope": "repo",
+            },
+        ],
+        "errors": [{"message": "warn"}],
+    }
+
+    items = map_skill_scopes(
+        {"data": [raw_scope, {"cwd": "/broken", "skills": "bad", "errors": []}]}
+    )
+
+    assert items == [
+        {
+            "cwd": "/workspace/repo",
+            "skills": [
+                {
+                    "name": "demo-skill",
+                    "path": "/workspace/repo/.codex/skills/demo/SKILL.md",
+                    "description": "Demo skill",
+                    "enabled": True,
+                    "scope": "repo",
+                    "interface": {"displayName": "Demo Skill"},
+                    "codex": {"raw": raw_scope["skills"][0]},
+                }
+            ],
+            "errors": [{"message": "warn"}],
+            "codex": {"raw": raw_scope},
+        }
+    ]
+
+
+def test_map_apps_list_normalizes_cursor_and_app_identity() -> None:
+    items, next_cursor = map_apps_list(
+        {
+            "data": [
+                {
+                    "id": " demo-app ",
+                    "name": " Demo App ",
+                    "description": "Example connector",
+                    "isAccessible": 1,
+                    "isEnabled": 0,
+                },
+                {"id": "", "name": "broken"},
+            ],
+            "nextCursor": "",
+        }
+    )
+
+    assert next_cursor is None
+    assert items == [
+        {
+            "id": "demo-app",
+            "name": "Demo App",
+            "description": "Example connector",
+            "is_accessible": True,
+            "is_enabled": False,
+            "install_url": None,
+            "mention_path": "app://demo-app",
+            "branding": None,
+            "labels": None,
+            "codex": {
+                "raw": {
+                    "id": " demo-app ",
+                    "name": " Demo App ",
+                    "description": "Example connector",
+                    "isAccessible": 1,
+                    "isEnabled": 0,
+                }
+            },
+        }
+    ]
+
+
+def test_map_plugin_marketplaces_filters_plugin_metadata_and_keeps_sync_state() -> None:
+    raw_marketplace = {
+        "name": " curated ",
+        "path": " /workspace/plugins/marketplace.json ",
+        "interface": {"category": "utility"},
+        "plugins": [
+            {
+                "name": " sample ",
+                "description": "Sample plugin",
+                "enabled": True,
+                "interface": {"displayName": "Sample"},
+            },
+            {
+                "name": " ",
+                "description": "skip me",
+            },
+        ],
+    }
+
+    result = map_plugin_marketplaces(
+        {
+            "marketplaces": [raw_marketplace, {"name": "broken", "path": "x", "plugins": "bad"}],
+            "featuredPluginIds": ["sample@curated", 42],
+            "marketplaceLoadErrors": [{"path": "bad.json"}, "skip"],
+            "remoteSyncError": "network timeout",
+        }
+    )
+
+    assert result == {
+        "items": [
+            {
+                "marketplace_name": "curated",
+                "marketplace_path": "/workspace/plugins/marketplace.json",
+                "interface": {"category": "utility"},
+                "plugins": [
+                    {
+                        "name": "sample",
+                        "description": "Sample plugin",
+                        "enabled": True,
+                        "interface": {"displayName": "Sample"},
+                        "mention_path": "plugin://sample@curated",
+                        "codex": {"raw": raw_marketplace["plugins"][0]},
+                    }
+                ],
+                "codex": {"raw": raw_marketplace},
+            }
+        ],
+        "featured_plugin_ids": ["sample@curated"],
+        "marketplace_load_errors": [{"path": "bad.json"}],
+        "remote_sync_error": "network timeout",
+    }
+
+
+def test_map_plugin_detail_requires_core_fields_and_filters_collections() -> None:
+    result = map_plugin_detail(
+        {
+            "plugin": {
+                "name": " sample ",
+                "marketplaceName": " curated ",
+                "marketplacePath": " /workspace/plugins/marketplace.json ",
+                "summary": ["First", 1],
+                "skills": [{"name": "skill-1"}, "skip"],
+                "apps": [{"name": "app-1"}, "skip"],
+                "mcpServers": ["server-1", 2],
+                "interface": {"category": "utility"},
+            }
+        }
+    )
+
+    assert result == {
+        "name": "sample",
+        "marketplace_name": "curated",
+        "marketplace_path": "/workspace/plugins/marketplace.json",
+        "mention_path": "plugin://sample@curated",
+        "summary": ["First"],
+        "skills": [{"name": "skill-1"}],
+        "apps": [{"name": "app-1"}],
+        "mcp_servers": ["server-1"],
+        "interface": {"category": "utility"},
+        "codex": {
+            "raw": {
+                "name": " sample ",
+                "marketplaceName": " curated ",
+                "marketplacePath": " /workspace/plugins/marketplace.json ",
+                "summary": ["First", 1],
+                "skills": [{"name": "skill-1"}, "skip"],
+                "apps": [{"name": "app-1"}, "skip"],
+                "mcpServers": ["server-1", 2],
+                "interface": {"category": "utility"},
+            }
+        },
+    }
+
+    with pytest.raises(ValueError, match="plugin/read payload missing plugin.marketplaceName"):
+        map_plugin_detail({"plugin": {"name": "sample", "marketplacePath": "/workspace/x"}})
+
+
+def test_payload_mapping_contract_helpers_require_core_identifiers() -> None:
+    task = as_a2a_session_task({"id": " sess-1 ", "title": " Demo Session "})
+    assert task is not None
+    assert task.id == "sess-1"
+    assert task.context_id == "sess-1"
+    assert task.metadata["shared"] == {"session": {"id": "sess-1", "title": "Demo Session"}}
+
+    assert as_a2a_session_task({"id": "sess-2", "title": "  "}) is None
+
+    message = as_a2a_message(
+        "sess-1",
+        {
+            "info": {"id": " msg-1 ", "role": " user "},
+            "parts": [{"type": "text", "text": "hello"}],
+        },
+    )
+
+    assert message is not None
+    assert message.message_id == "msg-1"
+    assert message.role == Role.ROLE_USER
+    assert message.context_id == "sess-1"
+    assert message.metadata["shared"] == {"session": {"id": "sess-1"}}
+    assert extract_raw_items([{"id": "ok"}], kind="sessions") == [{"id": "ok"}]
+
+    with pytest.raises(ValueError, match="Codex sessions payload must be an array; got dict"):
+        extract_raw_items({"id": "bad"}, kind="sessions")


### PR DESCRIPTION
## 摘要
- 为 `tests/jsonrpc/test_interrupt_protocol_handlers.py` 新增 handler 级协议测试，直接覆盖中断回调与恢复路径的成功返回、invalid params 响应 shape、404 中断回收与 notification 语义。
- 为 `tests/jsonrpc/test_protocol_payload_mapping.py` 新增 mapping helper 测试，覆盖 discovery payload 归一化、顶层 payload 非法输入与 session/message helper 的 contract 行为。
- 本 PR 不引入业务实现改动，仅补强 `jsonrpc` 边界层低覆盖测试。

## 关联
- Closes #280
- Relates to #277

## 提交
- `chore: add focused jsonrpc protocol boundary tests #280`
- `test: cover jsonrpc invalid param and payload error shapes #280`

## 验证
- `uv run pytest --no-cov tests/jsonrpc/test_interrupt_protocol_handlers.py tests/jsonrpc/test_protocol_payload_mapping.py -q`
- `bash ./scripts/validate_baseline.sh`

## 审查结论
- 本次改动与 `#280` 的目标一致，覆盖点聚焦在真实协议风险，而非单纯追逐覆盖率数字。
- 未发现需要阻断合并的问题。
- 剩余风险主要是 `interrupts.py` 中部分上游网络异常分支仍以现有测试为主，后续若继续追 coverage，可再独立补齐。
