### PR TITLE
refactor: tighten broad exception swallowing boundaries

### DIFF
--- a/src/codex_a2a/execution/request_metadata.py
+++ b/src/codex_a2a/execution/request_metadata.py
@@ -35,49 +35,36 @@ def _metadata_mapping(value: Any) -> Mapping[str, Any] | None:
     return normalized_mapping
 
 
-def _append_metadata_candidate(
-    candidates: list[Mapping[str, Any]],
-    value: Any,
-    *,
-    source: str,
-    purpose: str,
-) -> None:
-    try:
-        candidate = _metadata_mapping(value)
-    except Exception:
-        # Request metadata comes from external clients and protobuf adapters, so normalization must
-        # stay fail-open. We still log the failure at debug level to preserve diagnostics without
-        # turning malformed metadata into a request-wide failure path.
-        logger.debug(
-            "Ignoring unparseable request metadata while extracting %s from %s",
-            purpose,
-            source,
-            exc_info=True,
-        )
-        return
-    if candidate is not None:
-        candidates.append(candidate)
-
-
 def _collect_metadata_candidates(
     context: RequestContext,
     *,
     purpose: str,
 ) -> list[Mapping[str, Any]]:
     candidates: list[Mapping[str, Any]] = []
-    _append_metadata_candidate(
-        candidates,
-        context.metadata,
-        source="context.metadata",
-        purpose=purpose,
-    )
-    if context.message is not None:
-        _append_metadata_candidate(
-            candidates,
+    for source, value in (
+        ("context.metadata", context.metadata),
+        (
+            "context.message.metadata",
             getattr(context.message, "metadata", None) or {},
-            source="context.message.metadata",
-            purpose=purpose,
-        )
+        ),
+    ):
+        if source == "context.message.metadata" and context.message is None:
+            continue
+        try:
+            candidate = _metadata_mapping(value)
+        except Exception:
+            # Request metadata comes from external clients and protobuf adapters, so normalization
+            # must stay fail-open. We still log the failure at debug level to preserve diagnostics
+            # without turning malformed metadata into a request-wide failure path.
+            logger.debug(
+                "Ignoring unparseable request metadata while extracting %s from %s",
+                purpose,
+                source,
+                exc_info=True,
+            )
+            continue
+        if candidate is not None:
+            candidates.append(candidate)
     return candidates
 
 

--- a/src/codex_a2a/execution/request_metadata.py
+++ b/src/codex_a2a/execution/request_metadata.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from collections.abc import Mapping
 from typing import Any
 
@@ -13,6 +14,8 @@ from codex_a2a.execution.request_overrides import (
     RequestExecutionOptionsValidationError,
     build_request_execution_options,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def _metadata_mapping(value: Any) -> Mapping[str, Any] | None:
@@ -32,25 +35,62 @@ def _metadata_mapping(value: Any) -> Mapping[str, Any] | None:
     return normalized_mapping
 
 
+def _append_metadata_candidate(
+    candidates: list[Mapping[str, Any]],
+    value: Any,
+    *,
+    source: str,
+    purpose: str,
+) -> None:
+    try:
+        candidate = _metadata_mapping(value)
+    except Exception:
+        # Request metadata comes from external clients and protobuf adapters, so normalization must
+        # stay fail-open. We still log the failure at debug level to preserve diagnostics without
+        # turning malformed metadata into a request-wide failure path.
+        logger.debug(
+            "Ignoring unparseable request metadata while extracting %s from %s",
+            purpose,
+            source,
+            exc_info=True,
+        )
+        return
+    if candidate is not None:
+        candidates.append(candidate)
+
+
+def _collect_metadata_candidates(
+    context: RequestContext,
+    *,
+    purpose: str,
+) -> list[Mapping[str, Any]]:
+    candidates: list[Mapping[str, Any]] = []
+    _append_metadata_candidate(
+        candidates,
+        context.metadata,
+        source="context.metadata",
+        purpose=purpose,
+    )
+    if context.message is not None:
+        _append_metadata_candidate(
+            candidates,
+            getattr(context.message, "metadata", None) or {},
+            source="context.message.metadata",
+            purpose=purpose,
+        )
+    return candidates
+
+
 def extract_namespaced_string_metadata(
     context: RequestContext,
     *,
     namespace: str,
     path: tuple[str, ...],
 ) -> str | None:
-    candidates: list[Mapping[str, Any]] = []
-    try:
-        meta = _metadata_mapping(context.metadata)
-        if meta is not None:
-            candidates.append(meta)
-    except Exception:
-        pass
-
-    if context.message is not None:
-        message_metadata = _metadata_mapping(getattr(context.message, "metadata", None) or {})
-        if message_metadata is not None:
-            candidates.append(message_metadata)
-
+    candidates = _collect_metadata_candidates(
+        context,
+        purpose=f"{namespace}.{'.'.join(path)}",
+    )
     for candidate in candidates:
         current = candidate.get(namespace)
         for part in path[:-1]:
@@ -85,19 +125,10 @@ def extract_codex_directory(context: RequestContext) -> str | None:
 
 
 def extract_codex_execution_options(context: RequestContext) -> RequestExecutionOptions:
-    candidates: list[Mapping[str, Any]] = []
-    try:
-        meta = _metadata_mapping(context.metadata)
-        if meta is not None:
-            candidates.append(meta)
-    except Exception:
-        pass
-
-    if context.message is not None:
-        message_metadata = _metadata_mapping(getattr(context.message, "metadata", None) or {})
-        if message_metadata is not None:
-            candidates.append(message_metadata)
-
+    candidates = _collect_metadata_candidates(
+        context,
+        purpose="codex.execution options",
+    )
     merged: dict[str, Any] = {}
     for candidate in candidates:
         codex = candidate.get("codex")

--- a/src/codex_a2a/execution/thread_lifecycle_runtime.py
+++ b/src/codex_a2a/execution/thread_lifecycle_runtime.py
@@ -311,9 +311,6 @@ class CodexThreadLifecycleRuntime:
             )
         except (TaskNotFoundError, TaskNotCancelableError):
             pass
-        except Exception as exc:
-            if not isinstance(exc, (TaskNotFoundError, TaskNotCancelableError)):
-                raise
         if (
             handle is not None
             and handle.producer_task is not None
@@ -356,12 +353,17 @@ class CodexThreadLifecycleRuntime:
         for thread_id in subscription.thread_filter:
             try:
                 await self._client.thread_unsubscribe(thread_id)
-            except Exception:
+            except Exception as exc:
+                # Upstream unsubscribe runs in a best-effort cleanup path after local ownership has
+                # already been released. Surface the failure for diagnostics, but do not convert a
+                # cleanup issue into a user-visible release failure.
                 logger.warning(
-                    "Failed upstream thread/unsubscribe for subscription %s thread_id=%s",
+                    "Failed upstream thread/unsubscribe for subscription %s thread_id=%s "
+                    "error_type=%s",
                     subscription_key,
                     thread_id,
-                    exc_info=True,
+                    type(exc).__name__,
+                    exc_info=exc,
                 )
 
     @staticmethod

--- a/tests/execution/test_request_metadata.py
+++ b/tests/execution/test_request_metadata.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+from codex_a2a.execution.request_metadata import (
+    extract_codex_execution_options,
+    extract_shared_session_id,
+)
+from codex_a2a.execution.request_overrides import RequestExecutionOptionsValidationError
+
+
+def test_extract_shared_session_id_logs_and_falls_back_when_context_metadata_is_unparseable(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    broken_metadata = object()
+    context = SimpleNamespace(
+        metadata=broken_metadata,
+        message=SimpleNamespace(metadata={"shared": {"session": {"id": "sess-1"}}}),
+    )
+
+    original = extract_shared_session_id.__globals__["_metadata_mapping"]
+
+    def flaky_metadata_mapping(value):  # noqa: ANN001
+        if value is broken_metadata:
+            raise ValueError("bad metadata")
+        return original(value)
+
+    monkeypatch.setitem(
+        extract_shared_session_id.__globals__,
+        "_metadata_mapping",
+        flaky_metadata_mapping,
+    )
+
+    caplog.set_level(logging.DEBUG, logger="codex_a2a.execution.request_metadata")
+
+    assert extract_shared_session_id(context) == "sess-1"
+    assert "Ignoring unparseable request metadata while extracting shared.session.id" in caplog.text
+    assert "bad metadata" in caplog.text
+
+
+def test_extract_codex_execution_options_logs_and_uses_message_metadata_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    broken_metadata = object()
+    context = SimpleNamespace(
+        metadata=broken_metadata,
+        message=SimpleNamespace(
+            metadata={
+                "codex": {
+                    "execution": {
+                        "model": "gpt-5.5",
+                        "effort": "high",
+                        "summary": "concise",
+                    }
+                }
+            }
+        ),
+    )
+
+    original = extract_codex_execution_options.__globals__["_metadata_mapping"]
+
+    def flaky_metadata_mapping(value):  # noqa: ANN001
+        if value is broken_metadata:
+            raise TypeError("cannot normalize metadata")
+        return original(value)
+
+    monkeypatch.setitem(
+        extract_codex_execution_options.__globals__,
+        "_metadata_mapping",
+        flaky_metadata_mapping,
+    )
+
+    caplog.set_level(logging.DEBUG, logger="codex_a2a.execution.request_metadata")
+
+    options = extract_codex_execution_options(context)
+
+    assert options.model == "gpt-5.5"
+    assert options.effort == "high"
+    assert options.summary == "concise"
+    assert options.personality is None
+    assert "Ignoring unparseable request metadata while extracting codex.execution options" in (
+        caplog.text
+    )
+
+
+def test_extract_codex_execution_options_still_validates_normalized_metadata() -> None:
+    context = SimpleNamespace(
+        metadata={"codex": {"execution": "invalid"}},
+        message=None,
+    )
+
+    with pytest.raises(RequestExecutionOptionsValidationError) as exc_info:
+        extract_codex_execution_options(context)
+
+    assert exc_info.value.field == "metadata.codex.execution"
+    assert str(exc_info.value) == "metadata.codex.execution must be an object"

--- a/tests/execution/test_thread_lifecycle_runtime.py
+++ b/tests/execution/test_thread_lifecycle_runtime.py
@@ -1,13 +1,17 @@
 import asyncio
+import logging
 from collections.abc import AsyncIterator
 from typing import Any
 
 import pytest
-from a2a.types import CancelTaskRequest, TaskArtifactUpdateEvent
+from a2a.types import CancelTaskRequest, TaskArtifactUpdateEvent, TaskNotCancelableError
 from a2a.utils.errors import TaskNotFoundError
 
 from codex_a2a.a2a_proto import part_data
-from codex_a2a.execution.thread_lifecycle_runtime import CodexThreadLifecycleRuntime
+from codex_a2a.execution.thread_lifecycle_runtime import (
+    CodexThreadLifecycleRuntime,
+    ThreadLifecycleWatchHandle,
+)
 from codex_a2a.server.runtime_state import build_runtime_state_runtime
 from tests.execution.test_discovery_exec_runtime import RecordingRequestHandler
 from tests.support.context import DummyEventQueue
@@ -388,6 +392,89 @@ async def test_thread_lifecycle_runtime_release_skips_upstream_unsubscribe_on_sc
         )
 
         assert client.thread_unsubscribe_calls == []
+    finally:
+        await runtime_state.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_thread_lifecycle_runtime_cancel_tolerates_task_not_cancelable() -> None:
+    class NotCancelableRequestHandler(BackgroundThreadWatchRequestHandler):
+        async def on_cancel_task(self, params: CancelTaskRequest, context=None):  # noqa: ANN001
+            self.cancel_requests.append({"task_id": params.id, "context": context})
+            raise TaskNotCancelableError()
+
+    runtime = CodexThreadLifecycleRuntime(
+        client=ThreadLifecycleClientStub([]),
+        request_handler=NotCancelableRequestHandler(),
+    )
+    producer_task: asyncio.Task[None] = asyncio.create_task(asyncio.sleep(3600))
+    runtime_handle = ThreadLifecycleWatchHandle(
+        task_id="watch-1",
+        context_id="watch-1",
+        events=frozenset({"thread.started"}),
+        thread_ids=frozenset({"thr-1"}),
+        stop_event=asyncio.Event(),
+        owner_identity="user-1",
+        subscription_key="sub-1",
+        producer_task=producer_task,
+    )
+    runtime._active_handles["watch-1"] = runtime_handle
+
+    try:
+        await runtime._cancel_watch_task(task_id="watch-1", context={"identity": "user-1"})
+
+        assert runtime_handle.stop_event.is_set() is True
+        assert producer_task.cancelled() is True
+    finally:
+        if not producer_task.done():
+            producer_task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await producer_task
+
+
+@pytest.mark.asyncio
+async def test_thread_lifecycle_runtime_release_logs_unsubscribe_failures_and_keeps_success_result(
+    tmp_path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    database_path = (tmp_path / "thread-watch-release-unsubscribe-failure.db").resolve()
+    settings = make_settings(
+        a2a_bearer_token="test-token",
+        a2a_database_url=f"sqlite+aiosqlite:///{database_path}",
+    )
+    runtime_state = build_runtime_state_runtime(settings)
+    await runtime_state.startup()
+    assert runtime_state.state_store is not None
+
+    handler = BackgroundThreadWatchRequestHandler()
+    client = BlockingThreadLifecycleClientStub()
+
+    async def failing_unsubscribe(thread_id: str) -> None:
+        raise RuntimeError(f"boom:{thread_id}")
+
+    client.thread_unsubscribe = failing_unsubscribe  # type: ignore[method-assign]
+    runtime = CodexThreadLifecycleRuntime(
+        client=client,
+        request_handler=handler,
+        state_store=runtime_state.state_store,
+    )
+
+    try:
+        result = await runtime.start(
+            request={"events": ["thread.started"], "thread_ids": ["thr-1"]},
+            context={"identity": "user-1"},
+        )
+
+        caplog.set_level(logging.WARNING, logger="codex_a2a.execution.thread_lifecycle_runtime")
+        release_result = await runtime.release(
+            task_id=result["task_id"],
+            context={"identity": "user-1"},
+        )
+
+        assert release_result["ok"] is True
+        assert release_result["subscription_released"] is True
+        assert "Failed upstream thread/unsubscribe for subscription" in caplog.text
+        assert "error_type=RuntimeError" in caplog.text
     finally:
         await runtime_state.shutdown()
 


### PR DESCRIPTION
## 摘要
- 收敛 `request_metadata.py` 中的宽泛静默吞错：保留 fail-open 容错语义，但集中到统一 helper，并补 `debug` 级诊断日志。
- 清理 `thread_lifecycle_runtime.py` 中冗余的 broad catch；对 upstream unsubscribe 保留 best-effort cleanup，但补充明确注释与更可诊断的 warning。
- 新增针对性测试，覆盖 metadata fallback、归一化失败后的日志行为，以及 thread watch cancel/release 的异常边界。

## 关联
- Closes #281
- Relates to #277

## 提交
- `refactor: tighten broad metadata and watch cleanup catches #281`

## 验证
- `uv run pytest --no-cov tests/execution/test_request_metadata.py tests/execution/test_thread_lifecycle_runtime.py -q`
- `bash ./scripts/validate_baseline.sh`

## 审查结论
- 本 PR 的代码变动与 `#281` 的目标一致，处理方式不是机械删除广泛捕获，而是按语义区分 fail-open metadata 解析与 best-effort cleanup。
- 当前未发现阻断性问题。
- `Closes #281` 与 `Relates to #277` 关系准确，无需修正。
- 当前 open issues 中未发现适合与本 PR 一并开发的其它高耦合项；`#286` 与本 PR 不属于同一变更轴。
