### PR TITLE
refactor: tighten shared metadata and session query contract boundaries

### DIFF
--- a/docs/extension-specifications.md
+++ b/docs/extension-specifications.md
@@ -29,7 +29,7 @@ Negotiation note:
 URI: `urn:a2a:session-binding/v1`
 
 - Scope: shared A2A request metadata for rebinding to an existing upstream session
-- Public Agent Card: capability declaration plus minimal routing metadata
+- Public Agent Card: capability declaration plus minimal routing metadata for `shared.session.id` only
 - Authenticated extended card: full profile, notes, and detailed contract metadata
 - OpenAPI: shared contract payload under `x-a2a-extension-contracts.session_binding`
 - Runtime field: `metadata.shared.session.id`
@@ -39,7 +39,7 @@ URI: `urn:a2a:session-binding/v1`
 URI: `urn:a2a:stream-hints/v1`
 
 - Scope: shared canonical metadata for block, usage, interrupt, and session hints
-- Public Agent Card: metadata roots plus the minimum discoverability fields for block identity, status, interrupt lifecycle, session identity, and basic token usage
+- Public Agent Card: metadata roots plus the minimum discoverability fields for block identity, status source, interrupt lifecycle, session identity, and basic token usage
 - Authenticated extended card: full shared stream contract including detailed block payload mappings and extended usage metadata
 - OpenAPI: shared contract payload under `x-a2a-extension-contracts.streaming`
 - Runtime fields: `metadata.shared.stream`, `metadata.shared.usage`, `metadata.shared.interrupt`, `metadata.shared.session`

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -446,8 +446,9 @@ This path is for contributors. End users should prefer the released CLI path des
 - Those task-store failure surfaces use `metadata.codex.error` with `type=TASK_STORE_UNAVAILABLE` and an `operation` field such as `get` or `save`.
 - Stream artifacts carry `artifact.metadata.shared.stream.block_type` with values `text`, `reasoning`, and `tool_call`.
 - The published `urn:a2a:stream-hints/v1` contract also declares the emitted A2A part type per block: `text` and `reasoning` use `Part(text)`, while `tool_call` uses `Part(data)`.
-- All chunks share one stream artifact ID and preserve original timeline via `artifact.metadata.shared.stream.sequence`. Timeline identity fields such as `message_id`, `event_id`, and `source` are emitted under `metadata.shared.stream`.
-- Session projections are normalized under `metadata.shared.session`, with `id` as the canonical field and optional `title` when the upstream surface provides one. The corresponding leaf fields are `metadata.shared.session.id` and `metadata.shared.session.title`.
+- All chunks share one stream artifact ID and preserve original timeline via `artifact.metadata.shared.stream.sequence`.
+- Advanced correlation fields such as `metadata.shared.stream.message_id` and `metadata.shared.stream.event_id` may still appear on detailed/runtime surfaces, but the public shared contract only exposes the minimum stable discovery fields.
+- Session projections are normalized under `metadata.shared.session`, with `id` as the canonical shared field.
 - A final snapshot is emitted only when stream chunks did not already produce the same final text.
 - Stream routing is schema-first: the service classifies chunks primarily by Codex `part.type` plus `part_id` state rather than inline text markers.
 - `message.part.delta` and `message.part.updated` are merged per `part_id`; out-of-order deltas are buffered and replayed when the corresponding `part.updated` arrives.
@@ -563,7 +564,7 @@ This service exposes Codex session list and message-history queries via A2A JSON
   - `codex.sessions.messages.list` enforces `limit` locally after mapping the upstream thread history into A2A messages, keeping the most recent N messages while preserving their original order
   - canonical session metadata is exposed at `metadata.shared.session`
   - raw upstream payload is preserved at `metadata.codex.raw`
-  - session title is available at `metadata.shared.session.title`
+  - display-oriented session title hints remain provider-shaped data from the upstream payload rather than part of the shared metadata contract
 
 ### Session List (`codex.sessions.list`)
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -432,7 +432,7 @@ This path is for contributors. End users should prefer the released CLI path des
 - Image input maps to upstream `turn/start.input[].type=input_image`.
 - `mention.path` and `skill.path` are forwarded verbatim. The service does not guess app or plugin identifiers from display names.
 - `local_image` is not part of the current declared stable rich-input contract.
-- Session query projections currently use the upstream Codex `session_id` as the A2A `contextId`. This is intentional for the current deployment model: `contextId` and `metadata.shared.session.id` refer to the same upstream session identity, and the contract declares that equality explicitly.
+- Session query projections currently use the upstream Codex `session_id` as the A2A `contextId`. In that projection surface, `contextId` is the canonical session identity and the adapter does not duplicate the same value under `metadata.shared.session.id`.
 - Completed chat turns are persisted as `completed`; `input-required` is reserved for active interrupt asks that still need a reply.
 - Non-streaming requests return a `Task` directly.
 - Non-streaming `message:send` responses may include normalized token usage at `Task.metadata.shared.usage` with the same field schema.
@@ -562,8 +562,9 @@ This service exposes Codex session list and message-history queries via A2A JSON
   - limit pagination defaults to `20` items and rejects values above `100`
   - pagination behavior is mixed: `codex.sessions.list` forwards `limit` upstream, while `codex.sessions.messages.list` applies the limit locally
   - `codex.sessions.messages.list` enforces `limit` locally after mapping the upstream thread history into A2A messages, keeping the most recent N messages while preserving their original order
-  - canonical session metadata is exposed at `metadata.shared.session`
+  - `contextId` is the canonical projected session identity on this surface
   - raw upstream payload is preserved at `metadata.codex.raw`
+  - this surface does not duplicate the same session identity under `metadata.shared.session`
   - display-oriented session title hints remain provider-shaped data from the upstream payload rather than part of the shared metadata contract
 
 ### Session List (`codex.sessions.list`)

--- a/src/codex_a2a/contracts/extension_registry.py
+++ b/src/codex_a2a/contracts/extension_registry.py
@@ -94,7 +94,6 @@ EXTENSION_CONTRACT_REGISTRY: tuple[ExtensionContractDescriptor, ...] = (
             "metadata_field",
             "behavior",
             "supported_metadata",
-            "provider_private_metadata",
         ),
     ),
     ExtensionContractDescriptor(
@@ -286,23 +285,23 @@ def build_agent_card_extensions_from_registry(
                     "block_part_types": params["block_part_types"],
                     "stream_fields": _select_public_extension_params(
                         params["stream_fields"],
-                        keys=("block_type", "message_id", "sequence", "source"),
+                        keys=("block_type", "sequence", "source"),
                     ),
                     "status_stream_fields": _select_public_extension_params(
                         params["status_stream_fields"],
-                        keys=("type", "status", "source", "event_id"),
+                        keys=("source",),
                     ),
                     "session_fields": _select_public_extension_params(
                         params["session_fields"],
-                        keys=("id", "title"),
+                        keys=("id",),
                     ),
                     "interrupt_fields": _select_public_extension_params(
                         params["interrupt_fields"],
-                        keys=("request_id", "type", "phase", "resolution"),
+                        keys=("request_id", "type", "phase"),
                     ),
                     "usage_fields": _select_public_extension_params(
                         params["usage_fields"],
-                        keys=("input_tokens", "output_tokens", "total_tokens", "reasoning_tokens"),
+                        keys=("input_tokens", "output_tokens", "total_tokens"),
                     ),
                 }
             elif descriptor.public_params_keys is not None:

--- a/src/codex_a2a/contracts/extensions.py
+++ b/src/codex_a2a/contracts/extensions.py
@@ -649,14 +649,21 @@ def build_session_query_extension_params(
         "result_envelope": {},
         "context_semantics": {
             "a2a_context_id_field": "contextId",
-            "upstream_session_id_field": extension_specs.SHARED_SESSION_BINDING_FIELD,
+            "upstream_session_id_field": "contextId",
             "context_id_strategy": "equals_upstream_session_id",
             "notes": [
                 (
                     "session query projections currently set contextId equal to the "
                     "upstream session_id"
                 ),
-                "metadata.shared.session.id carries the same upstream session identity explicitly",
+                (
+                    "session query projections do not duplicate that identity under "
+                    "metadata.shared.session.id"
+                ),
+                (
+                    "metadata.shared.session.id remains the request-side rebinding hint "
+                    "for the shared session-binding extension"
+                ),
             ],
         },
     }

--- a/src/codex_a2a/contracts/extensions.py
+++ b/src/codex_a2a/contracts/extensions.py
@@ -453,11 +453,7 @@ def build_session_binding_extension_params(
     return {
         "metadata_field": extension_specs.SHARED_SESSION_BINDING_FIELD,
         "behavior": "prefer_metadata_binding_else_create_session",
-        "supported_metadata": [
-            "shared.session.id",
-            "codex.directory",
-            "codex.execution",
-        ],
+        "supported_metadata": ["shared.session.id"],
         "provider_private_metadata": list(extension_specs._REQUEST_EXECUTION_PROVIDER_METADATA),
         "request_execution_options": extension_specs._build_request_execution_options_contract(),
         "profile": runtime_profile.summary_dict(),

--- a/src/codex_a2a/contracts/runtime_output.py
+++ b/src/codex_a2a/contracts/runtime_output.py
@@ -17,7 +17,6 @@ class _StrictContractModel(A2ABaseModel):
 
 class SessionMetadata(_StrictContractModel):
     id: str
-    title: str | None = None
 
 
 class ArtifactStreamMetadata(_StrictContractModel):
@@ -102,14 +101,13 @@ def build_interrupt_metadata(
 def build_output_metadata(
     *,
     session_id: str | None = None,
-    session_title: str | None = None,
     usage: Mapping[str, Any] | None = None,
     stream: Mapping[str, Any] | None = None,
     interrupt: Mapping[str, Any] | None = None,
     codex_private: Mapping[str, Any] | None = None,
 ) -> dict[str, Any] | None:
     shared = SharedOutputMetadata(
-        session=SessionMetadata(id=session_id, title=session_title) if session_id else None,
+        session=SessionMetadata(id=session_id) if session_id else None,
         usage=UsageMetadata.model_validate(dict(usage)) if usage is not None else None,
         stream=(
             ArtifactStreamMetadata.model_validate(dict(stream))
@@ -155,10 +153,9 @@ def build_stream_artifact_metadata(
 def build_session_contract_params(*, field_path: str) -> dict[str, Any]:
     return {
         "required_fields": ["id"],
-        "optional_fields": ["title"],
+        "optional_fields": [],
         "field_paths": {
             "id": f"{field_path}.id",
-            "title": f"{field_path}.title",
         },
     }
 

--- a/src/codex_a2a/jsonrpc/payload_mapping.py
+++ b/src/codex_a2a/jsonrpc/payload_mapping.py
@@ -26,7 +26,6 @@ def as_a2a_session_task(session: Any) -> Task | None:
         context_id=session_context_id(session_id),
         status=TaskStatus(state=TaskState.TASK_STATE_COMPLETED),
         metadata={
-            "shared": {"session": {"id": session_id}},
             "codex": {"raw": session},
         },
     )
@@ -60,7 +59,6 @@ def as_a2a_message(session_id: str, item: Any) -> Message | None:
         parts=[new_text_part(text)],
         context_id=session_context_id(session_id),
         metadata={
-            "shared": {"session": {"id": session_id}},
             "codex": {"raw": item},
         },
     )

--- a/src/codex_a2a/jsonrpc/payload_mapping.py
+++ b/src/codex_a2a/jsonrpc/payload_mapping.py
@@ -12,13 +12,6 @@ def session_context_id(session_id: str) -> str:
     return session_id
 
 
-def extract_session_title(session: dict[str, Any]) -> str:
-    title = session.get("title")
-    if not isinstance(title, str):
-        return ""
-    return title.strip()
-
-
 def as_a2a_session_task(session: Any) -> Task | None:
     if not isinstance(session, dict):
         return None
@@ -28,15 +21,12 @@ def as_a2a_session_task(session: Any) -> Task | None:
     session_id = raw_id.strip()
     if not session_id:
         return None
-    title = extract_session_title(session)
-    if not title:
-        return None
     task = Task(
         id=session_id,
         context_id=session_context_id(session_id),
         status=TaskStatus(state=TaskState.TASK_STATE_COMPLETED),
         metadata={
-            "shared": {"session": {"id": session_id, "title": title}},
+            "shared": {"session": {"id": session_id}},
             "codex": {"raw": session},
         },
     )

--- a/tests/contracts/test_extension_contract_consistency.py
+++ b/tests/contracts/test_extension_contract_consistency.py
@@ -376,7 +376,6 @@ def test_guide_mentions_declared_streaming_contract_fields() -> None:
     required_doc_fragments = [
         streaming_contract["artifact_metadata_field"],
         streaming_contract["session_metadata_field"],
-        streaming_contract["session_fields"]["title"],
         streaming_contract["interrupt_fields"]["phase"],
         streaming_contract["interrupt_fields"]["resolution"],
         streaming_contract["usage_fields"]["reasoning_tokens"],

--- a/tests/jsonrpc/test_protocol_payload_mapping.py
+++ b/tests/jsonrpc/test_protocol_payload_mapping.py
@@ -213,11 +213,11 @@ def test_payload_mapping_contract_helpers_require_core_identifiers() -> None:
     assert task is not None
     assert task.id == "sess-1"
     assert task.context_id == "sess-1"
-    assert task.metadata["shared"] == {"session": {"id": "sess-1"}}
+    assert task.metadata == {"codex": {"raw": {"id": " sess-1 ", "title": " Demo Session "}}}
 
     task_without_title = as_a2a_session_task({"id": "sess-2", "title": "  "})
     assert task_without_title is not None
-    assert task_without_title.metadata["shared"] == {"session": {"id": "sess-2"}}
+    assert task_without_title.metadata == {"codex": {"raw": {"id": "sess-2", "title": "  "}}}
 
     message = as_a2a_message(
         "sess-1",
@@ -231,7 +231,14 @@ def test_payload_mapping_contract_helpers_require_core_identifiers() -> None:
     assert message.message_id == "msg-1"
     assert message.role == Role.ROLE_USER
     assert message.context_id == "sess-1"
-    assert message.metadata["shared"] == {"session": {"id": "sess-1"}}
+    assert message.metadata == {
+        "codex": {
+            "raw": {
+                "info": {"id": " msg-1 ", "role": " user "},
+                "parts": [{"type": "text", "text": "hello"}],
+            }
+        }
+    }
     assert extract_raw_items([{"id": "ok"}], kind="sessions") == [{"id": "ok"}]
 
     with pytest.raises(ValueError, match="Codex sessions payload must be an array; got dict"):

--- a/tests/jsonrpc/test_protocol_payload_mapping.py
+++ b/tests/jsonrpc/test_protocol_payload_mapping.py
@@ -213,9 +213,11 @@ def test_payload_mapping_contract_helpers_require_core_identifiers() -> None:
     assert task is not None
     assert task.id == "sess-1"
     assert task.context_id == "sess-1"
-    assert task.metadata["shared"] == {"session": {"id": "sess-1", "title": "Demo Session"}}
+    assert task.metadata["shared"] == {"session": {"id": "sess-1"}}
 
-    assert as_a2a_session_task({"id": "sess-2", "title": "  "}) is None
+    task_without_title = as_a2a_session_task({"id": "sess-2", "title": "  "})
+    assert task_without_title is not None
+    assert task_without_title.metadata["shared"] == {"session": {"id": "sess-2"}}
 
     message = as_a2a_message(
         "sess-1",

--- a/tests/server/test_agent_card.py
+++ b/tests/server/test_agent_card.py
@@ -265,8 +265,7 @@ def test_public_agent_card_minimizes_provider_private_contracts() -> None:
     assert session_binding_params == {
         "metadata_field": "metadata.shared.session.id",
         "behavior": "prefer_metadata_binding_else_create_session",
-        "supported_metadata": ["shared.session.id", "codex.directory", "codex.execution"],
-        "provider_private_metadata": ["codex.directory", "codex.execution"],
+        "supported_metadata": ["shared.session.id"],
     }
 
     streaming = ext_by_uri[STREAMING_EXTENSION_URI]
@@ -276,8 +275,11 @@ def test_public_agent_card_minimizes_provider_private_contracts() -> None:
     assert streaming_params["interrupt_metadata_field"] == "metadata.shared.interrupt"
     assert streaming_params["session_fields"] == {
         "id": "metadata.shared.session.id",
-        "title": "metadata.shared.session.title",
     }
+    assert "message_id" not in streaming_params["stream_fields"]
+    assert "event_id" not in streaming_params["status_stream_fields"]
+    assert "resolution" not in streaming_params["interrupt_fields"]
+    assert "reasoning_tokens" not in streaming_params["usage_fields"]
     assert streaming_params["usage_fields"]["total_tokens"] == "metadata.shared.usage.total_tokens"
     assert "tool_call_payload_contract" not in streaming_params
 
@@ -365,8 +367,6 @@ def test_authenticated_extended_agent_card_injects_profile_into_extensions() -> 
     assert binding_params["metadata_field"] == "metadata.shared.session.id"
     assert binding_params["supported_metadata"] == [
         "shared.session.id",
-        "codex.directory",
-        "codex.execution",
     ]
     assert binding_params["provider_private_metadata"] == ["codex.directory", "codex.execution"]
     assert binding_params["request_execution_options"] == {
@@ -399,7 +399,7 @@ def test_authenticated_extended_agent_card_injects_profile_into_extensions() -> 
     }
     assert streaming_params["stream_fields"]["sequence"] == "metadata.shared.stream.sequence"
     assert streaming_params["status_stream_fields"]["event_id"] == "metadata.shared.stream.event_id"
-    assert streaming_params["session_fields"]["title"] == "metadata.shared.session.title"
+    assert streaming_params["session_fields"] == {"id": "metadata.shared.session.id"}
     assert streaming_params["interrupt_fields"]["phase"] == "metadata.shared.interrupt.phase"
     assert (
         streaming_params["interrupt_fields"]["resolution"] == "metadata.shared.interrupt.resolution"

--- a/tests/server/test_agent_card.py
+++ b/tests/server/test_agent_card.py
@@ -485,15 +485,16 @@ def test_authenticated_extended_agent_card_injects_profile_into_extensions() -> 
     assert any(
         "forwards limit upstream" in note for note in session_query_params["pagination"]["notes"]
     )
-    assert (
-        session_query_params["context_semantics"]["upstream_session_id_field"]
-        == "metadata.shared.session.id"
-    )
+    assert session_query_params["context_semantics"]["upstream_session_id_field"] == "contextId"
     assert session_query_params["context_semantics"]["context_id_strategy"] == (
         "equals_upstream_session_id"
     )
     assert any(
         "contextId equal to the upstream session_id" in note
+        for note in session_query_params["context_semantics"]["notes"]
+    )
+    assert any(
+        "do not duplicate that identity under metadata.shared.session.id" in note
         for note in session_query_params["context_semantics"]["notes"]
     )
     assert "codex.sessions.shell" not in session_query_params["method_contracts"]


### PR DESCRIPTION
## 概要

本 PR 收窄 shared metadata 的公开契约面，并消除 session query projection 中对同一 session identity 的重复表达。

## 变更内容

- 收窄 public `session-binding` disclosure，public 面仅保留 `shared.session.id`
- 收窄 public `stream-hints` disclosure，不再公开 `message_id`、`event_id`、`shared.session.title`、`interrupt.resolution`、`usage.reasoning_tokens`
- 删除 shared session contract 中对 `title` 的承诺
- 调整 session query projection，不再输出 `metadata.shared.session.title`
- 调整 session query projection，不再在 `contextId` 之外重复输出 `metadata.shared.session.id`
- 更新 session query detailed contract 与 guide，明确 `contextId` 是该投影面的 canonical session identity
- 同步更新文档与契约测试

## 与 Issues 的关系

- Closes #289
- Closes #290
- Closes #291

## 额外说明

- `core.xxx` 的清理与排查策略已单独记录到 follow-up issue `#292`，不在本 PR 的实现范围内。

## 验证

- `uv run pytest --no-cov -q tests/server/test_agent_card.py tests/contracts/test_extension_contract_consistency.py tests/jsonrpc/test_protocol_payload_mapping.py`
- `uv run pytest --no-cov -q tests/jsonrpc/test_protocol_payload_mapping.py tests/jsonrpc/test_codex_session_extension.py tests/server/test_agent_card.py tests/contracts/test_extension_contract_consistency.py`
- `bash ./scripts/validate_baseline.sh`
