### PR TITLE
feat: support core a2a dual-stack compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Repository: https://github.com/liujuanjuan1984/codex-a2a
 
 Install: `uv tool install --upgrade codex-a2a`
 
-Protocol: A2A `1.0` only.
+Protocol: A2A `1.0` by default, with core `0.3` compatibility.
 
 Start the runtime explicitly with `codex-a2a serve`.
 

--- a/docs/a2a-extension-baseline.md
+++ b/docs/a2a-extension-baseline.md
@@ -84,7 +84,7 @@ That inventory must be reusable by:
 
 - No migration from `urn:` to HTTPS extension URI yet.
 - No public expansion of provider-private extension declarations.
-- No compatibility shim for A2A 0.3 behavior.
+- No provider-private compatibility shim for A2A 0.3 behavior beyond the SDK-managed core surface.
 
 ## Follow-On Phases
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -7,11 +7,18 @@ This document explains the compatibility promises this repository currently trie
 - Python versions: 3.11, 3.12, 3.13
 - A2A SDK line: `1.0.x`
 - A2A protocol version advertised by default: `1.0`
-- Normalized protocol compatibility lines declared today: `1.0`
+- Normalized protocol compatibility lines declared today: `1.0`, `0.3`
 
 The repository pins the SDK version in `pyproject.toml` and validates the published CLI build in CI. Upgrade the SDK deliberately rather than relying on floating dependency resolution.
 
-The OpenAPI-published compatibility profile and wire contract publish `default_protocol_version`, `supported_protocol_versions`, and `protocol_compatibility`. Request-time `A2A-Version` negotiation now targets the repository's `1.0` baseline only, and the published contracts should describe the implemented `1.0` transport surface rather than any legacy compatibility line.
+The OpenAPI-published compatibility profile and wire contract publish `default_protocol_version`, `supported_protocol_versions`, and `protocol_compatibility`. Request-time `A2A-Version` negotiation now supports both `1.0` and `0.3` for the core A2A surface. By default this repository still advertises `1.0`, while `0.3` remains an explicit compatibility line for SDK-managed core JSON-RPC and REST handling.
+
+Provider-private JSON-RPC methods are intentionally narrower than the core compatibility surface:
+
+- core A2A methods support explicit `1.0` and `0.3`
+- `codex.*` methods remain `1.0`-only
+- `a2a.interrupt.*` callback methods remain `1.0`-only
+- the legacy authenticated card discovery route remains `GET /v1/card` under explicit `0.3`
 
 ## Contract Honesty
 
@@ -30,6 +37,7 @@ Open-source consumption guidance:
 - Treat the core A2A send / stream / task methods as the portable baseline.
 - Treat the Agent Card `supported_interfaces[].url` value as the shared service discovery root. For `HTTP+JSON`, this repository uses that URL as the REST base root rather than as a concrete method path.
 - Treat `POST /` as the shared JSON-RPC surface for both core A2A methods and provider-private extension methods.
+- Treat explicit `0.3` support as a core-surface compatibility layer only, not as a blanket promise for every provider-private method on `POST /`.
 - Treat `urn:a2a:*` entries in this repository as shared repo-family conventions, not as claims that they are part of the A2A core baseline.
 - Treat `a2a.interrupt.*` reply methods as a shared provider-private callback contract on `POST /`, declared on authenticated discovery surfaces but not activated through `A2A-Extensions`.
 - Treat `codex.*` methods plus `metadata.codex.directory` and `metadata.codex.execution` as a Codex-specific control plane layered on top of the portable A2A surface.

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -13,6 +13,7 @@ This guide covers runtime configuration, transport contracts, streaming/session/
 - The authenticated extended card exposes the authenticated provider-private skill inventory and deployment-aware examples:
   - preferred: JSON-RPC `GetExtendedAgentCard`
   - HTTP core route: `GET /v1/extendedAgentCard`
+  - HTTP `0.3` compatibility route: `GET /v1/card`
 - Full provider-private contract payloads are available through OpenAPI metadata:
   - `GET /openapi.json`
   - `x-a2a-extension-contracts` for negotiated shared extensions
@@ -26,6 +27,10 @@ This guide covers runtime configuration, transport contracts, streaming/session/
 - Payload schema is transport-specific and should not be mixed:
   - REST send payload uses `message.parts` and role values like `ROLE_USER`
   - JSON-RPC `SendMessage` payload uses `params.message.parts` and role values like `ROLE_USER`
+- The core A2A surface also accepts explicit `A2A-Version: 0.3` requests through the SDK compatibility adapters:
+  - REST `0.3` send payloads use `request.content` and role values such as `user`
+  - JSON-RPC `0.3` send payloads use legacy method names such as `message/send`
+- Provider-private `codex.*` and `a2a.interrupt.*` methods remain on the `1.0` JSON-RPC contract even though they share `POST /`.
 - OpenAPI metadata on the shared JSON-RPC entrypoint publishes the explicit wire contract for the supported method set and unsupported-method error shape.
 
 ## Wire Contract
@@ -63,6 +68,10 @@ Unsupported method contract on the shared JSON-RPC endpoint (`POST /`):
   - JSON-RPC error code: `-32601`
   - error message: `Method not found`
   - no additional `error.data` contract is declared
+- Explicit `0.3` requests to provider-private namespaces:
+  - JSON-RPC error code: `-32601`
+  - error message: `Method not found`
+  - no additional `error.data` contract is declared
 - Recognized provider-private extension namespaces (`codex.*`, `a2a.interrupt.*`):
   - JSON-RPC error code: `-32601`
   - error message: `Method not found`
@@ -78,6 +87,7 @@ Consumer guidance:
 - Use OpenAPI when you need the detailed method matrix, provider-private notes, or full provider-private contract payloads.
 - Treat `supported_methods` in extension-namespace `error.data` as the runtime truth for the current deployment, especially when a deployment-conditional method is disabled.
 - Treat the core A2A methods as the portable interoperability baseline.
+- Treat explicit `0.3` support as limited to the core A2A surface; use `1.0` when calling provider-private `codex.*` or `a2a.interrupt.*` methods.
 - Treat `codex.*` methods plus `metadata.codex.directory` and `metadata.codex.execution` as a Codex-specific control plane for Codex-aware clients rather than generic A2A portability claims.
 - See [extension-specifications.md](./extension-specifications.md) for the stable URI/spec index, and [compatibility.md](./compatibility.md) for compatibility promises.
 

--- a/src/codex_a2a/cli.py
+++ b/src/codex_a2a/cli.py
@@ -25,7 +25,7 @@ CLI_BRAND_BANNER = (
 )
 ROOT_DESCRIPTION = (
     "Codex A2A runtime for explicit service startup and peer calls. "
-    "A2A Protocol 1.0 only.\n"
+    "A2A Protocol 1.0 by default, with core 0.3 compatibility.\n"
     "  codex-a2a <command> [arguments] [options]"
 )
 CODEX_SETUP_HELP = (

--- a/src/codex_a2a/contracts/extensions.py
+++ b/src/codex_a2a/contracts/extensions.py
@@ -13,9 +13,10 @@ from codex_a2a.execution.tool_call_payloads import build_tool_call_payload_contr
 from codex_a2a.profile.runtime import RuntimeProfile
 from codex_a2a.protocol_versions import (
     ADVERTISED_PROTOCOL_VERSION,
-    SUPPORTED_PROTOCOL_VERSIONS,
+    PROVIDER_PRIVATE_PROTOCOL_VERSION,
     build_protocol_compatibility_summary,
     normalize_protocol_version,
+    ordered_supported_protocol_versions,
 )
 
 from . import extension_specs
@@ -60,15 +61,43 @@ def _extension_jsonrpc_endpoint_contract() -> dict[str, Any]:
     }
 
 
+def _core_transport_interfaces(
+    default_protocol_version: str,
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "protocol_binding": protocol_binding,
+            "protocol_version": protocol_version,
+            transport_path_key: transport_path_value,
+        }
+        for protocol_version in ordered_supported_protocol_versions(default_protocol_version)
+        for protocol_binding, transport_path_key, transport_path_value in (
+            ("HTTP+JSON", "url_path_prefix", REST_API_PATH_PREFIX),
+            ("JSON-RPC", "url_path", CORE_JSONRPC_PATH),
+        )
+    ]
+
+
+def _declared_provider_private_protocol_version(protocol_version: str) -> str:
+    declared_protocol_version = normalize_protocol_version(protocol_version)
+    if declared_protocol_version != PROVIDER_PRIVATE_PROTOCOL_VERSION:
+        raise ValueError("Provider-private codex contracts must stay on the 1.0 protocol line.")
+    return declared_protocol_version
+
+
 def build_wire_contract_extension_params(
     *,
     protocol_version: str,
     runtime_profile: RuntimeProfile,
 ) -> dict[str, Any]:
-    declared_protocol_version = normalize_protocol_version(protocol_version)
+    declared_protocol_version = _declared_provider_private_protocol_version(protocol_version)
     declared_default_protocol_version = normalize_protocol_version(ADVERTISED_PROTOCOL_VERSION)
-    declared_supported_protocol_versions = SUPPORTED_PROTOCOL_VERSIONS
-    protocol_compatibility = build_protocol_compatibility_summary()
+    declared_supported_protocol_versions = ordered_supported_protocol_versions(
+        declared_default_protocol_version
+    )
+    protocol_compatibility = build_protocol_compatibility_summary(
+        default_protocol_version=declared_default_protocol_version
+    )
     snapshot = extension_specs.build_capability_snapshot(runtime_profile=runtime_profile)
     resubscribe_behavior = {
         "scope": "service-level",
@@ -92,18 +121,7 @@ def build_wire_contract_extension_params(
         "default_protocol_version": declared_default_protocol_version,
         "supported_protocol_versions": list(declared_supported_protocol_versions),
         "protocol_compatibility": protocol_compatibility,
-        "transport_interfaces": [
-            {
-                "protocol_binding": "HTTP+JSON",
-                "protocol_version": declared_protocol_version,
-                "url_path_prefix": REST_API_PATH_PREFIX,
-            },
-            {
-                "protocol_binding": "JSON-RPC",
-                "protocol_version": declared_protocol_version,
-                "url_path": CORE_JSONRPC_PATH,
-            },
-        ],
+        "transport_interfaces": _core_transport_interfaces(declared_default_protocol_version),
         "core": {
             "jsonrpc_endpoint": {
                 "protocol_binding": "JSON-RPC",
@@ -116,7 +134,7 @@ def build_wire_contract_extension_params(
         "extensions": {
             "jsonrpc_endpoint": {
                 "protocol_binding": "JSON-RPC",
-                "protocol_version": declared_protocol_version,
+                "protocol_version": PROVIDER_PRIVATE_PROTOCOL_VERSION,
                 "url_path": EXTENSION_JSONRPC_PATH,
             },
             "jsonrpc_methods": list(snapshot.extension_jsonrpc_methods),
@@ -160,10 +178,14 @@ def build_compatibility_profile_params(
     protocol_version: str,
     runtime_profile: RuntimeProfile,
 ) -> dict[str, Any]:
-    declared_protocol_version = normalize_protocol_version(protocol_version)
+    declared_protocol_version = _declared_provider_private_protocol_version(protocol_version)
     declared_default_protocol_version = normalize_protocol_version(ADVERTISED_PROTOCOL_VERSION)
-    declared_supported_protocol_versions = SUPPORTED_PROTOCOL_VERSIONS
-    protocol_compatibility = build_protocol_compatibility_summary()
+    declared_supported_protocol_versions = ordered_supported_protocol_versions(
+        declared_default_protocol_version
+    )
+    protocol_compatibility = build_protocol_compatibility_summary(
+        default_protocol_version=declared_default_protocol_version
+    )
     snapshot = extension_specs.build_capability_snapshot(runtime_profile=runtime_profile)
     resubscribe_behavior = {
         "scope": "service-level",
@@ -356,6 +378,7 @@ def build_compatibility_profile_params(
         },
         "extension_transport": {
             "jsonrpc_endpoint": EXTENSION_JSONRPC_PATH,
+            "protocol_version": PROVIDER_PRIVATE_PROTOCOL_VERSION,
         },
         "service_behaviors": {
             extension_specs.TASKS_RESUBSCRIBE_METHOD: resubscribe_behavior,
@@ -396,6 +419,11 @@ def build_compatibility_profile_params(
                 f"Use {CORE_JSONRPC_PATH} for both core A2A JSON-RPC methods and "
                 "provider-private codex.* / a2a.interrupt.* methods; distinguish them "
                 "by method name and the published compatibility contracts."
+            ),
+            (
+                "Treat explicit A2A 0.3 support as a core-surface compatibility layer only; "
+                "provider-private codex.* and a2a.interrupt.* methods remain on the 1.0 "
+                "JSON-RPC contract."
             ),
             (
                 "Treat codex.* methods and codex.directory/codex.execution metadata as "

--- a/src/codex_a2a/jsonrpc/application.py
+++ b/src/codex_a2a/jsonrpc/application.py
@@ -27,7 +27,11 @@ from codex_a2a.jsonrpc.review_control import handle_review_control_request
 from codex_a2a.jsonrpc.session_query import handle_session_query_request
 from codex_a2a.jsonrpc.thread_lifecycle_control import handle_thread_lifecycle_control_request
 from codex_a2a.jsonrpc.turn_control import handle_turn_control_request
-from codex_a2a.protocol_versions import get_current_protocol_version
+from codex_a2a.protocol_versions import (
+    LEGACY_COMPAT_PROTOCOL_VERSION,
+    PROVIDER_PRIVATE_PROTOCOL_VERSION,
+    get_current_protocol_version,
+)
 from codex_a2a.upstream.client import CodexClient
 
 
@@ -44,6 +48,7 @@ def create_extension_jsonrpc_routes(
     supported_methods: list[str],
     guard_hooks: SessionGuardHooks,
     rpc_url: str,
+    enable_v0_3_compat: bool = False,
     dispatcher_factory=None,
 ) -> list[Route]:
     factory = dispatcher_factory or CodexSessionQueryJSONRPCApplication
@@ -58,6 +63,7 @@ def create_extension_jsonrpc_routes(
         methods=methods,
         supported_methods=supported_methods,
         guard_hooks=guard_hooks,
+        enable_v0_3_compat=enable_v0_3_compat,
     )
     return [
         Route(
@@ -140,12 +146,26 @@ class CodexSessionQueryJSONRPCApplication(JsonRpcDispatcher):
         except Exception:
             return await super().handle_requests(request)
 
+        if self._is_legacy_core_method(base_request.method):
+            if get_current_protocol_version() != LEGACY_COMPAT_PROTOCOL_VERSION:
+                if base_request.id is None:
+                    return Response(status_code=204)
+                return self._provider_private_method_not_found(base_request.id)
+            return await super().handle_requests(request)
+
         if not self._method_registry.is_extension_method(base_request.method):
             if self._looks_like_extension_method(base_request.method):
                 if base_request.id is None:
                     return Response(status_code=204)
+                if get_current_protocol_version() == LEGACY_COMPAT_PROTOCOL_VERSION:
+                    return self._provider_private_method_not_found(base_request.id)
                 return self._unsupported_method_response(base_request.id, base_request.method)
             return await super().handle_requests(request)
+
+        if get_current_protocol_version() != PROVIDER_PRIVATE_PROTOCOL_VERSION:
+            if base_request.id is None:
+                return Response(status_code=204)
+            return self._provider_private_method_not_found(base_request.id)
 
         params = base_request.params or {}
         if not isinstance(params, dict):
@@ -211,6 +231,13 @@ class CodexSessionQueryJSONRPCApplication(JsonRpcDispatcher):
     def _looks_like_extension_method(method: str) -> bool:
         return method.startswith("codex.") or method.startswith("a2a.interrupt.")
 
+    def _is_legacy_core_method(self, method: str) -> bool:
+        return bool(
+            self.enable_v0_3_compat
+            and self._v03_adapter is not None
+            and self._v03_adapter.supports_method(method)
+        )
+
     def _unsupported_method_response(
         self,
         request_id: str | int,
@@ -228,6 +255,18 @@ class CodexSessionQueryJSONRPCApplication(JsonRpcDispatcher):
                     "supported_methods": self._supported_methods,
                     "protocol_version": protocol_version,
                 },
+            ),
+        )
+
+    def _provider_private_method_not_found(
+        self,
+        request_id: str | int,
+    ) -> JSONResponse:
+        return self._generate_error_response(
+            request_id,
+            JSONRPCError(
+                code=-32601,
+                message="Method not found",
             ),
         )
 

--- a/src/codex_a2a/protocol_versions.py
+++ b/src/codex_a2a/protocol_versions.py
@@ -11,21 +11,39 @@ _CURRENT_PROTOCOL_VERSION: ContextVar[str | None] = ContextVar(
     default=None,
 )
 SUPPORTED_PROTOCOL_VERSION = "1.0"
-SUPPORTED_PROTOCOL_VERSIONS: tuple[str, ...] = (SUPPORTED_PROTOCOL_VERSION,)
-ADVERTISED_PROTOCOL_VERSION = "1.0"
+LEGACY_COMPAT_PROTOCOL_VERSION = "0.3"
+SUPPORTED_PROTOCOL_VERSIONS: tuple[str, ...] = (
+    SUPPORTED_PROTOCOL_VERSION,
+    LEGACY_COMPAT_PROTOCOL_VERSION,
+)
+ADVERTISED_PROTOCOL_VERSION = SUPPORTED_PROTOCOL_VERSION
+PROVIDER_PRIVATE_PROTOCOL_VERSION = SUPPORTED_PROTOCOL_VERSION
 
 V1_SUPPORTED_FEATURES: tuple[str, ...] = (
     "A2A-Version request-time negotiation and response header echo.",
     "Official A2A 1.0 JSON-RPC methods and /v1 HTTP endpoints.",
     "Unified Part(text|data|url|raw) payloads, task streaming, and protocol-aware error shaping.",
 )
+V03_SUPPORTED_FEATURES: tuple[str, ...] = (
+    "Explicit A2A-Version=0.3 request-time negotiation on the shared runtime endpoint.",
+    "SDK-managed A2A 0.3 JSON-RPC aliases and HTTP payload compatibility for core methods.",
+    "Core send, stream, and task APIs bridged into the repository's shared task/runtime model.",
+)
+V03_KNOWN_GAPS: tuple[str, ...] = (
+    "Provider-private codex.* and a2a.interrupt.* JSON-RPC methods remain available on 1.0 only.",
+)
 
 
 class UnsupportedProtocolVersionError(ValueError):
-    def __init__(self, requested_version: str) -> None:
+    def __init__(
+        self,
+        requested_version: str,
+        *,
+        default_protocol_version: str = ADVERTISED_PROTOCOL_VERSION,
+    ) -> None:
         self.requested_version = requested_version
         self.supported_protocol_versions = SUPPORTED_PROTOCOL_VERSIONS
-        self.default_protocol_version = ADVERTISED_PROTOCOL_VERSION
+        self.default_protocol_version = default_protocol_version
         supported_display = ", ".join(SUPPORTED_PROTOCOL_VERSIONS)
         super().__init__(
             f"Unsupported A2A protocol version {requested_version!r}. "
@@ -49,23 +67,49 @@ def normalize_protocol_version(value: str) -> str:
     return f"{match.group('major')}.{match.group('minor')}"
 
 
+def ordered_supported_protocol_versions(
+    default_protocol_version: str = ADVERTISED_PROTOCOL_VERSION,
+) -> tuple[str, ...]:
+    normalized_default = normalize_protocol_version(default_protocol_version)
+    if normalized_default not in SUPPORTED_PROTOCOL_VERSIONS:
+        raise ValueError(
+            f"Default protocol version must be one of: {', '.join(SUPPORTED_PROTOCOL_VERSIONS)}"
+        )
+    ordered_versions = tuple(
+        version for version in SUPPORTED_PROTOCOL_VERSIONS if version != normalized_default
+    )
+    return (normalized_default, *ordered_versions)
+
+
 def negotiate_protocol_version(
     *,
     header_value: str | None,
     query_value: str | None,
+    default_protocol_version: str = ADVERTISED_PROTOCOL_VERSION,
 ) -> NegotiatedProtocolVersion:
+    normalized_default = normalize_protocol_version(default_protocol_version)
+    if normalized_default not in SUPPORTED_PROTOCOL_VERSIONS:
+        raise ValueError(
+            "default_protocol_version must be one of: " + ", ".join(SUPPORTED_PROTOCOL_VERSIONS)
+        )
     raw_header = (header_value or "").strip()
     raw_query = (query_value or "").strip()
     explicit = bool(raw_header or raw_query)
-    raw_requested = raw_header or raw_query or ADVERTISED_PROTOCOL_VERSION
+    raw_requested = raw_header or raw_query or normalized_default
 
     try:
         normalized_requested = normalize_protocol_version(raw_requested)
     except ValueError as exc:
-        raise UnsupportedProtocolVersionError(raw_requested) from exc
+        raise UnsupportedProtocolVersionError(
+            raw_requested,
+            default_protocol_version=normalized_default,
+        ) from exc
 
-    if normalized_requested != SUPPORTED_PROTOCOL_VERSION:
-        raise UnsupportedProtocolVersionError(normalized_requested)
+    if normalized_requested not in SUPPORTED_PROTOCOL_VERSIONS:
+        raise UnsupportedProtocolVersionError(
+            normalized_requested,
+            default_protocol_version=normalized_default,
+        )
 
     return NegotiatedProtocolVersion(
         protocol_version=normalized_requested,
@@ -88,17 +132,28 @@ def get_current_protocol_version() -> str:
     return ADVERTISED_PROTOCOL_VERSION
 
 
-def build_protocol_compatibility_summary() -> dict[str, Any]:
+def build_protocol_compatibility_summary(
+    *,
+    default_protocol_version: str = ADVERTISED_PROTOCOL_VERSION,
+) -> dict[str, Any]:
+    ordered_versions = ordered_supported_protocol_versions(default_protocol_version)
     return {
-        "default_protocol_version": ADVERTISED_PROTOCOL_VERSION,
-        "supported_protocol_versions": list(SUPPORTED_PROTOCOL_VERSIONS),
+        "default_protocol_version": ordered_versions[0],
+        "supported_protocol_versions": list(ordered_versions),
         "versions": {
             SUPPORTED_PROTOCOL_VERSION: {
                 "enabled": True,
-                "default": True,
+                "default": SUPPORTED_PROTOCOL_VERSION == ordered_versions[0],
                 "status": "supported",
                 "supported_features": list(V1_SUPPORTED_FEATURES),
                 "known_gaps": [],
-            }
+            },
+            LEGACY_COMPAT_PROTOCOL_VERSION: {
+                "enabled": True,
+                "default": LEGACY_COMPAT_PROTOCOL_VERSION == ordered_versions[0],
+                "status": "supported",
+                "supported_features": list(V03_SUPPORTED_FEATURES),
+                "known_gaps": list(V03_KNOWN_GAPS),
+            },
         },
     }

--- a/src/codex_a2a/server/agent_card.py
+++ b/src/codex_a2a/server/agent_card.py
@@ -22,6 +22,7 @@ from codex_a2a.media_modes import (
     TEXT_OUTPUT_MEDIA_MODES,
 )
 from codex_a2a.profile.runtime import RuntimeProfile, build_runtime_profile
+from codex_a2a.protocol_versions import ordered_supported_protocol_versions
 
 
 def _build_agent_card_description(
@@ -388,14 +389,11 @@ def _build_agent_card(
     supported_interfaces = [
         AgentInterface(
             url=public_url,
-            protocol_binding=TransportProtocol.HTTP_JSON,
-            protocol_version=settings.a2a_protocol_version,
-        ),
-        AgentInterface(
-            url=public_url,
-            protocol_binding=TransportProtocol.JSONRPC,
-            protocol_version=settings.a2a_protocol_version,
-        ),
+            protocol_binding=protocol_binding,
+            protocol_version=protocol_version,
+        )
+        for protocol_version in ordered_supported_protocol_versions(settings.a2a_protocol_version)
+        for protocol_binding in (TransportProtocol.HTTP_JSON, TransportProtocol.JSONRPC)
     ]
 
     return AgentCard(

--- a/src/codex_a2a/server/application.py
+++ b/src/codex_a2a/server/application.py
@@ -8,6 +8,7 @@ import uvicorn
 from a2a.server.routes.agent_card_routes import create_agent_card_routes
 from a2a.server.routes.rest_routes import create_rest_routes
 from fastapi import FastAPI
+from starlette.routing import BaseRoute, Mount, Route
 
 from codex_a2a.client.manager import A2AClientManager
 from codex_a2a.config import Settings
@@ -24,6 +25,10 @@ from codex_a2a.jsonrpc.application import (
 from codex_a2a.jsonrpc.hooks import SessionGuardHooks
 from codex_a2a.logging_context import install_log_record_factory
 from codex_a2a.profile.runtime import build_runtime_profile
+from codex_a2a.protocol_versions import (
+    LEGACY_COMPAT_PROTOCOL_VERSION,
+    get_current_protocol_version,
+)
 from codex_a2a.server.agent_card import (
     build_agent_card,
     build_authenticated_extended_agent_card,
@@ -44,6 +49,135 @@ from .http_middlewares import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _flatten_rest_routes(
+    routes: list[BaseRoute],
+    *,
+    prefix: str = "",
+) -> list[tuple[str, str, Any, str | None]]:
+    flattened: list[tuple[str, str, Any, str | None]] = []
+    for route in routes:
+        if isinstance(route, Route):
+            methods = sorted((route.methods or set()) - {"HEAD"})
+            if len(methods) != 1:
+                continue
+            flattened.append((f"{prefix}{route.path}", methods[0], route.endpoint, route.name))
+            continue
+        if isinstance(route, Mount):
+            flattened.extend(
+                _flatten_rest_routes(
+                    list(route.routes),
+                    prefix=f"{prefix}{route.path}",
+                )
+            )
+    return flattened
+
+
+def _extract_compat_rest_routes(
+    *,
+    request_handler,
+    context_builder,
+    path_prefix: str,
+) -> list[tuple[str, str, Any, str | None]]:
+    compat_prefix = f"{path_prefix}{extension_contracts.REST_API_PATH_PREFIX}"
+    compat_card_path = f"{compat_prefix}/card"
+    routes = create_rest_routes(
+        request_handler=request_handler,
+        context_builder=context_builder,
+        enable_v0_3_compat=True,
+        path_prefix=path_prefix,
+    )
+    return [
+        route
+        for route in _flatten_rest_routes(routes)
+        if route[0].startswith(f"{compat_prefix}/") or route[0] == compat_card_path
+    ]
+
+
+def _merge_dual_stack_rest_routes(
+    *,
+    base_routes: list[tuple[str, str, Any, str | None]],
+    compat_routes: list[tuple[str, str, Any, str | None]],
+) -> list[Route]:
+    compat_route_map = {
+        (path, method): (endpoint, name) for path, method, endpoint, name in compat_routes
+    }
+    merged_routes: list[Route] = []
+
+    for path, method, base_endpoint, name in base_routes:
+        compat_endpoint = compat_route_map.pop((path, method), None)
+        if compat_endpoint is None:
+            merged_routes.append(
+                Route(
+                    path=path,
+                    endpoint=base_endpoint,
+                    methods=[method],
+                    name=name,
+                )
+            )
+            continue
+
+        async def _dispatch(
+            request,
+            *,
+            base_endpoint=base_endpoint,
+            compat_endpoint=compat_endpoint[0],
+        ):
+            if get_current_protocol_version() == LEGACY_COMPAT_PROTOCOL_VERSION:
+                return await compat_endpoint(request)
+            return await base_endpoint(request)
+
+        merged_routes.append(
+            Route(
+                path=path,
+                endpoint=_dispatch,
+                methods=[method],
+                name=name,
+            )
+        )
+
+    for (path, method), (compat_endpoint, name) in compat_route_map.items():
+        merged_routes.append(
+            Route(
+                path=path,
+                endpoint=compat_endpoint,
+                methods=[method],
+                name=name,
+            )
+        )
+
+    return merged_routes
+
+
+def _create_dual_stack_rest_routes(
+    *,
+    request_handler,
+    context_builder,
+) -> list[Any]:
+    base_routes = _flatten_rest_routes(
+        create_rest_routes(
+            request_handler=request_handler,
+            context_builder=context_builder,
+            path_prefix=extension_contracts.REST_API_PATH_PREFIX,
+        )
+    )
+    compat_routes = _extract_compat_rest_routes(
+        request_handler=request_handler,
+        context_builder=context_builder,
+        path_prefix="",
+    )
+    compat_routes.extend(
+        _extract_compat_rest_routes(
+            request_handler=request_handler,
+            context_builder=context_builder,
+            path_prefix="/{tenant}",
+        )
+    )
+    return _merge_dual_stack_rest_routes(
+        base_routes=base_routes,
+        compat_routes=compat_routes,
+    )
 
 
 def create_app(settings: Settings) -> FastAPI:
@@ -190,14 +324,14 @@ def create_app(settings: Settings) -> FastAPI:
             supported_methods=supported_extension_jsonrpc_methods,
             guard_hooks=session_guard_hooks,
             rpc_url=extension_contracts.CORE_JSONRPC_PATH,
+            enable_v0_3_compat=True,
             dispatcher_factory=CodexSessionQueryJSONRPCApplication,
         )
     )
     app.router.routes.extend(
-        create_rest_routes(
+        _create_dual_stack_rest_routes(
             request_handler=handler,
             context_builder=context_builder,
-            path_prefix=extension_contracts.REST_API_PATH_PREFIX,
         )
     )
     app.state.codex_client = client

--- a/src/codex_a2a/server/http_middlewares.py
+++ b/src/codex_a2a/server/http_middlewares.py
@@ -47,6 +47,7 @@ _PUBLIC_AGENT_CARD_PATHS = {
 }
 _AUTHENTICATED_EXTENDED_CARD_PATHS = {
     f"{extension_contracts.REST_API_PATH_PREFIX}/extendedAgentCard",
+    f"{extension_contracts.REST_API_PATH_PREFIX}/card",
 }
 _OPENAPI_PATHS = {
     "/openapi.json",
@@ -206,8 +207,23 @@ def _is_jsonrpc_path(path: str) -> bool:
     }
 
 
+def _canonical_rest_path(path: str) -> str:
+    rest_prefix = extension_contracts.REST_API_PATH_PREFIX
+    if path == rest_prefix or path.startswith(f"{rest_prefix}/"):
+        return path
+    marker = f"{rest_prefix}/"
+    marker_index = path.find(marker, 1)
+    if marker_index > 0 and "/" not in path[1:marker_index]:
+        return path[marker_index:]
+    return path
+
+
+def _is_rest_message_path(path: str) -> bool:
+    return _canonical_rest_path(path) in _REST_MESSAGE_PATHS
+
+
 def _requires_protocol_negotiation(request: Request) -> bool:
-    path = request.url.path
+    path = _canonical_rest_path(request.url.path)
     if request.method == "OPTIONS":
         return False
     return _is_jsonrpc_path(path) or path.startswith(f"{extension_contracts.REST_API_PATH_PREFIX}/")
@@ -334,6 +350,7 @@ def install_http_middlewares(
             negotiated = negotiate_protocol_version(
                 header_value=header_value,
                 query_value=query_value,
+                default_protocol_version=settings.a2a_protocol_version,
             )
         except UnsupportedProtocolVersionError as exc:
             request_id: str | int | None = None
@@ -364,8 +381,9 @@ def install_http_middlewares(
             return await call_next(request)
 
         path = request.url.path
+        canonical_path = _canonical_rest_path(path)
         is_public_card = path in _PUBLIC_AGENT_CARD_PATHS
-        is_extended_card = path in _AUTHENTICATED_EXTENDED_CARD_PATHS
+        is_extended_card = canonical_path in _AUTHENTICATED_EXTENDED_CARD_PATHS
         if not is_public_card and not is_extended_card:
             return await call_next(request)
 
@@ -405,7 +423,7 @@ def install_http_middlewares(
 
     @app.middleware("http")
     async def guard_rest_payload_shape(request: Request, call_next):
-        if request.method != "POST" or request.url.path not in _REST_MESSAGE_PATHS:
+        if request.method != "POST" or not _is_rest_message_path(request.url.path):
             return await call_next(request)
 
         body = await _get_request_body(request)
@@ -415,7 +433,8 @@ def install_http_middlewares(
                 {
                     "error": (
                         "Invalid HTTP+JSON payload for REST endpoint. "
-                        "Use an A2A 1.0 request body with message.parts, or call "
+                        "Use the transport-specific A2A REST request body for the "
+                        "negotiated protocol version, or call "
                         f"POST {extension_contracts.CORE_JSONRPC_PATH} "
                         "with JSON-RPC method=SendMessage or "
                         "method=SendStreamingMessage."
@@ -427,7 +446,7 @@ def install_http_middlewares(
 
     @app.middleware("http")
     async def guard_missing_subscribe_task(request: Request, call_next):
-        path = request.url.path
+        path = _canonical_rest_path(request.url.path)
         if not path.startswith("/v1/tasks/") or not path.endswith(":subscribe"):
             return await call_next(request)
 

--- a/src/codex_a2a/server/openapi.py
+++ b/src/codex_a2a/server/openapi.py
@@ -115,6 +115,69 @@ def _ensure_minimal_a2a_schemas(schema: dict[str, Any]) -> None:
             "additionalProperties": True,
         },
     )
+    _ensure_object_schema(
+        schemas,
+        "A2A03ContentPart",
+        {
+            "type": "object",
+            "description": (
+                "A2A 0.3 compatibility content part. Text parts typically use "
+                "{'text': '...'} and the SDK maps them into the v1 core model."
+            ),
+            "additionalProperties": True,
+        },
+    )
+    _ensure_object_schema(
+        schemas,
+        "A2A03Message",
+        {
+            "type": "object",
+            "required": ["messageId", "role", "content"],
+            "properties": {
+                "messageId": {"type": "string"},
+                "role": {
+                    "type": "string",
+                    "enum": ["user", "agent"],
+                },
+                "content": {
+                    "type": "array",
+                    "items": {"$ref": "#/components/schemas/A2A03ContentPart"},
+                },
+                "metadata": {
+                    "type": "object",
+                    "additionalProperties": True,
+                },
+            },
+            "additionalProperties": True,
+        },
+    )
+    _ensure_object_schema(
+        schemas,
+        "A2A03SendMessageRequest",
+        {
+            "type": "object",
+            "required": ["request"],
+            "properties": {
+                "request": {"$ref": "#/components/schemas/A2A03Message"},
+                "configuration": {
+                    "type": "object",
+                    "additionalProperties": True,
+                },
+                "metadata": {
+                    "type": "object",
+                    "additionalProperties": True,
+                },
+            },
+            "additionalProperties": True,
+        },
+    )
+    _ensure_object_schema(
+        schemas,
+        "A2A03SendStreamingMessageRequest",
+        {
+            "$ref": "#/components/schemas/A2A03SendMessageRequest",
+        },
+    )
 
 
 def _ensure_path_item(
@@ -205,9 +268,16 @@ def patch_openapi_contract(
                     "summary": "Send Message (HTTP+JSON)",
                     "description": (
                         "A2A HTTP+JSON message send endpoint. "
-                        "Use the A2A 1.0 request body with message.parts."
+                        "Use the negotiated A2A REST request body for the selected "
+                        "protocol version; the SDK also accepts explicit 0.3 "
+                        "compatibility payloads on this core route."
                     ),
-                    "schema_ref": "#/components/schemas/SendMessageRequest",
+                    "schema": {
+                        "oneOf": [
+                            {"$ref": "#/components/schemas/SendMessageRequest"},
+                            {"$ref": "#/components/schemas/A2A03SendMessageRequest"},
+                        ]
+                    },
                     "contracts": {
                         "session_binding": a2a_extension_contracts["session_binding"],
                     },
@@ -216,9 +286,16 @@ def patch_openapi_contract(
                     "summary": "Stream Message (HTTP+JSON)",
                     "description": (
                         "A2A HTTP+JSON streaming endpoint. "
-                        "Use the A2A 1.0 request body with message.parts."
+                        "Use the negotiated A2A REST request body for the selected "
+                        "protocol version; the SDK also accepts explicit 0.3 "
+                        "compatibility payloads on this core route."
                     ),
-                    "schema_ref": "#/components/schemas/SendStreamingMessageRequest",
+                    "schema": {
+                        "oneOf": [
+                            {"$ref": "#/components/schemas/SendStreamingMessageRequest"},
+                            {"$ref": "#/components/schemas/A2A03SendStreamingMessageRequest"},
+                        ]
+                    },
                     "contracts": {
                         "session_binding": a2a_extension_contracts["session_binding"],
                         "streaming": a2a_extension_contracts["streaming"],
@@ -255,8 +332,19 @@ def patch_openapi_contract(
                 app_json = content.setdefault("application/json", {})
                 if not isinstance(app_json, dict):
                     continue
-                app_json["schema"] = {"$ref": contract["schema_ref"]}
+                app_json["schema"] = contract["schema"]
                 app_json["examples"] = rest_examples
+
+            card_get = _ensure_path_item(paths, "/v1/card", "get")
+            if "security" in schema:
+                card_get["security"] = list(cast(list[dict[str, list[str]]], schema["security"]))
+            card_get["summary"] = "Get Authenticated Extended Agent Card (HTTP+JSON 0.3)"
+            card_get["description"] = (
+                "A2A 0.3 compatibility REST discovery route for the authenticated extended "
+                "Agent Card. Use explicit A2A-Version: 0.3 when calling this compatibility "
+                "endpoint."
+            )
+            card_get.setdefault("responses", {"200": {"description": "Authenticated Agent Card"}})
 
         app.openapi_schema = schema
         return schema

--- a/src/codex_a2a/server/openapi_contract_fragments.py
+++ b/src/codex_a2a/server/openapi_contract_fragments.py
@@ -39,6 +39,9 @@ def build_core_jsonrpc_openapi_description() -> str:
         "ListTaskPushNotificationConfigs, DeleteTaskPushNotificationConfig, "
         "SubscribeToTask, GetExtendedAgentCard) on POST "
         f"{extension_contracts.CORE_JSONRPC_PATH}.\n\n"
+        "When clients explicitly negotiate A2A 0.3 on the same endpoint, the SDK also "
+        "accepts legacy method aliases such as message/send, message/stream, tasks/get, "
+        "tasks/cancel, tasks/resubscribe, and agent/getAuthenticatedExtendedCard.\n\n"
         "Provider-private Codex methods share the same public JSON-RPC endpoint and "
         "are distinguished by method name plus the published compatibility contracts."
     )
@@ -71,6 +74,8 @@ def build_extension_jsonrpc_openapi_description(*, runtime_profile: RuntimeProfi
     return (
         "Provider-private Codex JSON-RPC methods also use POST "
         f"{extension_contracts.CORE_JSONRPC_PATH}. "
+        "These provider-private methods remain on the 1.0 JSON-RPC contract even when "
+        "the core A2A surface is serving explicit 0.3 compatibility traffic. "
         "Supports Codex session extensions, Codex thread lifecycle extensions, "
         "interrupt recovery extensions, active-turn control extensions, review "
         "control extensions, Codex discovery extensions, interactive exec "
@@ -127,6 +132,45 @@ def build_core_jsonrpc_openapi_examples() -> dict[str, Any]:
                 "jsonrpc": "2.0",
                 "id": 103,
                 "method": "GetExtendedAgentCard",
+                "params": {},
+            },
+        },
+        "message_send_v03": {
+            "summary": "Send message via JSON-RPC 0.3 compatibility method",
+            "value": {
+                "jsonrpc": "2.0",
+                "id": 104,
+                "method": "message/send",
+                "params": {
+                    "message": {
+                        "messageId": "msg-legacy-1",
+                        "role": "user",
+                        "parts": [{"kind": "text", "text": "Explain what this repository does."}],
+                    }
+                },
+            },
+        },
+        "message_stream_v03": {
+            "summary": "Stream message via JSON-RPC 0.3 compatibility method",
+            "value": {
+                "jsonrpc": "2.0",
+                "id": 105,
+                "method": "message/stream",
+                "params": {
+                    "message": {
+                        "messageId": "msg-legacy-stream-1",
+                        "role": "user",
+                        "parts": [{"kind": "text", "text": "Stream the answer and summarize."}],
+                    }
+                },
+            },
+        },
+        "authenticated_extended_card_v03": {
+            "summary": "Fetch the authenticated extended Agent Card via 0.3 compatibility",
+            "value": {
+                "jsonrpc": "2.0",
+                "id": 106,
+                "method": "agent/getAuthenticatedExtendedCard",
                 "params": {},
             },
         },
@@ -450,6 +494,16 @@ def build_rest_message_openapi_examples() -> dict[str, Any]:
                     "parts": [{"text": "Continue previous work and summarize next steps."}],
                 },
                 "metadata": {"shared": {"session": {"id": "s-1"}}},
+            },
+        },
+        "basic_message_v03": {
+            "summary": "Send a basic user message (HTTP+JSON 0.3 compatibility)",
+            "value": {
+                "request": {
+                    "messageId": "msg-rest-legacy-1",
+                    "role": "user",
+                    "content": [{"text": "Explain what this repository does."}],
+                }
             },
         },
     }

--- a/tests/client/test_cli.py
+++ b/tests/client/test_cli.py
@@ -17,7 +17,7 @@ def test_root_help_includes_branding_and_compact_commands_section() -> None:
 
     assert f"repo: {CLI_REPOSITORY_URL}" in help_text
     assert "uv tool install --upgrade codex-a2a" in help_text
-    assert "A2A Protocol 1.0 only." in help_text
+    assert "A2A Protocol 1.0 by default, with core 0.3 compatibility." in help_text
     assert "codex-a2a <command> [arguments] [options]" in help_text
     assert "commands:\n    serve        Run the A2A service." in help_text
     assert "commands:\n  command" not in help_text

--- a/tests/config/test_settings.py
+++ b/tests/config/test_settings.py
@@ -78,6 +78,17 @@ def test_settings_valid():
         assert settings.a2a_log_level == "WARNING"
 
 
+def test_settings_accept_1_0_protocol_line() -> None:
+    env = {
+        **_registry_env(),
+        "A2A_PROTOCOL_VERSION": "1.0.0",
+    }
+    with mock.patch.dict(os.environ, env, clear=True):
+        settings = Settings.from_env()
+
+    assert settings.a2a_protocol_version == "1.0"
+
+
 @pytest.mark.parametrize("protocol_version", ["0.3.0", "1.1.0"])
 def test_settings_reject_non_1_0_protocol_line(protocol_version: str) -> None:
     env = {

--- a/tests/contracts/test_extension_contract_consistency.py
+++ b/tests/contracts/test_extension_contract_consistency.py
@@ -546,6 +546,9 @@ def test_openapi_jsonrpc_examples_match_declared_extension_contracts() -> None:
             "SendMessage",
             "SendStreamingMessage",
             "GetExtendedAgentCard",
+            "message/send",
+            "message/stream",
+            "agent/getAuthenticatedExtendedCard",
         }:
             continue
 

--- a/tests/server/test_agent_card.py
+++ b/tests/server/test_agent_card.py
@@ -123,6 +123,14 @@ def test_agent_card_supported_interfaces_share_same_public_url() -> None:
     assert [interface.url for interface in card.supported_interfaces] == [
         "http://127.0.0.1:8000",
         "http://127.0.0.1:8000",
+        "http://127.0.0.1:8000",
+        "http://127.0.0.1:8000",
+    ]
+    assert [interface.protocol_version for interface in card.supported_interfaces] == [
+        "1.0",
+        "1.0",
+        "0.3",
+        "0.3",
     ]
 
 
@@ -673,8 +681,8 @@ def test_authenticated_extended_agent_card_injects_profile_into_extensions() -> 
     wire_contract_params = codex_contracts["wire_contract"]
     assert wire_contract_params["protocol_version"] == "1.0"
     assert wire_contract_params["default_protocol_version"] == "1.0"
-    assert wire_contract_params["supported_protocol_versions"] == ["1.0"]
-    assert set(wire_contract_params["protocol_compatibility"]["versions"]) == {"1.0"}
+    assert wire_contract_params["supported_protocol_versions"] == ["1.0", "0.3"]
+    assert set(wire_contract_params["protocol_compatibility"]["versions"]) == {"1.0", "0.3"}
     assert (
         wire_contract_params["protocol_compatibility"]["versions"]["1.0"]["status"] == "supported"
     )
@@ -684,6 +692,12 @@ def test_authenticated_extended_agent_card_injects_profile_into_extensions() -> 
             0
         ]
     )
+    assert wire_contract_params["protocol_compatibility"]["versions"]["0.3"]["known_gaps"] == [
+        (
+            "Provider-private codex.* and a2a.interrupt.* JSON-RPC methods remain "
+            "available on 1.0 only."
+        )
+    ]
     assert "GetExtendedAgentCard" in wire_contract_params["all_jsonrpc_methods"]
     assert "CreateTaskPushNotificationConfig" in wire_contract_params["all_jsonrpc_methods"]
     assert (
@@ -715,13 +729,23 @@ def test_authenticated_extended_agent_card_injects_profile_into_extensions() -> 
             "protocol_version": "1.0",
             "url_path": CORE_JSONRPC_PATH,
         },
+        {
+            "protocol_binding": "HTTP+JSON",
+            "protocol_version": "0.3",
+            "url_path_prefix": REST_API_PATH_PREFIX,
+        },
+        {
+            "protocol_binding": "JSON-RPC",
+            "protocol_version": "0.3",
+            "url_path": CORE_JSONRPC_PATH,
+        },
     ]
 
     compatibility_params = codex_contracts["compatibility_profile"]
     assert compatibility_params["profile_id"] == "codex-a2a-single-tenant-coding-v1"
     assert compatibility_params["protocol_version"] == "1.0"
     assert compatibility_params["default_protocol_version"] == "1.0"
-    assert compatibility_params["supported_protocol_versions"] == ["1.0"]
+    assert compatibility_params["supported_protocol_versions"] == ["1.0", "0.3"]
     assert (
         compatibility_params["protocol_compatibility"]
         == wire_contract_params["protocol_compatibility"]
@@ -729,7 +753,10 @@ def test_authenticated_extended_agent_card_injects_profile_into_extensions() -> 
     assert compatibility_params["deployment"] == profile["deployment"]
     assert compatibility_params["runtime_features"] == profile["runtime_features"]
     assert compatibility_params["core"]["jsonrpc_endpoint"] == CORE_JSONRPC_PATH
-    assert compatibility_params["extension_transport"]["jsonrpc_endpoint"] == EXTENSION_JSONRPC_PATH
+    assert compatibility_params["extension_transport"] == {
+        "jsonrpc_endpoint": EXTENSION_JSONRPC_PATH,
+        "protocol_version": "1.0",
+    }
     assert "GetExtendedAgentCard" in compatibility_params["core"]["jsonrpc_methods"]
     assert compatibility_params["extension_taxonomy"]["shared_agent_card_extensions"] == [
         SESSION_BINDING_EXTENSION_URI,
@@ -757,6 +784,10 @@ def test_authenticated_extended_agent_card_injects_profile_into_extensions() -> 
         for note in compatibility_params["consumer_guidance"]
     )
     assert any("urn:a2a:*" in note for note in compatibility_params["consumer_guidance"])
+    assert any(
+        "explicit A2A 0.3 support as a core-surface compatibility layer only" in note
+        for note in compatibility_params["consumer_guidance"]
+    )
     assert any(
         "execution_environment" in note for note in compatibility_params["consumer_guidance"]
     )

--- a/tests/server/test_cli.py
+++ b/tests/server/test_cli.py
@@ -21,7 +21,7 @@ def test_cli_help_does_not_require_runtime_settings(capsys: pytest.CaptureFixtur
     assert excinfo.value.code == 0
     output = capsys.readouterr().out
     assert "uv tool install --upgrade codex-a2a" in output
-    assert "A2A Protocol 1.0 only." in output
+    assert "A2A Protocol 1.0 by default, with core 0.3 compatibility." in output
     assert "codex-a2a <command> [arguments] [options]" in output
     assert "A2A_STATIC_AUTH_CREDENTIALS" in output
     serve_mock.assert_not_called()

--- a/tests/server/test_transport_contract.py
+++ b/tests/server/test_transport_contract.py
@@ -1,5 +1,7 @@
 import asyncio
 import logging
+import subprocess
+import sys
 import uuid
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -68,6 +70,12 @@ def test_agent_card_declares_dual_stack_with_http_json_preferred() -> None:
     assert card.supported_interfaces[0].protocol_binding == TransportProtocol.HTTP_JSON
     assert card.supported_interfaces[0].url == "http://127.0.0.1:8000"
     assert card.supported_interfaces[1].url == "http://127.0.0.1:8000"
+    assert [iface.protocol_version for iface in card.supported_interfaces] == [
+        "1.0",
+        "1.0",
+        "0.3",
+        "0.3",
+    ]
     assert TransportProtocol.HTTP_JSON in transports
     assert TransportProtocol.JSONRPC in transports
 
@@ -82,8 +90,10 @@ def test_rest_subscription_route_matches_current_sdk_contract() -> None:
     assert f"{REST_API_PATH_PREFIX}/tasks/{{id}}:subscribe" in route_paths
     assert f"{REST_API_PATH_PREFIX}/tasks/{{id}}:resubscribe" not in route_paths
     assert f"{REST_API_PATH_PREFIX}/extendedAgentCard" in route_paths
+    assert f"{REST_API_PATH_PREFIX}/card" in route_paths
+    assert f"/{{tenant}}{REST_API_PATH_PREFIX}/message:send" in route_paths
+    assert f"/{{tenant}}{REST_API_PATH_PREFIX}/card" in route_paths
     assert "/agent/authenticatedExtendedCard" not in route_paths
-    assert f"{REST_API_PATH_PREFIX}/card" not in route_paths
 
 
 def test_health_route_can_be_disabled() -> None:
@@ -375,19 +385,27 @@ def test_openapi_rest_message_routes_include_schema_examples_and_extension_contr
     openapi = app.openapi()
     paths = openapi["paths"]
 
-    expected: dict[str, str] = {
-        "/v1/message:send": "#/components/schemas/SendMessageRequest",
-        "/v1/message:stream": "#/components/schemas/SendStreamingMessageRequest",
+    expected: dict[str, tuple[str, str]] = {
+        "/v1/message:send": (
+            "#/components/schemas/SendMessageRequest",
+            "#/components/schemas/A2A03SendMessageRequest",
+        ),
+        "/v1/message:stream": (
+            "#/components/schemas/SendStreamingMessageRequest",
+            "#/components/schemas/A2A03SendStreamingMessageRequest",
+        ),
     }
-    for path, expected_schema_ref in expected.items():
+    for path, expected_schema_refs in expected.items():
         post = paths[path]["post"]
         assert post["summary"] in {"Send Message (HTTP+JSON)", "Stream Message (HTTP+JSON)"}
         content = post.get("requestBody", {}).get("content", {}).get("application/json", {})
-        assert content.get("schema", {}).get("$ref") == expected_schema_ref
+        schema_refs = {item.get("$ref") for item in content.get("schema", {}).get("oneOf", [])}
+        assert schema_refs == set(expected_schema_refs)
         examples = content.get("examples")
         assert isinstance(examples, dict)
         assert "basic_message" in examples
         assert "continue_session" in examples
+        assert "basic_message_v03" in examples
         contracts = post.get("x-a2a-extension-contracts")
         assert isinstance(contracts, dict)
         assert "session_binding" in contracts
@@ -418,6 +436,9 @@ def test_openapi_rest_message_routes_include_schema_examples_and_extension_contr
     assert "turn_control" in extension_contracts
     assert "review_control" in extension_contracts
 
+    card_get = paths["/v1/card"]["get"]
+    assert "0.3 compatibility REST discovery route" in card_get["description"]
+
 
 def test_openapi_jsonrpc_examples_include_core_and_extension_methods() -> None:
     app = create_app(make_settings(a2a_bearer_token="test-token"))
@@ -436,6 +457,9 @@ def test_openapi_jsonrpc_examples_include_core_and_extension_methods() -> None:
     assert "SendMessage" in core_methods
     assert "SendStreamingMessage" in core_methods
     assert "GetExtendedAgentCard" in core_methods
+    assert "message/send" in core_methods
+    assert "message/stream" in core_methods
+    assert "agent/getAuthenticatedExtendedCard" in core_methods
 
     extension_post = openapi["paths"][EXTENSION_JSONRPC_PATH]["post"]
     extension_example_values = (
@@ -802,39 +826,51 @@ async def test_dual_stack_send_accepts_transport_native_payloads(monkeypatch) ->
     transport = httpx.ASGITransport(app=app)
     headers = {"Authorization": "Bearer test-token"}
 
-    rest_payload = {
-        "message": {
-            "messageId": "m-rest",
-            "role": "ROLE_USER",
-            "parts": [{"text": "hello from rest"}],
-        }
-    }
-    rpc_payload = {
-        "jsonrpc": "2.0",
-        "id": 1,
-        "method": "SendMessage",
-        "params": {
-            "message": {
-                "messageId": "m-rpc",
-                "role": "ROLE_USER",
-                "parts": [{"text": "hello from jsonrpc"}],
-            }
-        },
-    }
-
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
         rest_resp = await client.post(
             f"{REST_API_PATH_PREFIX}/message:send",
             headers=headers,
-            json=rest_payload,
+            json=_rest_message_payload(),
         )
         assert rest_resp.status_code == 200
         assert rest_resp.headers["A2A-Version"] == "1.0"
 
-        rpc_resp = await client.post(CORE_JSONRPC_PATH, headers=headers, json=rpc_payload)
+        rpc_resp = await client.post(
+            CORE_JSONRPC_PATH,
+            headers=headers,
+            json=_jsonrpc_message_send_payload("hello from jsonrpc"),
+        )
         assert rpc_resp.status_code == 200
         assert rpc_resp.headers["A2A-Version"] == "1.0"
         assert rpc_resp.json().get("error") is None
+
+        rest_v03_resp = await client.post(
+            f"{REST_API_PATH_PREFIX}/message:send",
+            headers={**headers, "A2A-Version": "0.3"},
+            json=_rest_message_payload_v03(),
+        )
+        assert rest_v03_resp.status_code == 200
+        assert rest_v03_resp.headers["A2A-Version"] == "0.3"
+
+        rpc_v03_resp = await client.post(
+            CORE_JSONRPC_PATH,
+            headers={**headers, "A2A-Version": "0.3"},
+            json=_jsonrpc_message_send_payload_v03("hello from legacy jsonrpc"),
+        )
+        assert rpc_v03_resp.status_code == 200
+        assert rpc_v03_resp.headers["A2A-Version"] == "0.3"
+        assert rpc_v03_resp.json().get("error") is None
+
+
+def test_server_application_imports_cleanly_in_fresh_interpreter() -> None:
+    result = subprocess.run(
+        [sys.executable, "-c", "import codex_a2a.server.application"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
 
 
 @pytest.mark.asyncio
@@ -871,6 +907,51 @@ async def test_jsonrpc_legacy_core_method_alias_is_rejected_under_v1(monkeypatch
 
 
 @pytest.mark.asyncio
+async def test_tenant_rest_0_3_route_uses_sdk_compat_handler(monkeypatch) -> None:
+    import codex_a2a.server.application as app_module
+
+    monkeypatch.setattr(app_module, "CodexClient", DummyChatCodexClient)
+    app = app_module.create_app(make_settings(a2a_bearer_token="test-token"))
+    transport = httpx.ASGITransport(app=app)
+    headers = {"Authorization": "Bearer test-token", "A2A-Version": "0.3"}
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            f"/acme{REST_API_PATH_PREFIX}/message:send",
+            headers=headers,
+            json=_rest_message_payload_v03(),
+        )
+
+    assert response.status_code == 200
+    assert response.headers["A2A-Version"] == "0.3"
+
+
+@pytest.mark.asyncio
+async def test_jsonrpc_provider_private_method_is_rejected_under_v0_3(monkeypatch) -> None:
+    import codex_a2a.server.application as app_module
+
+    monkeypatch.setattr(app_module, "CodexClient", DummyChatCodexClient)
+    app = app_module.create_app(make_settings(a2a_bearer_token="test-token"))
+    transport = httpx.ASGITransport(app=app)
+    headers = {"Authorization": "Bearer test-token", "A2A-Version": "0.3"}
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            CORE_JSONRPC_PATH,
+            headers=headers,
+            json={"jsonrpc": "2.0", "id": 44, "method": "codex.sessions.list", "params": {}},
+        )
+
+    assert response.status_code == 200
+    assert response.headers["A2A-Version"] == "0.3"
+    payload = response.json()
+    assert payload["id"] == 44
+    assert payload["error"]["code"] == -32601
+    assert payload["error"]["message"] == "Method not found"
+    assert payload["error"].get("data") is None
+
+
+@pytest.mark.asyncio
 async def test_jsonrpc_unsupported_protocol_version_preserves_request_id(monkeypatch) -> None:
     import codex_a2a.server.application as app_module
 
@@ -895,7 +976,7 @@ async def test_jsonrpc_unsupported_protocol_version_preserves_request_id(monkeyp
     error_info = details[0]
     assert error_info["reason"] == "VERSION_NOT_SUPPORTED"
     assert error_info["metadata"]["requested_version"] == "2.0"
-    assert error_info["metadata"]["supported_protocol_versions"] == '["1.0"]'
+    assert error_info["metadata"]["supported_protocol_versions"] == '["1.0","0.3"]'
 
 
 @pytest.mark.asyncio
@@ -1146,6 +1227,16 @@ def _rest_message_payload() -> dict:
     }
 
 
+def _rest_message_payload_v03() -> dict:
+    return {
+        "request": {
+            "messageId": "m-rest-v03",
+            "role": "user",
+            "content": [{"text": "hello from legacy rest"}],
+        }
+    }
+
+
 def _jsonrpc_message_send_payload(text: str) -> dict:
     return {
         "jsonrpc": "2.0",
@@ -1156,6 +1247,21 @@ def _jsonrpc_message_send_payload(text: str) -> dict:
                 "messageId": "m-rpc",
                 "role": "ROLE_USER",
                 "parts": [{"text": text}],
+            }
+        },
+    }
+
+
+def _jsonrpc_message_send_payload_v03(text: str) -> dict:
+    return {
+        "jsonrpc": "2.0",
+        "id": 100,
+        "method": "message/send",
+        "params": {
+            "message": {
+                "messageId": "m-rpc-v03",
+                "role": "user",
+                "parts": [{"kind": "text", "text": text}],
             }
         },
     }

--- a/tests/test_protocol_versions.py
+++ b/tests/test_protocol_versions.py
@@ -22,13 +22,26 @@ def test_protocol_compatibility_summary_declares_supported_lines_only() -> None:
     summary = build_protocol_compatibility_summary()
 
     assert summary["default_protocol_version"] == "1.0"
-    assert summary["supported_protocol_versions"] == ["1.0"]
-    assert set(summary["versions"]) == {"1.0"}
+    assert summary["supported_protocol_versions"] == ["1.0", "0.3"]
+    assert set(summary["versions"]) == {"1.0", "0.3"}
     assert summary["versions"]["1.0"]["enabled"] is True
     assert summary["versions"]["1.0"]["default"] is True
     assert summary["versions"]["1.0"]["status"] == "supported"
     assert "A2A-Version" in summary["versions"]["1.0"]["supported_features"][0]
     assert summary["versions"]["1.0"]["known_gaps"] == []
+    assert summary["versions"]["0.3"]["enabled"] is True
+    assert summary["versions"]["0.3"]["default"] is False
+    assert "SDK-managed A2A 0.3" in summary["versions"]["0.3"]["supported_features"][1]
+    assert "codex.*" in summary["versions"]["0.3"]["known_gaps"][0]
+
+
+def test_protocol_compatibility_summary_can_reorder_default_line() -> None:
+    summary = build_protocol_compatibility_summary(default_protocol_version="0.3")
+
+    assert summary["default_protocol_version"] == "0.3"
+    assert summary["supported_protocol_versions"] == ["0.3", "1.0"]
+    assert summary["versions"]["0.3"]["default"] is True
+    assert summary["versions"]["1.0"]["default"] is False
 
 
 def test_negotiate_protocol_version_defaults_to_configured_baseline() -> None:
@@ -51,6 +64,16 @@ def test_negotiate_protocol_version_prefers_header_over_query() -> None:
     assert negotiated.explicit is True
 
 
+def test_negotiate_protocol_version_accepts_0_3_when_explicit() -> None:
+    negotiated = negotiate_protocol_version(
+        header_value="0.3.0",
+        query_value=None,
+    )
+
+    assert negotiated.protocol_version == "0.3"
+    assert negotiated.explicit is True
+
+
 def test_negotiate_protocol_version_rejects_unsupported_line() -> None:
     with pytest.raises(UnsupportedProtocolVersionError) as exc_info:
         negotiate_protocol_version(
@@ -59,4 +82,4 @@ def test_negotiate_protocol_version_rejects_unsupported_line() -> None:
         )
 
     assert exc_info.value.requested_version == "2.0"
-    assert exc_info.value.supported_protocol_versions == ("1.0",)
+    assert exc_info.value.supported_protocol_versions == ("1.0", "0.3")


### PR DESCRIPTION
## 关联

Relates to #299

## 说明

本 PR 记录一版基于 `a2a-sdk 1.0.2` 的 core A2A `1.0 + 0.3 compat` 试验实现，范围覆盖：

- core JSON-RPC / REST 双栈接入
- Agent Card / OpenAPI / compatibility 文档同步声明
- provider-private `codex.*` 继续停留在 `1.0` 契约

当前先保留为评估用 Draft PR，方便对实现质量、运行时纯度、可维护性与可证明性做集中审查。
