### PR TITLE
docs: document stable native Codex CLI usage for Linux deployments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,8 @@ pip-delete-this-directory.txt
 logs/
 run/
 .codex-a2a/
+core
+core.*
 *.db
 *.db-shm
 *.db-wal

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Before starting the runtime:
 - Configure Codex with a working provider/model setup and any required credentials.
 - `codex-a2a` does not provision Codex providers, login state, or API keys for you.
 - Startup fails fast if the local `codex` runtime is missing or cannot initialize.
+- For long-running Linux service-manager deployments, prefer setting `CODEX_CLI_BIN` to the bundled native Codex binary instead of the npm `codex` wrapper. See [Usage Guide](docs/guide.md) for the stable deployment notes.
 
 Self-start the released CLI against a workspace root:
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Before starting the runtime:
 - Configure Codex with a working provider/model setup and any required credentials.
 - `codex-a2a` does not provision Codex providers, login state, or API keys for you.
 - Startup fails fast if the local `codex` runtime is missing or cannot initialize.
-- For long-running Linux service-manager deployments, prefer setting `CODEX_CLI_BIN` to the bundled native Codex binary instead of the npm `codex` wrapper. See [Usage Guide](docs/guide.md) for the stable deployment notes.
+- For long-running Linux service-manager deployments, set `CODEX_CLI_BIN` explicitly to the bundled native Codex binary. See [Usage Guide](docs/guide.md) for the recommended setup.
 
 Self-start the released CLI against a workspace root:
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -221,6 +221,7 @@ These variables are forwarded to the local `codex app-server` subprocess.
 
 - `CODEX_WORKSPACE_ROOT`: default Codex workspace root (optional)
 - `CODEX_CLI_BIN`: Codex CLI binary path, default `codex`
+  - For long-running Linux deployments managed by PM2, systemd, or similar supervisors, prefer the bundled native Codex binary over the npm `codex` Node wrapper when that native binary is available.
 - `CODEX_MODEL`: default Codex model, default `gpt-5.1-codex`
 - `CODEX_APPROVAL_POLICY`: default approval policy (`never`, `on-request`, etc.)
 - `CODEX_SANDBOX_MODE`: default sandbox mode (`danger-full-access`, `read-only`, etc.)
@@ -399,6 +400,55 @@ CODEX_WORKSPACE_ROOT=/abs/path/to/workspace uv run codex-a2a serve
 ```
 
 This path is for contributors. End users should prefer the released CLI path described first in [README.md](../README.md) and above in this guide.
+
+## Core Dump Hygiene
+
+If a local crash leaves a `core` or `core.<pid>` file in the workspace, treat it as a local debugging artifact rather than a repository file.
+
+- The repository ignores `core` and `core.*` by default because a core dump can contain process memory snapshots.
+- Before deleting the file, capture a minimal diagnostic snapshot so future triage does not depend on the raw dump alone.
+
+Recommended minimum steps:
+
+```bash
+file core.*
+node -v
+codex --version
+```
+
+If `file` reports a command such as `node .../codex`, the crash came from the local Codex CLI stack rather than from the `codex-a2a-serve` Python service itself.
+
+When native debugging tools are available, collect one stack trace before removing the dump:
+
+```bash
+gdb -batch -ex 'thread apply all bt' /usr/local/bin/node core.<pid>
+```
+
+If `gdb` is not installed, record that limitation and keep the higher-level metadata:
+
+- the `file core.*` output
+- `node -v`
+- `codex --version`
+- the command or workflow that produced the crash
+
+For stable long-running Linux deployments, prefer resolving the bundled native Codex binary and setting `CODEX_CLI_BIN` explicitly instead of relying on the npm `codex` wrapper:
+
+```bash
+CODEX_WRAPPER_BIN="$(readlink -f "$(command -v codex)")"
+CODEX_PACKAGE_ROOT="$(dirname "$(dirname "$CODEX_WRAPPER_BIN")")"
+CODEX_NATIVE_BIN="$CODEX_PACKAGE_ROOT/node_modules/@openai/codex-linux-x64/vendor/x86_64-unknown-linux-musl/codex/codex"
+test -x "$CODEX_NATIVE_BIN" && printf '%s\n' "$CODEX_NATIVE_BIN"
+```
+
+On the current npm global install layout for Linux x64, the printed path can be used as:
+
+```bash
+export CODEX_CLI_BIN="$CODEX_NATIVE_BIN"
+```
+
+This is a deployment-stability preference for wrapper-related shutdown crashes on Linux. It is not required when the default `codex` wrapper is already stable in your environment.
+
+After the metadata is captured, remove the dump from the workspace unless you explicitly need to keep it for native debugging outside the repository.
 
 ## Service Behavior
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -221,7 +221,7 @@ These variables are forwarded to the local `codex app-server` subprocess.
 
 - `CODEX_WORKSPACE_ROOT`: default Codex workspace root (optional)
 - `CODEX_CLI_BIN`: Codex CLI binary path, default `codex`
-  - For long-running Linux deployments managed by PM2, systemd, or similar supervisors, prefer the bundled native Codex binary over the npm `codex` Node wrapper when that native binary is available.
+  - For long-running Linux deployments managed by PM2, systemd, or similar supervisors, set this explicitly to the bundled native Codex binary.
 - `CODEX_MODEL`: default Codex model, default `gpt-5.1-codex`
 - `CODEX_APPROVAL_POLICY`: default approval policy (`never`, `on-request`, etc.)
 - `CODEX_SANDBOX_MODE`: default sandbox mode (`danger-full-access`, `read-only`, etc.)
@@ -401,54 +401,38 @@ CODEX_WORKSPACE_ROOT=/abs/path/to/workspace uv run codex-a2a serve
 
 This path is for contributors. End users should prefer the released CLI path described first in [README.md](../README.md) and above in this guide.
 
-## Core Dump Hygiene
+## Stable Linux Codex CLI Setup
 
-If a local crash leaves a `core` or `core.<pid>` file in the workspace, treat it as a local debugging artifact rather than a repository file.
+For long-running Linux deployments, configure `codex-a2a-serve` to launch the bundled native Codex binary directly through `CODEX_CLI_BIN`.
 
-- The repository ignores `core` and `core.*` by default because a core dump can contain process memory snapshots.
-- Before deleting the file, capture a minimal diagnostic snapshot so future triage does not depend on the raw dump alone.
-
-Recommended minimum steps:
-
-```bash
-file core.*
-node -v
-codex --version
-```
-
-If `file` reports a command such as `node .../codex`, the crash came from the local Codex CLI stack rather than from the `codex-a2a-serve` Python service itself.
-
-When native debugging tools are available, collect one stack trace before removing the dump:
-
-```bash
-gdb -batch -ex 'thread apply all bt' /usr/local/bin/node core.<pid>
-```
-
-If `gdb` is not installed, record that limitation and keep the higher-level metadata:
-
-- the `file core.*` output
-- `node -v`
-- `codex --version`
-- the command or workflow that produced the crash
-
-For stable long-running Linux deployments, prefer resolving the bundled native Codex binary and setting `CODEX_CLI_BIN` explicitly instead of relying on the npm `codex` wrapper:
+Resolve the native binary from the installed `codex` command:
 
 ```bash
 CODEX_WRAPPER_BIN="$(readlink -f "$(command -v codex)")"
 CODEX_PACKAGE_ROOT="$(dirname "$(dirname "$CODEX_WRAPPER_BIN")")"
 CODEX_NATIVE_BIN="$CODEX_PACKAGE_ROOT/node_modules/@openai/codex-linux-x64/vendor/x86_64-unknown-linux-musl/codex/codex"
-test -x "$CODEX_NATIVE_BIN" && printf '%s\n' "$CODEX_NATIVE_BIN"
+test -x "$CODEX_NATIVE_BIN"
 ```
 
-On the current npm global install layout for Linux x64, the printed path can be used as:
+Export the resolved path before starting the service:
 
 ```bash
 export CODEX_CLI_BIN="$CODEX_NATIVE_BIN"
 ```
 
-This is a deployment-stability preference for wrapper-related shutdown crashes on Linux. It is not required when the default `codex` wrapper is already stable in your environment.
+PM2 example:
 
-After the metadata is captured, remove the dump from the workspace unless you explicitly need to keep it for native debugging outside the repository.
+```bash
+CODEX_CLI_BIN="$CODEX_NATIVE_BIN" uv run codex-a2a serve
+```
+
+Systemd example:
+
+```ini
+Environment=CODEX_CLI_BIN=/absolute/path/to/codex
+```
+
+On the current npm global install layout for Linux x64, the command above resolves the bundled native binary shipped with `@openai/codex`.
 
 ## Service Behavior
 


### PR DESCRIPTION
## 摘要

围绕 `#292` 的收口，本 PR 只提供仓内当前可用的稳定方案文档，不展开现象对比或排查叙述。

## 变更内容

- 在 `.gitignore` 中忽略 `core` 和 `core.*`
- 在 `README.md` 中补充长期运行 Linux 部署应显式设置 native `CODEX_CLI_BIN`
- 在 `docs/guide.md` 中新增稳定 Linux 部署的配置步骤
- 在 `docs/guide.md` 中补充 native Codex binary 的解析命令，以及 PM2 / systemd 的最小配置示例

## 审查结论

- 这批改动和 `#292` 的收口目标一致，重点是给出当下可执行的稳定用法
- 文档没有引入额外封装或运行时代码改造，风险维持在最小范围
- 当前方案直接对应长期运行 Linux supervisor 场景，表达清晰，落地成本低
- 当前没有发现与需求目标不符的偏差、遗漏或冗余

## 验证

- 已验证文档中的 native binary 解析命令可在本机解析到可执行路径
- 已运行：`uv run pytest --no-cov tests/package/test_release_distribution_contract.py tests/contracts/test_extension_contract_consistency.py -q`
- 未运行：`bash ./scripts/validate_baseline.sh`
  - 原因：本次仅涉及文档与 `.gitignore` 调整

## 关联

- Relates to #292
- 上游跟踪 issue：https://github.com/openai/codex/issues/21339
