### PR TITLE
chore: narrow single-tenant REST surface

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -83,6 +83,8 @@ The current service profile is intentionally:
 
 One deployed instance should be treated as a single-tenant trust boundary, not as a secure multi-tenant runtime boundary.
 
+The supported HTTP+JSON contract is rooted at `/v1/...` only. Tenant-prefixed REST aliases such as `/{tenant}/v1/...` are intentionally not part of the supported surface for this single-tenant deployment profile.
+
 The compatibility surface distinguishes between:
 
 - a stable deployment profile

--- a/src/codex_a2a/server/application.py
+++ b/src/codex_a2a/server/application.py
@@ -8,6 +8,7 @@ import uvicorn
 from a2a.server.routes.agent_card_routes import create_agent_card_routes
 from a2a.server.routes.rest_routes import create_rest_routes
 from fastapi import FastAPI
+from starlette.routing import BaseRoute, Mount
 
 from codex_a2a.client.manager import A2AClientManager
 from codex_a2a.config import Settings
@@ -44,6 +45,17 @@ from .http_middlewares import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _is_sdk_tenant_mount(route: BaseRoute) -> bool:
+    return isinstance(route, Mount) and route.path == "/{tenant}"
+
+
+def _create_single_tenant_rest_routes(**kwargs: Any) -> list[BaseRoute]:
+    # The SDK exposes a tenant-prefixed REST alias by default. This service's
+    # supported HTTP+JSON contract is the documented single-tenant `/v1/...`
+    # surface, so the application assembly narrows the route set explicitly.
+    return [route for route in create_rest_routes(**kwargs) if not _is_sdk_tenant_mount(route)]
 
 
 def create_app(settings: Settings) -> FastAPI:
@@ -194,7 +206,7 @@ def create_app(settings: Settings) -> FastAPI:
         )
     )
     app.router.routes.extend(
-        create_rest_routes(
+        _create_single_tenant_rest_routes(
             request_handler=handler,
             context_builder=context_builder,
             path_prefix=extension_contracts.REST_API_PATH_PREFIX,

--- a/tests/server/test_transport_contract.py
+++ b/tests/server/test_transport_contract.py
@@ -84,6 +84,7 @@ def test_rest_subscription_route_matches_current_sdk_contract() -> None:
     assert f"{REST_API_PATH_PREFIX}/tasks/{{id}}:subscribe" in route_paths
     assert f"{REST_API_PATH_PREFIX}/tasks/{{id}}:resubscribe" not in route_paths
     assert f"{REST_API_PATH_PREFIX}/extendedAgentCard" in route_paths
+    assert "/{tenant}" not in route_paths
     assert "/agent/authenticatedExtendedCard" not in route_paths
     assert f"{REST_API_PATH_PREFIX}/card" not in route_paths
 
@@ -851,7 +852,7 @@ def test_server_application_imports_cleanly_in_fresh_interpreter() -> None:
 
 
 @pytest.mark.asyncio
-async def test_tenant_rest_message_route_negotiates_protocol_header(monkeypatch) -> None:
+async def test_tenant_prefixed_rest_message_route_is_not_supported(monkeypatch) -> None:
     import codex_a2a.server.application as app_module
 
     monkeypatch.setattr(app_module, "CodexClient", DummyChatCodexClient)
@@ -866,44 +867,11 @@ async def test_tenant_rest_message_route_negotiates_protocol_header(monkeypatch)
             json=_rest_message_payload(),
         )
 
-    assert response.status_code == 200
-    assert response.headers["A2A-Version"] == "1.0"
+    assert response.status_code == 404
 
 
 @pytest.mark.asyncio
-async def test_tenant_rest_message_route_uses_payload_shape_guard(monkeypatch) -> None:
-    import codex_a2a.server.application as app_module
-
-    monkeypatch.setattr(app_module, "CodexClient", DummyChatCodexClient)
-    app = app_module.create_app(make_settings(a2a_bearer_token="test-token"))
-    transport = httpx.ASGITransport(app=app)
-    headers = {"Authorization": "Bearer test-token"}
-    jsonrpc_envelope = {
-        "jsonrpc": "2.0",
-        "id": 7,
-        "method": "SendMessage",
-        "params": {
-            "message": {
-                "messageId": "m-tenant-cross-envelope",
-                "role": "ROLE_USER",
-                "parts": [{"text": "hello from tenant envelope"}],
-            }
-        },
-    }
-
-    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
-        response = await client.post(
-            f"/acme{REST_API_PATH_PREFIX}/message:send",
-            headers=headers,
-            json=jsonrpc_envelope,
-        )
-
-    assert response.status_code == 400
-    assert "Invalid HTTP+JSON payload" in response.text
-
-
-@pytest.mark.asyncio
-async def test_tenant_extended_card_uses_authenticated_cache_contract(monkeypatch) -> None:
+async def test_tenant_prefixed_extended_card_route_is_not_supported(monkeypatch) -> None:
     import codex_a2a.server.application as app_module
 
     monkeypatch.setattr(app_module, "CodexClient", DummyChatCodexClient)
@@ -917,23 +885,25 @@ async def test_tenant_extended_card_uses_authenticated_cache_contract(monkeypatc
             headers=headers,
         )
 
-        cached = await client.get(
-            f"/acme{REST_API_PATH_PREFIX}/extendedAgentCard",
-            headers={
-                **headers,
-                "If-None-Match": response.headers["etag"],
-            },
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_tenant_subscribe_route_is_not_supported(monkeypatch) -> None:
+    import codex_a2a.server.application as app_module
+
+    monkeypatch.setattr(app_module, "CodexClient", DummyChatCodexClient)
+    app = app_module.create_app(make_settings(a2a_bearer_token="test-token"))
+    transport = httpx.ASGITransport(app=app)
+    headers = {"Authorization": "Bearer test-token"}
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get(
+            f"/acme{REST_API_PATH_PREFIX}/tasks/task-missing:subscribe",
+            headers=headers,
         )
 
-    assert response.status_code == 200
-    assert response.headers["A2A-Version"] == "1.0"
-    assert response.headers["cache-control"] == AUTHENTICATED_EXTENDED_CARD_CACHE_CONTROL
-    assert {value.strip() for value in response.headers["vary"].split(",") if value.strip()} == {
-        "Authorization",
-        "Accept-Encoding",
-    }
-    assert response.headers["etag"]
-    assert cached.status_code == 304
+    assert response.status_code == 404
 
 
 @pytest.mark.asyncio
@@ -1196,24 +1166,6 @@ async def test_subscribe_missing_task_returns_controlled_404(monkeypatch) -> Non
 
 
 @pytest.mark.asyncio
-async def test_tenant_subscribe_missing_task_returns_controlled_404(monkeypatch) -> None:
-    import codex_a2a.server.application as app_module
-
-    monkeypatch.setattr(app_module, "CodexClient", DummyChatCodexClient)
-    app = app_module.create_app(make_settings(a2a_bearer_token="test-token"))
-    transport = httpx.ASGITransport(app=app)
-    headers = {"Authorization": "Bearer test-token"}
-
-    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
-        response = await client.get(
-            f"/acme{REST_API_PATH_PREFIX}/tasks/task-missing:subscribe",
-            headers=headers,
-        )
-
-    assert response.status_code == 404
-    assert response.json() == {"error": "Task not found", "task_id": "task-missing"}
-
-
 @pytest.mark.asyncio
 async def test_subscribe_task_store_failure_returns_controlled_503(monkeypatch) -> None:
     import codex_a2a.server.application as app_module


### PR DESCRIPTION
## 概要
- 收敛单租户 HTTP+JSON surface，在应用装配层过滤 `a2a-sdk` 默认生成的 tenant-prefixed REST mount，避免服务继续额外挂出 `/{tenant}/v1/...` alias
- 更新 transport contract 回归测试，明确 tenant-prefixed REST 路径不受支持并返回 `404`
- 更新兼容性文档，声明本仓受支持的 HTTP+JSON contract 仅覆盖 `/v1/...`

## 相关 Commit
- `d20c1f2` `chore: drop tenant-prefixed REST aliases (#302)`

## 关联 Issue
- Closes #302

## 关系说明
- 本 PR 直接实现并收口 `#302` 要求的 runtime surface / contract 对齐，因此使用 `Closes #302` 准确
- 当前未发现需要在本 PR 中额外补充 `Relates to` 或 `Closes` 的其它 open issues

## 验证
- `uv run pytest tests/server/test_transport_contract.py -q --no-cov`
- `bash ./scripts/validate_baseline.sh`
