### PR TITLE
chore: align extension URI and discovery governance

### DIFF
--- a/docs/a2a-extension-baseline.md
+++ b/docs/a2a-extension-baseline.md
@@ -7,7 +7,7 @@ Phase 1 is intentionally internal-facing. It does not change the external extens
 ## Goals
 
 - Define which runtime surfaces are true A2A extensions versus auxiliary machine-readable contracts.
-- Define the intended responsibilities of the public Agent Card, authenticated extended Agent Card, and OpenAPI metadata.
+- Define the intended responsibilities of the public Agent Card, authenticated extended Agent Card, and anonymous OpenAPI metadata.
 - Centralize extension inventory so that Agent Card, OpenAPI, compatibility guidance, and documentation stop drifting independently.
 - Preserve current externally visible behavior during phase 1 unless a change is required to remove ambiguity.
 
@@ -26,7 +26,7 @@ Phase 1 is intentionally internal-facing. It does not change the external extens
 - These are adapter-managed `codex.*` or shared-repo callback contracts that remain specific to this deployment family.
 - They are still treated as extensions conceptually, but their public disclosure remains conservative.
 - They should be declared through authenticated extended Agent Card `capabilities.extensions`.
-- Their detailed contract payloads remain machine-readable through OpenAPI and human-discoverable through authenticated skill inventory.
+- Their detailed contract payloads should stay machine-readable on the authenticated extended card, with authenticated skill inventory remaining additive discovery guidance.
 
 3. Machine-readable contract metadata
 
@@ -51,15 +51,16 @@ Phase 1 is intentionally internal-facing. It does not change the external extens
 
 ### OpenAPI Metadata
 
-- Full machine-readable contract surface.
-- Remains the detailed source for provider-private request/response method contracts, transport notes, and compatibility metadata.
-- Should be derived from the same registry as Agent Card declarations whenever possible.
+- Anonymous, transport-adjacent discovery surface.
+- Should remain limited to the minimum shared-contract disclosure needed for interoperable clients.
+- Should not be treated as the canonical machine-readable source for provider-private method matrices or deployment-private compatibility metadata.
+- Should still be derived from the same registry as Agent Card declarations whenever possible.
 
 ## Negotiation Rules
 
 - Shared request/response extensions are the only extensions treated as negotiated by default in phase 1.
 - Shared request/response extensions use request-level `A2A-Extensions` activation only when the request depends on that negotiated behavior.
-- Provider-private `codex.*` contracts and shared callback contracts marked `declaration_only` are discovered through the authenticated extended Agent Card and OpenAPI, then used by directly invoking their documented provider-private methods. They do not require a separate `A2A-Extensions` activation header.
+- Provider-private `codex.*` contracts and shared callback contracts marked `declaration_only` are discovered through the authenticated extended Agent Card, then used by directly invoking their documented provider-private methods. They do not require a separate `A2A-Extensions` activation header.
 - Compatibility and wire-profile documents are not negotiable extensions.
 
 ## Inventory Rules

--- a/docs/a2a-extension-baseline.md
+++ b/docs/a2a-extension-baseline.md
@@ -88,10 +88,10 @@ That inventory must be reusable by:
 
 ## Canonical URI Strategy Snapshot
 
-- Existing `urn:` extension URIs remain the canonical contract identifiers for the current `1.x` line.
-- `docs/extension-specifications.md` is the repository-managed specification index, but it is not itself the canonical extension URI namespace.
-- A future migration to dereferenceable HTTPS extension URIs should only happen after the project controls a long-lived namespace with explicit redirect governance. Deployment instance URLs and GitHub branch/blob URLs are not suitable canonical identifiers.
-- If a future migration happens, each extension should move to a versioned HTTPS URI that becomes the single canonical identifier for that compatibility line. Legacy `urn:` identifiers may remain documented as historical aliases, but they should not be dual-advertised indefinitely as concurrent runtime identities.
+- `urn:codex-a2a:extension:...` URIs are the repository-governed, versioned permanent identifiers for this repository family.
+- `docs/extension-specifications.md` is the repository-managed specification index for those URIs, but it is not itself the extension URI namespace.
+- The current contract strategy does not assume a later migration to dereferenceable HTTPS extension URIs as the default next step.
+- Any future namespace change would require an explicit compatibility and governance decision, and it should replace the old canonical identifiers for the new compatibility line rather than creating an indefinite dual-identity runtime contract.
 
 ## Follow-On Phases
 

--- a/docs/a2a-extension-baseline.md
+++ b/docs/a2a-extension-baseline.md
@@ -86,6 +86,13 @@ That inventory must be reusable by:
 - No public expansion of provider-private extension declarations.
 - No compatibility shim for A2A 0.3 behavior.
 
+## Canonical URI Strategy Snapshot
+
+- Existing `urn:` extension URIs remain the canonical contract identifiers for the current `1.x` line.
+- `docs/extension-specifications.md` is the repository-managed specification index, but it is not itself the canonical extension URI namespace.
+- A future migration to dereferenceable HTTPS extension URIs should only happen after the project controls a long-lived namespace with explicit redirect governance. Deployment instance URLs and GitHub branch/blob URLs are not suitable canonical identifiers.
+- If a future migration happens, each extension should move to a versioned HTTPS URI that becomes the single canonical identifier for that compatibility line. Legacy `urn:` identifiers may remain documented as historical aliases, but they should not be dual-advertised indefinitely as concurrent runtime identities.
+
 ## Follow-On Phases
 
 Phase 2 will unify request-level negotiation, disclosure layering, and runtime behavior around the authenticated extension declaration model.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -19,7 +19,7 @@ Machine-readable discovery surfaces must reflect actual runtime behavior:
 
 - public Agent Card
 - authenticated extended card
-- OpenAPI metadata, including `x-a2a-extension-contracts` and `x-codex-contracts`
+- OpenAPI metadata, including anonymous `x-a2a-extension-contracts`
 - JSON-RPC wire contract
 - compatibility profile
 
@@ -31,7 +31,7 @@ Open-source consumption guidance:
 - Treat the Agent Card `supported_interfaces[].url` value as the shared service discovery root. For `HTTP+JSON`, this repository uses that URL as the REST base root rather than as a concrete method path.
 - Treat `POST /` as the shared JSON-RPC surface for both core A2A methods and provider-private extension methods.
 - Treat `urn:codex-a2a:extension:...` entries in this repository as repository-governed extension identifiers, not as claims that they are part of the A2A core baseline.
-- Treat `a2a.interrupt.*` reply methods as a shared provider-private callback contract on `POST /`, declared on authenticated discovery surfaces but not activated through `A2A-Extensions`.
+- Treat `a2a.interrupt.*` reply methods as a shared callback contract on `POST /`, declared on public and authenticated discovery surfaces but not activated through `A2A-Extensions`.
 - Treat `codex.*` methods plus `metadata.codex.directory` and `metadata.codex.execution` as a Codex-specific control plane layered on top of the portable A2A surface.
 - Treat [extension-specifications.md](./extension-specifications.md) as the stable URI/spec index, not as the main usage guide.
 
@@ -95,7 +95,7 @@ Execution-environment boundary fields are also published through the runtime pro
 ## Extension Stability
 
 - Shared metadata and extension contracts should stay synchronized across Agent Card, OpenAPI, and runtime behavior.
-- Public Agent Card should stay intentionally minimal. Negotiated shared extension params belong in public `capabilities.extensions`; provider-private and machine-readable extension contracts belong in authenticated extended card `capabilities.extensions`, with OpenAPI `x-codex-contracts` carrying the full payloads and skill decomposition remaining additive discovery guidance.
+- Public Agent Card should stay intentionally minimal. Negotiated shared extension params and the shared interrupt callback contract belong in public `capabilities.extensions`; provider-private and machine-readable extension contracts belong in authenticated extended card `capabilities.extensions`, with skill decomposition remaining additive discovery guidance.
 - Only shared request/response extensions currently participate in request-level `A2A-Extensions` negotiation. Provider-private extension URIs declared on the authenticated extended card are declaration-only unless explicitly documented otherwise; clients discover them there and then invoke their documented methods directly.
 - Product-specific extensions should remain stable within the current major line unless explicitly documented otherwise.
 - Deployment-conditional methods must be declared as conditional rather than silently disappearing.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -30,7 +30,7 @@ Open-source consumption guidance:
 - Treat the core A2A send / stream / task methods as the portable baseline.
 - Treat the Agent Card `supported_interfaces[].url` value as the shared service discovery root. For `HTTP+JSON`, this repository uses that URL as the REST base root rather than as a concrete method path.
 - Treat `POST /` as the shared JSON-RPC surface for both core A2A methods and provider-private extension methods.
-- Treat `urn:a2a:*` entries in this repository as shared repo-family conventions, not as claims that they are part of the A2A core baseline.
+- Treat `urn:codex-a2a:extension:...` entries in this repository as repository-governed extension identifiers, not as claims that they are part of the A2A core baseline.
 - Treat `a2a.interrupt.*` reply methods as a shared provider-private callback contract on `POST /`, declared on authenticated discovery surfaces but not activated through `A2A-Extensions`.
 - Treat `codex.*` methods plus `metadata.codex.directory` and `metadata.codex.execution` as a Codex-specific control plane layered on top of the portable A2A surface.
 - Treat [extension-specifications.md](./extension-specifications.md) as the stable URI/spec index, not as the main usage guide.
@@ -176,7 +176,7 @@ Discovery note:
 
 Important note:
 
-- `urn:a2a:*` extension URIs used here should be read as shared conventions in this repository family.
+- `urn:codex-a2a:extension:...` extension URIs used here are repository-governed, versioned permanent identifiers.
 - They are not a claim that those extensions are part of the A2A core baseline.
 - `codex.*` methods are intentionally product-specific. They improve Codex-aware workflows but should not be assumed to transfer unchanged to unrelated A2A agents.
 - The public Agent Card is intentionally smaller than the authenticated extended card; that size difference is part of the current discovery contract rather than a documentation accident.

--- a/docs/conformance-triage.md
+++ b/docs/conformance-triage.md
@@ -25,7 +25,7 @@ For each failed or errored node ID:
 
 1. Copy the node ID from `failed-tests.json`.
 2. Inspect the corresponding raw details in `pytest-report.json` and `tck.log`.
-3. Compare the expectation with `docs/compatibility.md`, authenticated extended card skills/examples, and OpenAPI `x-a2a-extension-contracts` plus `x-codex-contracts`.
+3. Compare the expectation with `docs/compatibility.md`, authenticated extended card skills/examples, and OpenAPI `x-a2a-extension-contracts`.
 4. Assign one classification label.
 5. Record whether the next action belongs in this repository, the TCK, or a future protocol compatibility issue.
 

--- a/docs/extension-specifications.md
+++ b/docs/extension-specifications.md
@@ -20,20 +20,20 @@ Provider-private contract note:
 
 Negotiation note:
 
-- `urn:a2a:session-binding/v1` and `urn:a2a:stream-hints/v1` are the only current request-level negotiated extensions in this repository family.
+- `urn:codex-a2a:extension:shared:session-binding:v1` and `urn:codex-a2a:extension:shared:stream-hints:v1` are the only current request-level negotiated extensions in this repository family.
 - Provider-private `codex.*` extension URIs and the shared interrupt callback URI are declaration-only contracts. Discover them from the authenticated extended Agent Card or OpenAPI, then invoke the documented JSON-RPC methods directly; no additional `A2A-Extensions` activation header is required for those methods.
 - `wire_contract` and `compatibility_profile` are descriptive metadata contracts, not activatable runtime extensions.
 
 Canonical URI note:
 
-- The `urn:` identifiers listed below remain the canonical extension URIs for the current `1.x` line of `codex-a2a`.
+- The `urn:codex-a2a:extension:...` identifiers listed below are the canonical extension URIs for the current repository contract line.
 - This document is the stable repository-owned specification index for those URIs, but the project does not currently claim "spec hosting at the extension URI" for them.
-- A future move to dereferenceable HTTPS extension URIs should happen only when the project has a long-lived namespace and redirect policy that are independent from deployment instance URLs and GitHub branch/blob URLs.
-- If that migration happens later, the new HTTPS URIs should be versioned and should replace the legacy `urn:` identifiers as the single canonical runtime identities for the new compatibility line.
+- The current strategy treats this repository-owned URN namespace as the long-lived canonical identity layer rather than as a temporary bridge to a planned HTTPS migration.
+- Any future namespace change should be handled as an explicit compatibility-line decision, not as an indefinitely dual-advertised runtime identity.
 
 ## Shared Session Binding v1
 
-URI: `urn:a2a:session-binding/v1`
+URI: `urn:codex-a2a:extension:shared:session-binding:v1`
 
 - Scope: shared A2A request metadata for rebinding to an existing upstream session
 - Public Agent Card: capability declaration plus minimal routing metadata for `shared.session.id` only
@@ -43,7 +43,7 @@ URI: `urn:a2a:session-binding/v1`
 
 ## Shared Stream Hints v1
 
-URI: `urn:a2a:stream-hints/v1`
+URI: `urn:codex-a2a:extension:shared:stream-hints:v1`
 
 - Scope: shared canonical metadata for block, usage, interrupt, and session hints
 - Public Agent Card: metadata roots plus the minimum discoverability fields for block identity, status source, interrupt lifecycle, session identity, and basic token usage
@@ -53,7 +53,7 @@ URI: `urn:a2a:stream-hints/v1`
 
 ## Codex Session Query v1
 
-URI: `urn:codex-a2a:codex-session-query/v1`
+URI: `urn:codex-a2a:extension:private:session-query:v1`
 
 - Scope: provider-private Codex session history and low-risk control methods
 - Discovery surface: authenticated extended card `capabilities.extensions` plus skill inventory, with full payload mirrored in OpenAPI `x-codex-contracts.session_query`
@@ -63,7 +63,7 @@ URI: `urn:codex-a2a:codex-session-query/v1`
 
 ## Codex Discovery v1
 
-URI: `urn:codex-a2a:codex-discovery/v1`
+URI: `urn:codex-a2a:extension:private:discovery:v1`
 
 - Scope: provider-private skills/apps/plugins discovery methods and discovery watch bridge
 - Discovery surface: authenticated extended card `capabilities.extensions` plus skill inventory, with full payload mirrored in OpenAPI `x-codex-contracts.discovery`
@@ -73,7 +73,7 @@ URI: `urn:codex-a2a:codex-discovery/v1`
 
 ## Codex Thread Lifecycle v1
 
-URI: `urn:codex-a2a:codex-thread-lifecycle/v1`
+URI: `urn:codex-a2a:extension:private:thread-lifecycle:v1`
 
 - Scope: provider-private thread lifecycle control and lifecycle watch bridge
 - Discovery surface: authenticated extended card `capabilities.extensions` plus skill inventory, with full payload mirrored in OpenAPI `x-codex-contracts.thread_lifecycle`
@@ -81,9 +81,19 @@ URI: `urn:codex-a2a:codex-thread-lifecycle/v1`
 - Negotiation: declaration-only; discover first, then invoke the documented methods directly
 - Note: this URI remains a stable contract identifier and is published only on authenticated discovery surfaces
 
+## Codex Interrupt Recovery v1
+
+URI: `urn:codex-a2a:extension:private:interrupt-recovery:v1`
+
+- Scope: provider-private interrupt rediscovery contract for authenticated callers
+- Discovery surface: authenticated extended card `capabilities.extensions` plus skill inventory, with full payload mirrored in OpenAPI `x-codex-contracts.interrupt_recovery`
+- Transport: provider-private JSON-RPC methods on `POST /`
+- Negotiation: declaration-only; discover first, then invoke the documented methods directly
+- Note: this URI remains a stable contract identifier and is published only on authenticated discovery surfaces
+
 ## Codex Turn Control v1
 
-URI: `urn:codex-a2a:codex-turn-control/v1`
+URI: `urn:codex-a2a:extension:private:turn-control:v1`
 
 - Scope: provider-private active-turn steering for already-running regular turns
 - Discovery surface: authenticated extended card `capabilities.extensions` plus skill inventory, with full payload mirrored in OpenAPI `x-codex-contracts.turn_control`
@@ -93,7 +103,7 @@ URI: `urn:codex-a2a:codex-turn-control/v1`
 
 ## Codex Review Control v1
 
-URI: `urn:codex-a2a:codex-review/v1`
+URI: `urn:codex-a2a:extension:private:review-control:v1`
 
 - Scope: provider-private review-start control and review lifecycle watch bridge for uncommitted changes, branches, commits, and custom reviewer instructions
 - Discovery surface: authenticated extended card `capabilities.extensions` plus skill inventory, with full payload mirrored in OpenAPI `x-codex-contracts.review_control`
@@ -103,7 +113,7 @@ URI: `urn:codex-a2a:codex-review/v1`
 
 ## Codex Exec v1
 
-URI: `urn:codex-a2a:codex-exec/v1`
+URI: `urn:codex-a2a:extension:private:exec-control:v1`
 
 - Scope: provider-private standalone interactive command execution
 - Discovery surface: authenticated extended card `capabilities.extensions` plus skill inventory, with full payload mirrored in OpenAPI `x-codex-contracts.exec_control`
@@ -113,7 +123,7 @@ URI: `urn:codex-a2a:codex-exec/v1`
 
 ## Shared Interactive Interrupt v1
 
-URI: `urn:a2a:interactive-interrupt/v1`
+URI: `urn:codex-a2a:extension:shared:interactive-interrupt:v1`
 
 - Scope: shared interrupt callback reply methods
 - Discovery surface: authenticated extended card `capabilities.extensions` plus skill inventory, with full payload mirrored in OpenAPI `x-codex-contracts.interrupt_callback`
@@ -123,7 +133,7 @@ URI: `urn:a2a:interactive-interrupt/v1`
 
 ## A2A Compatibility Profile v1
 
-URI: `urn:codex-a2a:compatibility-profile/v1`
+URI: `urn:codex-a2a:extension:private:compatibility-profile:v1`
 
 - Scope: compatibility profile describing core baselines, extension retention, and declared service behaviors
 - Discovery surface: authenticated extended card `capabilities.extensions`, with full payload mirrored in OpenAPI `x-codex-contracts.compatibility_profile`
@@ -133,7 +143,7 @@ URI: `urn:codex-a2a:compatibility-profile/v1`
 
 ## A2A Wire Contract v1
 
-URI: `urn:codex-a2a:wire-contract/v1`
+URI: `urn:codex-a2a:extension:private:wire-contract:v1`
 
 - Scope: wire-level contract for supported methods, endpoints, and error semantics
 - Discovery surface: authenticated extended card `capabilities.extensions`, with full payload mirrored in OpenAPI `x-codex-contracts.wire_contract`

--- a/docs/extension-specifications.md
+++ b/docs/extension-specifications.md
@@ -7,10 +7,10 @@ This document is the stable specification index for the shared-extension and pro
 `codex-a2a` now splits Agent Card discovery into two layers:
 
 - Public Agent Card: minimal anonymous discovery for core interfaces and shared A2A extensions
-- Authenticated extended card: standard extension declarations plus authenticated skill inventory and deployment-aware examples for provider-private controls
-- OpenAPI metadata: full machine-readable contract payloads via `x-a2a-extension-contracts` and `x-codex-contracts`
+- Authenticated extended card: the canonical machine-readable source for provider-private contracts, deployment-aware examples, and machine-readable compatibility metadata
+- OpenAPI metadata: minimal anonymous shared-contract disclosure via `x-a2a-extension-contracts` only
 
-Use the public card for lightweight discovery. Fetch the authenticated extended card when you need authenticated skill discovery or deployment-aware examples. Use OpenAPI when you need the full provider-private contract payloads, compatibility metadata, or detailed transport notes.
+Use the public card for lightweight discovery. Fetch the authenticated extended card when you need provider-private contracts, authenticated skill discovery, compatibility metadata, or deployment-aware examples. Use OpenAPI for anonymous shared-contract hints and transport-adjacent examples only.
 
 Provider-private contract note:
 
@@ -21,7 +21,7 @@ Provider-private contract note:
 Negotiation note:
 
 - `urn:codex-a2a:extension:shared:session-binding:v1` and `urn:codex-a2a:extension:shared:stream-hints:v1` are the only current request-level negotiated extensions in this repository family.
-- Provider-private `codex.*` extension URIs and the shared interrupt callback URI are declaration-only contracts. Discover them from the authenticated extended Agent Card or OpenAPI, then invoke the documented JSON-RPC methods directly; no additional `A2A-Extensions` activation header is required for those methods.
+- Provider-private `codex.*` extension URIs and the shared interrupt callback URI are declaration-only contracts. Discover them from the authenticated extended Agent Card (with the interrupt callback also summarized on public anonymous surfaces), then invoke the documented JSON-RPC methods directly; no additional `A2A-Extensions` activation header is required for those methods.
 - `wire_contract` and `compatibility_profile` are descriptive metadata contracts, not activatable runtime extensions.
 
 Canonical URI note:
@@ -38,7 +38,7 @@ URI: `urn:codex-a2a:extension:shared:session-binding:v1`
 - Scope: shared A2A request metadata for rebinding to an existing upstream session
 - Public Agent Card: capability declaration plus minimal routing metadata for `shared.session.id` only
 - Authenticated extended card: full profile, notes, and detailed contract metadata
-- OpenAPI: shared contract payload under `x-a2a-extension-contracts.session_binding`
+- OpenAPI: anonymous shared contract payload under `x-a2a-extension-contracts.session_binding`
 - Runtime field: `metadata.shared.session.id`
 
 ## Shared Stream Hints v1
@@ -48,7 +48,7 @@ URI: `urn:codex-a2a:extension:shared:stream-hints:v1`
 - Scope: shared canonical metadata for block, usage, interrupt, and session hints
 - Public Agent Card: metadata roots plus the minimum discoverability fields for block identity, status source, interrupt lifecycle, session identity, and basic token usage
 - Authenticated extended card: full shared stream contract including detailed block payload mappings and extended usage metadata
-- OpenAPI: shared contract payload under `x-a2a-extension-contracts.streaming`
+- OpenAPI: anonymous shared contract payload under `x-a2a-extension-contracts.streaming`
 - Runtime fields: `metadata.shared.stream`, `metadata.shared.usage`, `metadata.shared.interrupt`, `metadata.shared.session`
 
 ## Codex Session Query v1
@@ -56,7 +56,7 @@ URI: `urn:codex-a2a:extension:shared:stream-hints:v1`
 URI: `urn:codex-a2a:extension:private:session-query:v1`
 
 - Scope: provider-private Codex session history and low-risk control methods
-- Discovery surface: authenticated extended card `capabilities.extensions` plus skill inventory, with full payload mirrored in OpenAPI `x-codex-contracts.session_query`
+- Discovery surface: authenticated extended card `capabilities.extensions` plus skill inventory
 - Transport: provider-private JSON-RPC methods on `POST /`
 - Negotiation: declaration-only; discover first, then invoke the documented methods directly
 - Note: this URI remains a stable contract identifier and is published only on authenticated discovery surfaces
@@ -66,7 +66,7 @@ URI: `urn:codex-a2a:extension:private:session-query:v1`
 URI: `urn:codex-a2a:extension:private:discovery:v1`
 
 - Scope: provider-private skills/apps/plugins discovery methods and discovery watch bridge
-- Discovery surface: authenticated extended card `capabilities.extensions` plus skill inventory, with full payload mirrored in OpenAPI `x-codex-contracts.discovery`
+- Discovery surface: authenticated extended card `capabilities.extensions` plus skill inventory
 - Transport: provider-private JSON-RPC methods on `POST /`
 - Negotiation: declaration-only; discover first, then invoke the documented methods directly
 - Note: this URI remains a stable contract identifier and is published only on authenticated discovery surfaces
@@ -76,7 +76,7 @@ URI: `urn:codex-a2a:extension:private:discovery:v1`
 URI: `urn:codex-a2a:extension:private:thread-lifecycle:v1`
 
 - Scope: provider-private thread lifecycle control and lifecycle watch bridge
-- Discovery surface: authenticated extended card `capabilities.extensions` plus skill inventory, with full payload mirrored in OpenAPI `x-codex-contracts.thread_lifecycle`
+- Discovery surface: authenticated extended card `capabilities.extensions` plus skill inventory
 - Transport: provider-private JSON-RPC methods on `POST /`
 - Negotiation: declaration-only; discover first, then invoke the documented methods directly
 - Note: this URI remains a stable contract identifier and is published only on authenticated discovery surfaces
@@ -86,7 +86,7 @@ URI: `urn:codex-a2a:extension:private:thread-lifecycle:v1`
 URI: `urn:codex-a2a:extension:private:interrupt-recovery:v1`
 
 - Scope: provider-private interrupt rediscovery contract for authenticated callers
-- Discovery surface: authenticated extended card `capabilities.extensions` plus skill inventory, with full payload mirrored in OpenAPI `x-codex-contracts.interrupt_recovery`
+- Discovery surface: authenticated extended card `capabilities.extensions` plus skill inventory
 - Transport: provider-private JSON-RPC methods on `POST /`
 - Negotiation: declaration-only; discover first, then invoke the documented methods directly
 - Note: this URI remains a stable contract identifier and is published only on authenticated discovery surfaces
@@ -96,7 +96,7 @@ URI: `urn:codex-a2a:extension:private:interrupt-recovery:v1`
 URI: `urn:codex-a2a:extension:private:turn-control:v1`
 
 - Scope: provider-private active-turn steering for already-running regular turns
-- Discovery surface: authenticated extended card `capabilities.extensions` plus skill inventory, with full payload mirrored in OpenAPI `x-codex-contracts.turn_control`
+- Discovery surface: authenticated extended card `capabilities.extensions` plus skill inventory
 - Transport: provider-private JSON-RPC methods on `POST /`
 - Negotiation: declaration-only; discover first, then invoke the documented methods directly
 - Note: this URI remains a stable contract identifier and is published only on authenticated discovery surfaces
@@ -106,7 +106,7 @@ URI: `urn:codex-a2a:extension:private:turn-control:v1`
 URI: `urn:codex-a2a:extension:private:review-control:v1`
 
 - Scope: provider-private review-start control and review lifecycle watch bridge for uncommitted changes, branches, commits, and custom reviewer instructions
-- Discovery surface: authenticated extended card `capabilities.extensions` plus skill inventory, with full payload mirrored in OpenAPI `x-codex-contracts.review_control`
+- Discovery surface: authenticated extended card `capabilities.extensions` plus skill inventory
 - Transport: provider-private JSON-RPC methods on `POST /`
 - Negotiation: declaration-only; discover first, then invoke the documented methods directly
 - Note: this URI remains a stable contract identifier and is published only on authenticated discovery surfaces
@@ -116,7 +116,7 @@ URI: `urn:codex-a2a:extension:private:review-control:v1`
 URI: `urn:codex-a2a:extension:private:exec-control:v1`
 
 - Scope: provider-private standalone interactive command execution
-- Discovery surface: authenticated extended card `capabilities.extensions` plus skill inventory, with full payload mirrored in OpenAPI `x-codex-contracts.exec_control`
+- Discovery surface: authenticated extended card `capabilities.extensions` plus skill inventory
 - Transport: provider-private JSON-RPC methods on `POST /`
 - Negotiation: declaration-only; discover first, then invoke the documented methods directly
 - Note: this URI remains a stable contract identifier and is published only on authenticated discovery surfaces
@@ -126,17 +126,17 @@ URI: `urn:codex-a2a:extension:private:exec-control:v1`
 URI: `urn:codex-a2a:extension:shared:interactive-interrupt:v1`
 
 - Scope: shared interrupt callback reply methods
-- Discovery surface: authenticated extended card `capabilities.extensions` plus skill inventory, with full payload mirrored in OpenAPI `x-codex-contracts.interrupt_callback`
+- Discovery surface: public Agent Card, authenticated extended card `capabilities.extensions`, and anonymous OpenAPI `x-a2a-extension-contracts.interrupt_callback`
 - Transport: provider-private JSON-RPC methods on `POST /`
 - Negotiation: declaration-only; discover first, then invoke the documented methods directly
-- Note: this URI identifies a shared repo-family callback contract and is published on authenticated discovery surfaces
+- Note: this URI identifies a shared repo-family callback contract and is published on both anonymous and authenticated discovery surfaces
 
 ## A2A Compatibility Profile v1
 
 URI: `urn:codex-a2a:extension:private:compatibility-profile:v1`
 
 - Scope: compatibility profile describing core baselines, extension retention, and declared service behaviors
-- Discovery surface: authenticated extended card `capabilities.extensions`, with full payload mirrored in OpenAPI `x-codex-contracts.compatibility_profile`
+- Discovery surface: authenticated extended card `capabilities.extensions`
 - Transport: provider-private machine-readable contract metadata
 - Negotiation: not applicable; descriptive metadata only
 - Note: this URI remains a stable contract identifier and is published only on authenticated discovery surfaces
@@ -146,7 +146,7 @@ URI: `urn:codex-a2a:extension:private:compatibility-profile:v1`
 URI: `urn:codex-a2a:extension:private:wire-contract:v1`
 
 - Scope: wire-level contract for supported methods, endpoints, and error semantics
-- Discovery surface: authenticated extended card `capabilities.extensions`, with full payload mirrored in OpenAPI `x-codex-contracts.wire_contract`
+- Discovery surface: authenticated extended card `capabilities.extensions`
 - Transport: provider-private machine-readable contract metadata
 - Negotiation: not applicable; descriptive metadata only
 - Note: this URI remains a stable contract identifier and is published only on authenticated discovery surfaces

--- a/docs/extension-specifications.md
+++ b/docs/extension-specifications.md
@@ -24,6 +24,13 @@ Negotiation note:
 - Provider-private `codex.*` extension URIs and the shared interrupt callback URI are declaration-only contracts. Discover them from the authenticated extended Agent Card or OpenAPI, then invoke the documented JSON-RPC methods directly; no additional `A2A-Extensions` activation header is required for those methods.
 - `wire_contract` and `compatibility_profile` are descriptive metadata contracts, not activatable runtime extensions.
 
+Canonical URI note:
+
+- The `urn:` identifiers listed below remain the canonical extension URIs for the current `1.x` line of `codex-a2a`.
+- This document is the stable repository-owned specification index for those URIs, but the project does not currently claim "spec hosting at the extension URI" for them.
+- A future move to dereferenceable HTTPS extension URIs should happen only when the project has a long-lived namespace and redirect policy that are independent from deployment instance URLs and GitHub branch/blob URLs.
+- If that migration happens later, the new HTTPS URIs should be versioned and should replace the legacy `urn:` identifiers as the single canonical runtime identities for the new compatibility line.
+
 ## Shared Session Binding v1
 
 URI: `urn:a2a:session-binding/v1`

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -139,7 +139,7 @@ Retention guidance:
 - Treat core methods as the generic client interoperability baseline.
 - Treat this deployment as a single-tenant, shared-workspace coding profile.
 - Treat shared session-binding and streaming metadata contracts as required for the current deployment model; they are not optional documentation-only hints.
-- Treat `urn:a2a:*` extension URIs in this repository as shared extension conventions used across this repo family, not as claims that they are part of the A2A core baseline.
+- Treat `urn:codex-a2a:extension:...` extension URIs in this repository as repository-governed extension identifiers, not as claims that they are part of the A2A core baseline.
 - Treat `a2a.interrupt.*` methods as a shared provider-private callback contract on `POST /`, not as core A2A methods or Agent Card-negotiated extensions.
 - Treat `codex.*` methods plus `metadata.codex.directory` and `metadata.codex.execution` as Codex-specific extensions or provider-private operational surfaces rather than portable A2A baseline capabilities.
 - Treat `codex.interrupts.list` as an adapter-local recovery surface for rediscovering active pending interrupt request IDs after reconnecting.
@@ -479,7 +479,7 @@ On the current npm global install layout for Linux x64, the command above resolv
 - If task persistence fails while processing a request, the service maps that failure to a stable failed task or failed final status instead of leaking raw task-store exceptions.
 - Those task-store failure surfaces use `metadata.codex.error` with `type=TASK_STORE_UNAVAILABLE` and an `operation` field such as `get` or `save`.
 - Stream artifacts carry `artifact.metadata.shared.stream.block_type` with values `text`, `reasoning`, and `tool_call`.
-- The published `urn:a2a:stream-hints/v1` contract also declares the emitted A2A part type per block: `text` and `reasoning` use `Part(text)`, while `tool_call` uses `Part(data)`.
+- The published `urn:codex-a2a:extension:shared:stream-hints:v1` contract also declares the emitted A2A part type per block: `text` and `reasoning` use `Part(text)`, while `tool_call` uses `Part(data)`.
 - All chunks share one stream artifact ID and preserve original timeline via `artifact.metadata.shared.stream.sequence`.
 - Advanced correlation fields such as `metadata.shared.stream.message_id` and `metadata.shared.stream.event_id` may still appear on detailed/runtime surfaces, but the public shared contract only exposes the minimum stable discovery fields.
 - Session projections are normalized under `metadata.shared.session`, with `id` as the canonical shared field.

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -13,10 +13,10 @@ This guide covers runtime configuration, transport contracts, streaming/session/
 - The authenticated extended card exposes the authenticated provider-private skill inventory and deployment-aware examples:
   - preferred: JSON-RPC `GetExtendedAgentCard`
   - HTTP core route: `GET /v1/extendedAgentCard`
-- Full provider-private contract payloads are available through OpenAPI metadata:
+- Anonymous shared-contract hints are available through OpenAPI metadata:
   - `GET /openapi.json`
-  - `x-a2a-extension-contracts` for negotiated shared extensions
-  - `x-codex-contracts` for provider-private control contracts
+  - `x-a2a-extension-contracts` for negotiated shared extensions and shared interrupt callback hints
+- Full provider-private contract payloads are available through the authenticated extended Agent Card rather than anonymous OpenAPI.
 - Agent Card responses publish `ETag` and `Cache-Control`; clients should revalidate instead of repeatedly fetching full payloads.
 - Larger discovery documents support gzip compression on these HTTP GET routes:
   - `/.well-known/agent-card.json`
@@ -26,7 +26,7 @@ This guide covers runtime configuration, transport contracts, streaming/session/
 - Payload schema is transport-specific and should not be mixed:
   - REST send payload uses `message.parts` and role values like `ROLE_USER`
   - JSON-RPC `SendMessage` payload uses `params.message.parts` and role values like `ROLE_USER`
-- OpenAPI metadata on the shared JSON-RPC entrypoint publishes the explicit wire contract for the supported method set and unsupported-method error shape.
+- OpenAPI metadata on the shared JSON-RPC entrypoint publishes anonymous shared-contract hints and transport notes for the supported method set.
 
 ## Wire Contract
 
@@ -75,7 +75,7 @@ Consumer guidance:
 
 - Discover the current method set from Agent Card / OpenAPI before calling custom JSON-RPC methods.
 - Fetch the authenticated extended card when you need the authenticated skill inventory or deployment-aware examples.
-- Use OpenAPI when you need the detailed method matrix, provider-private notes, or full provider-private contract payloads.
+- Use OpenAPI for anonymous shared-contract hints and transport notes; use the authenticated extended card for provider-private method matrices and detailed compatibility metadata.
 - Treat `supported_methods` in extension-namespace `error.data` as the runtime truth for the current deployment, especially when a deployment-conditional method is disabled.
 - Treat the core A2A methods as the portable interoperability baseline.
 - Treat `codex.*` methods plus `metadata.codex.directory` and `metadata.codex.execution` as a Codex-specific control plane for Codex-aware clients rather than generic A2A portability claims.
@@ -140,10 +140,10 @@ Retention guidance:
 - Treat this deployment as a single-tenant, shared-workspace coding profile.
 - Treat shared session-binding and streaming metadata contracts as required for the current deployment model; they are not optional documentation-only hints.
 - Treat `urn:codex-a2a:extension:...` extension URIs in this repository as repository-governed extension identifiers, not as claims that they are part of the A2A core baseline.
-- Treat `a2a.interrupt.*` methods as a shared provider-private callback contract on `POST /`, not as core A2A methods or Agent Card-negotiated extensions.
+- Treat `a2a.interrupt.*` methods as a shared callback contract on `POST /`, not as core A2A methods or Agent Card-negotiated extensions.
 - Treat `codex.*` methods plus `metadata.codex.directory` and `metadata.codex.execution` as Codex-specific extensions or provider-private operational surfaces rather than portable A2A baseline capabilities.
 - Treat `codex.interrupts.list` as an adapter-local recovery surface for rediscovering active pending interrupt request IDs after reconnecting.
-- Treat `codex.turns.steer`, `codex.review.*`, and `codex.exec.*` as deployment-aware provider-private controls. Discover them from the authenticated extended card or OpenAPI before calling them.
+- Treat `codex.turns.steer`, `codex.review.*`, and `codex.exec.*` as deployment-aware provider-private controls. Discover them from the authenticated extended card before calling them.
 - Treat `codex.exec.*` as the standalone interactive exec surface for internal or tightly controlled deployments. Use it for stdin write, PTY resize, and terminate flows as a separate provider-private contract rather than inferring terminal lifecycle support from chat/session flows.
 - Default deployment posture keeps `codex.review.*` and `codex.exec.*` disabled unless a deployment intentionally opts into them. `codex.turns.steer` is enabled by default but remains provider-private and can still be disabled with `A2A_ENABLE_TURN_CONTROL=false`.
 - Generic A2A clients should remain usable without the `codex.*` control plane. Opt into those methods only when you are intentionally integrating with Codex-specific workflows such as session continuation, discovery-backed mentions, or interactive exec.
@@ -460,7 +460,7 @@ On the current npm global install layout for Linux x64, the command above resolv
 - Agent Card media modes reflect that stable core message surface: default input modes are `text/plain`, `image/*`, and `application/json`; default output modes are `text/plain` and `application/json`.
 - The authenticated extended Agent Card also decomposes provider-private JSON-RPC surfaces into narrower skills: `codex.sessions.query`, `codex.discovery.query`, `codex.discovery.watch`, `codex.threads.control`, `codex.threads.watch`, `codex.turns.control`, `codex.review.control`, `codex.exec.control`, `codex.exec.stream`, and `codex.interrupt.callback`.
 - `codex.turns.control`, `codex.review.*`, and `codex.exec.*` only appear in the authenticated extended card when their deployment toggles are enabled.
-- OpenAPI carries the full provider-private contract payloads for those skills under `x-codex-contracts`; the authenticated extended card is intentionally narrower and discovery-oriented.
+- The authenticated extended Agent Card is the canonical machine-readable discovery surface for those provider-private skills; anonymous OpenAPI stays limited to shared-contract hints and transport-adjacent examples.
 - Those provider-private skills use narrower `output_modes` where practical: query/control/watch handle surfaces declare `application/json` when their primary contract is a structured JSON-RPC result or `Part(data)` watch payload, while `codex.exec.stream` declares `text/plain` because stdout/stderr deltas and terminal summaries are emitted as `Part(text)`.
 - On the core chat surface, the `application/json` input mode is intentionally narrower than arbitrary JSON: only `Part(data={"type":"mention"|"skill", ...})` is part of the declared stable contract.
 - Image input maps to upstream `turn/start.input[].type=input_image`.

--- a/src/codex_a2a/contracts/extension_registry.py
+++ b/src/codex_a2a/contracts/extension_registry.py
@@ -47,6 +47,48 @@ def _select_public_extension_params(
     return {key: params[key] for key in keys if key in params}
 
 
+def _project_public_extension_params(
+    descriptor: ExtensionContractDescriptor,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    if descriptor.public_params_transform == "streaming_public":
+        return {
+            "artifact_metadata_field": params["artifact_metadata_field"],
+            "status_metadata_field": params["status_metadata_field"],
+            "interrupt_metadata_field": params["interrupt_metadata_field"],
+            "session_metadata_field": params["session_metadata_field"],
+            "usage_metadata_field": params["usage_metadata_field"],
+            "block_types": params["block_types"],
+            "block_part_types": params["block_part_types"],
+            "stream_fields": _select_public_extension_params(
+                params["stream_fields"],
+                keys=("block_type", "sequence", "source"),
+            ),
+            "status_stream_fields": _select_public_extension_params(
+                params["status_stream_fields"],
+                keys=("source",),
+            ),
+            "session_fields": _select_public_extension_params(
+                params["session_fields"],
+                keys=("id",),
+            ),
+            "interrupt_fields": _select_public_extension_params(
+                params["interrupt_fields"],
+                keys=("request_id", "type", "phase"),
+            ),
+            "usage_fields": _select_public_extension_params(
+                params["usage_fields"],
+                keys=("input_tokens", "output_tokens", "total_tokens"),
+            ),
+        }
+    if descriptor.public_params_keys is not None:
+        return _select_public_extension_params(
+            params,
+            keys=descriptor.public_params_keys,
+        )
+    return params
+
+
 def _build_extension_contract_params(
     descriptor: ExtensionContractDescriptor,
     settings: Settings | None,
@@ -217,14 +259,20 @@ EXTENSION_CONTRACT_REGISTRY: tuple[ExtensionContractDescriptor, ...] = (
         uri=extension_specs.INTERRUPT_CALLBACK_EXTENSION_URI,
         title="Shared Interactive Interrupt v1",
         description="Shared repo-family interrupt callback reply methods.",
-        family="provider_private",
+        family="shared",
         negotiation_mode="declaration_only",
-        public_agent_card=False,
+        public_agent_card=True,
         authenticated_agent_card=True,
-        openapi_group="codex",
-        taxonomy_group="shared_provider_private_contracts",
+        openapi_group="a2a",
+        taxonomy_group="shared_agent_card_extensions",
         params_builder_name="build_interrupt_callback_extension_params",
         params_builder_signature="runtime_profile",
+        public_params_keys=(
+            "methods",
+            "supported_interrupt_events",
+            "interrupt_metadata_field",
+            "request_id_field",
+        ),
     ),
     ExtensionContractDescriptor(
         key="wire_contract",
@@ -274,41 +322,7 @@ def build_agent_card_extensions_from_registry(
             continue
         params = _build_extension_contract_params(descriptor, settings, runtime_profile)
         if not include_detailed_contracts:
-            if descriptor.public_params_transform == "streaming_public":
-                params = {
-                    "artifact_metadata_field": params["artifact_metadata_field"],
-                    "status_metadata_field": params["status_metadata_field"],
-                    "interrupt_metadata_field": params["interrupt_metadata_field"],
-                    "session_metadata_field": params["session_metadata_field"],
-                    "usage_metadata_field": params["usage_metadata_field"],
-                    "block_types": params["block_types"],
-                    "block_part_types": params["block_part_types"],
-                    "stream_fields": _select_public_extension_params(
-                        params["stream_fields"],
-                        keys=("block_type", "sequence", "source"),
-                    ),
-                    "status_stream_fields": _select_public_extension_params(
-                        params["status_stream_fields"],
-                        keys=("source",),
-                    ),
-                    "session_fields": _select_public_extension_params(
-                        params["session_fields"],
-                        keys=("id",),
-                    ),
-                    "interrupt_fields": _select_public_extension_params(
-                        params["interrupt_fields"],
-                        keys=("request_id", "type", "phase"),
-                    ),
-                    "usage_fields": _select_public_extension_params(
-                        params["usage_fields"],
-                        keys=("input_tokens", "output_tokens", "total_tokens"),
-                    ),
-                }
-            elif descriptor.public_params_keys is not None:
-                params = _select_public_extension_params(
-                    params,
-                    keys=descriptor.public_params_keys,
-                )
+            params = _project_public_extension_params(descriptor, params)
         extensions.append(
             AgentExtension(
                 uri=descriptor.uri,
@@ -325,16 +339,20 @@ def build_openapi_extension_contracts_from_registry(
     settings: Settings | None,
     runtime_profile: RuntimeProfile,
     group: Literal["a2a", "codex"],
+    public: bool = False,
 ) -> dict[str, dict[str, Any]]:
     contracts: dict[str, dict[str, Any]] = {}
     for descriptor in EXTENSION_CONTRACT_REGISTRY:
         if descriptor.openapi_group != group:
             continue
-        contracts[descriptor.key] = _build_extension_contract_params(
+        params = _build_extension_contract_params(
             descriptor,
             settings,
             runtime_profile,
         )
+        if public:
+            params = _project_public_extension_params(descriptor, params)
+        contracts[descriptor.key] = params
     return contracts
 
 

--- a/src/codex_a2a/contracts/extension_specs.py
+++ b/src/codex_a2a/contracts/extension_specs.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from types import MappingProxyType
 from typing import Any
 
 from a2a.server.routes.jsonrpc_dispatcher import JsonRpcDispatcher
@@ -8,18 +9,48 @@ from a2a.server.routes.jsonrpc_dispatcher import JsonRpcDispatcher
 from codex_a2a.execution.request_overrides import request_execution_options_fields
 from codex_a2a.profile.runtime import RuntimeProfile
 
-COMPATIBILITY_PROFILE_EXTENSION_URI = "urn:codex-a2a:compatibility-profile/v1"
-WIRE_CONTRACT_EXTENSION_URI = "urn:codex-a2a:wire-contract/v1"
-SESSION_BINDING_EXTENSION_URI = "urn:a2a:session-binding/v1"
-STREAMING_EXTENSION_URI = "urn:a2a:stream-hints/v1"
-SESSION_QUERY_EXTENSION_URI = "urn:codex-a2a:codex-session-query/v1"
-DISCOVERY_EXTENSION_URI = "urn:codex-a2a:codex-discovery/v1"
-THREAD_LIFECYCLE_EXTENSION_URI = "urn:codex-a2a:codex-thread-lifecycle/v1"
-INTERRUPT_RECOVERY_EXTENSION_URI = "urn:codex-a2a:codex-interrupt-recovery/v1"
-TURN_CONTROL_EXTENSION_URI = "urn:codex-a2a:codex-turn-control/v1"
-REVIEW_CONTROL_EXTENSION_URI = "urn:codex-a2a:codex-review/v1"
-EXEC_CONTROL_EXTENSION_URI = "urn:codex-a2a:codex-exec/v1"
-INTERRUPT_CALLBACK_EXTENSION_URI = "urn:a2a:interactive-interrupt/v1"
+EXTENSION_URI_NAMESPACE = "urn:codex-a2a:extension:"
+EXTENSION_SPEC_INDEX_DOCUMENT_PATH = "docs/extension-specifications.md"
+
+
+def _extension_uri(*segments: str) -> str:
+    normalized_segments = [segment.strip(": /") for segment in segments if segment.strip(": /")]
+    return f"{EXTENSION_URI_NAMESPACE}{':'.join(normalized_segments)}"
+
+
+COMPATIBILITY_PROFILE_EXTENSION_URI = _extension_uri("private", "compatibility-profile", "v1")
+WIRE_CONTRACT_EXTENSION_URI = _extension_uri("private", "wire-contract", "v1")
+SESSION_BINDING_EXTENSION_URI = _extension_uri("shared", "session-binding", "v1")
+STREAMING_EXTENSION_URI = _extension_uri("shared", "stream-hints", "v1")
+SESSION_QUERY_EXTENSION_URI = _extension_uri("private", "session-query", "v1")
+DISCOVERY_EXTENSION_URI = _extension_uri("private", "discovery", "v1")
+THREAD_LIFECYCLE_EXTENSION_URI = _extension_uri("private", "thread-lifecycle", "v1")
+INTERRUPT_RECOVERY_EXTENSION_URI = _extension_uri("private", "interrupt-recovery", "v1")
+TURN_CONTROL_EXTENSION_URI = _extension_uri("private", "turn-control", "v1")
+REVIEW_CONTROL_EXTENSION_URI = _extension_uri("private", "review-control", "v1")
+EXEC_CONTROL_EXTENSION_URI = _extension_uri("private", "exec-control", "v1")
+INTERRUPT_CALLBACK_EXTENSION_URI = _extension_uri("shared", "interactive-interrupt", "v1")
+
+PUBLIC_EXTENSION_URIS: tuple[str, ...] = (
+    SESSION_BINDING_EXTENSION_URI,
+    STREAMING_EXTENSION_URI,
+)
+AUTHENTICATED_ONLY_EXTENSION_URIS: tuple[str, ...] = (
+    SESSION_QUERY_EXTENSION_URI,
+    DISCOVERY_EXTENSION_URI,
+    THREAD_LIFECYCLE_EXTENSION_URI,
+    INTERRUPT_RECOVERY_EXTENSION_URI,
+    TURN_CONTROL_EXTENSION_URI,
+    REVIEW_CONTROL_EXTENSION_URI,
+    EXEC_CONTROL_EXTENSION_URI,
+    INTERRUPT_CALLBACK_EXTENSION_URI,
+    WIRE_CONTRACT_EXTENSION_URI,
+    COMPATIBILITY_PROFILE_EXTENSION_URI,
+)
+ALL_EXTENSION_URIS: tuple[str, ...] = PUBLIC_EXTENSION_URIS + AUTHENTICATED_ONLY_EXTENSION_URIS
+EXTENSION_SPEC_DOCUMENT_PATHS_BY_URI = MappingProxyType(
+    {uri: EXTENSION_SPEC_INDEX_DOCUMENT_PATH for uri in ALL_EXTENSION_URIS}
+)
 
 TASKS_RESUBSCRIBE_METHOD = "SubscribeToTask"
 TASKS_SUBSCRIBE_HTTP_ENDPOINT = "/v1/tasks/{id}:subscribe"

--- a/src/codex_a2a/contracts/extensions.py
+++ b/src/codex_a2a/contracts/extensions.py
@@ -397,9 +397,10 @@ def build_compatibility_profile_params(
                 "Agent Card extension surface for this deployment."
             ),
             (
-                "Treat a2a.interrupt.* callback methods as a shared provider-private "
-                "contract exposed on the shared JSON-RPC endpoint rather than as core "
-                "A2A behavior or an Agent Card-negotiated extension."
+                "Treat a2a.interrupt.* callback methods as a shared callback contract "
+                "declared on the public and authenticated discovery surfaces, then "
+                "invoked directly on the shared JSON-RPC endpoint rather than treated "
+                "as core A2A behavior."
             ),
             (
                 f"Use {CORE_JSONRPC_PATH} for both core A2A JSON-RPC methods and "
@@ -648,6 +649,7 @@ def build_session_query_extension_params(
             ],
         },
         "method_contracts": method_contracts,
+        "interrupt_metadata_field": extension_specs.SHARED_INTERRUPT_METADATA_FIELD,
         "errors": {
             "business_codes": dict(extension_specs.SESSION_QUERY_ERROR_BUSINESS_CODES),
             "error_data_fields": list(extension_specs.SESSION_QUERY_ERROR_DATA_FIELDS),
@@ -1240,6 +1242,7 @@ def build_interrupt_callback_extension_params(
         "jsonrpc_endpoint": _extension_jsonrpc_endpoint_contract(),
         "methods": dict(extension_specs.INTERRUPT_CALLBACK_METHODS),
         "method_contracts": method_contracts,
+        "interrupt_metadata_field": extension_specs.SHARED_INTERRUPT_METADATA_FIELD,
         "supported_interrupt_events": [
             "permission.asked",
             "question.asked",

--- a/src/codex_a2a/contracts/extensions.py
+++ b/src/codex_a2a/contracts/extensions.py
@@ -388,9 +388,9 @@ def build_compatibility_profile_params(
                 "do not assume per-consumer workspace or tenant isolation."
             ),
             (
-                "Treat urn:a2a:* extension URIs in this repository as shared extension "
-                "conventions used across this repo family, not as claims that they are part "
-                "of the A2A core baseline."
+                "Treat urn:codex-a2a:extension:* URIs in this repository as "
+                "repository-governed, versioned extension identifiers rather than as "
+                "claims that they are part of the A2A core baseline."
             ),
             (
                 "Treat shared session-binding and stream-hints as the negotiated "

--- a/src/codex_a2a/server/agent_card.py
+++ b/src/codex_a2a/server/agent_card.py
@@ -36,8 +36,7 @@ def _build_agent_card_description(
             base,
             (
                 "Supports HTTP+JSON and JSON-RPC transports, standard A2A messaging, "
-                "authenticated extended Agent Card discovery, and OpenAPI-based "
-                "provider-private contract discovery."
+                "and authenticated extended Agent Card discovery."
             ),
             (
                 "Single-tenant deployment; all consumers share the same underlying Codex "
@@ -63,7 +62,8 @@ def _build_agent_card_description(
         "(GetExtendedAgentCard), task APIs (GetTask, ListTasks, CancelTask, "
         "SubscribeToTask), and shared session-binding plus streaming contracts. "
         "Provider-private control surfaces are declared through authenticated "
-        "extended Agent Card extensions, authenticated skills, and OpenAPI contracts. "
+        "extended Agent Card extensions and authenticated skills, while anonymous "
+        "OpenAPI stays limited to minimal shared-contract disclosure. "
         f"Provider-private surfaces in this deployment include {codex_surface_summary}, "
         "shared interrupt callback handling, a machine-readable compatibility profile, "
         "and a machine-readable wire contract."

--- a/src/codex_a2a/server/openapi.py
+++ b/src/codex_a2a/server/openapi.py
@@ -140,14 +140,10 @@ def patch_openapi_contract(
     runtime_profile: RuntimeProfile,
 ) -> None:
     a2a_extension_contracts = build_openapi_extension_contracts_from_registry(
-        settings=None,
-        runtime_profile=runtime_profile,
-        group="a2a",
-    )
-    codex_contracts = build_openapi_extension_contracts_from_registry(
         settings=settings,
         runtime_profile=runtime_profile,
-        group="codex",
+        group="a2a",
+        public=True,
     )
     original_openapi = app.openapi
 
@@ -179,7 +175,6 @@ def patch_openapi_contract(
                 ]
             )
             post["x-a2a-extension-contracts"] = a2a_extension_contracts
-            post["x-codex-contracts"] = codex_contracts
             post.setdefault("responses", {"200": {"description": "JSON-RPC response"}})
 
             request_body = post.setdefault("requestBody", {})
@@ -223,9 +218,6 @@ def patch_openapi_contract(
                         "session_binding": a2a_extension_contracts["session_binding"],
                         "streaming": a2a_extension_contracts["streaming"],
                     },
-                    "codex_contracts": {
-                        "interrupt_callback": codex_contracts["interrupt_callback"],
-                    },
                 },
             }
             rest_examples = openapi_contract_fragments.build_rest_message_openapi_examples()
@@ -239,8 +231,6 @@ def patch_openapi_contract(
                 rest_post["summary"] = contract["summary"]
                 rest_post["description"] = contract["description"]
                 rest_post["x-a2a-extension-contracts"] = contract["contracts"]
-                if "codex_contracts" in contract:
-                    rest_post["x-codex-contracts"] = contract["codex_contracts"]
                 rest_post.setdefault("responses", {"200": {"description": "A2A response"}})
                 if rest_path == "/v1/message:stream":
                     rest_post["x-a2a-streaming"] = a2a_extension_contracts["streaming"]

--- a/src/codex_a2a/server/openapi_contract_fragments.py
+++ b/src/codex_a2a/server/openapi_contract_fragments.py
@@ -39,50 +39,20 @@ def build_core_jsonrpc_openapi_description() -> str:
         "ListTaskPushNotificationConfigs, DeleteTaskPushNotificationConfig, "
         "SubscribeToTask, GetExtendedAgentCard) on POST "
         f"{extension_contracts.CORE_JSONRPC_PATH}.\n\n"
-        "Provider-private Codex methods share the same public JSON-RPC endpoint and "
-        "are distinguished by method name plus the published compatibility contracts."
+        "Anonymous OpenAPI discovery intentionally exposes only the minimal shared "
+        "contract surface needed for interoperable clients."
     )
 
 
 def build_extension_jsonrpc_openapi_description(*, runtime_profile: RuntimeProfile) -> str:
-    session_methods: list[str] = [
-        extension_contracts.SESSION_QUERY_METHODS["list_sessions"],
-        extension_contracts.SESSION_QUERY_METHODS["get_session_messages"],
-    ]
-    discovery_methods = ", ".join(extension_contracts.DISCOVERY_METHODS.values())
-    thread_lifecycle_methods = ", ".join(extension_contracts.THREAD_LIFECYCLE_METHODS.values())
-    interrupt_recovery_methods = ", ".join(extension_contracts.INTERRUPT_RECOVERY_METHODS.values())
-    turn_methods = (
-        ", ".join(extension_contracts.TURN_CONTROL_METHODS.values())
-        if runtime_profile.turn_control_enabled
-        else "(disabled)"
-    )
-    review_methods = (
-        ", ".join(extension_contracts.REVIEW_CONTROL_METHODS.values())
-        if runtime_profile.review_control_enabled
-        else "(disabled)"
-    )
-    exec_methods = (
-        ", ".join(extension_contracts.EXEC_CONTROL_METHODS.values())
-        if runtime_profile.exec_control_enabled
-        else "(disabled)"
-    )
+    del runtime_profile
     interrupt_methods = ", ".join(sorted(extension_contracts.INTERRUPT_CALLBACK_METHODS.values()))
     return (
         "Provider-private Codex JSON-RPC methods also use POST "
-        f"{extension_contracts.CORE_JSONRPC_PATH}. "
-        "Supports Codex session extensions, Codex thread lifecycle extensions, "
-        "interrupt recovery extensions, active-turn control extensions, review "
-        "control extensions, Codex discovery extensions, interactive exec "
-        "extensions, and shared interrupt callback methods.\n\n"
-        f"Codex session query methods: {', '.join(session_methods)}.\n"
-        f"Codex thread lifecycle methods: {thread_lifecycle_methods}.\n"
-        f"Codex interrupt recovery methods: {interrupt_recovery_methods}.\n"
-        f"Codex active-turn control methods: {turn_methods}.\n"
-        f"Codex review control methods: {review_methods}.\n"
-        f"Codex discovery methods: {discovery_methods}.\n"
-        f"Codex interactive exec methods: {exec_methods}.\n"
-        f"Shared interrupt callback methods: {interrupt_methods}.\n\n"
+        f"{extension_contracts.CORE_JSONRPC_PATH}, but their canonical machine-readable "
+        "discovery surface is the authenticated extended Agent Card rather than this "
+        "anonymous OpenAPI document.\n"
+        f"Shared interrupt callback methods disclosed here: {interrupt_methods}.\n\n"
         "Notification semantics: extension requests without JSON-RPC id return HTTP 204. "
         "Unsupported methods return JSON-RPC -32601 with supported_methods and "
         "protocol_version in error.data."
@@ -137,147 +107,8 @@ def build_extension_jsonrpc_openapi_examples(
     *,
     runtime_profile: RuntimeProfile,
 ) -> dict[str, Any]:
-    examples: dict[str, Any] = {
-        "session_list": {
-            "summary": "List Codex sessions",
-            "value": {
-                "jsonrpc": "2.0",
-                "id": 1,
-                "method": extension_contracts.SESSION_QUERY_METHODS["list_sessions"],
-                "params": {"limit": extension_contracts.SESSION_QUERY_DEFAULT_LIMIT},
-            },
-        },
-        "session_messages": {
-            "summary": "List messages for a session",
-            "value": {
-                "jsonrpc": "2.0",
-                "id": 2,
-                "method": extension_contracts.SESSION_QUERY_METHODS["get_session_messages"],
-                "params": {
-                    "session_id": "s-1",
-                    "limit": extension_contracts.SESSION_QUERY_DEFAULT_LIMIT,
-                },
-            },
-        },
-        "discovery_skills_list": {
-            "summary": "List available Codex skills",
-            "value": {
-                "jsonrpc": "2.0",
-                "id": 23,
-                "method": extension_contracts.DISCOVERY_METHODS["list_skills"],
-                "params": {"cwds": ["/workspace/project"], "force_reload": True},
-            },
-        },
-        "discovery_apps_list": {
-            "summary": "List available Codex apps",
-            "value": {
-                "jsonrpc": "2.0",
-                "id": 24,
-                "method": extension_contracts.DISCOVERY_METHODS["list_apps"],
-                "params": {"limit": 20, "force_refetch": False},
-            },
-        },
-        "discovery_plugins_list": {
-            "summary": "List available Codex plugins",
-            "value": {
-                "jsonrpc": "2.0",
-                "id": 25,
-                "method": extension_contracts.DISCOVERY_METHODS["list_plugins"],
-                "params": {"cwds": ["/workspace/project"], "force_remote_sync": False},
-            },
-        },
-        "discovery_plugin_read": {
-            "summary": "Read one Codex plugin",
-            "value": {
-                "jsonrpc": "2.0",
-                "id": 26,
-                "method": extension_contracts.DISCOVERY_METHODS["read_plugin"],
-                "params": {
-                    "marketplace_path": "/workspace/project/.codex/plugins/marketplace.json",
-                    "plugin_name": "sample",
-                },
-            },
-        },
-        "discovery_watch": {
-            "summary": "Watch discovery invalidation and refresh signals",
-            "value": {
-                "jsonrpc": "2.0",
-                "id": 27,
-                "method": extension_contracts.DISCOVERY_METHODS["watch"],
-                "params": {"request": {"events": ["skills.changed", "apps.updated"]}},
-            },
-        },
-        "thread_fork": {
-            "summary": "Fork a Codex thread",
-            "value": {
-                "jsonrpc": "2.0",
-                "id": 271,
-                "method": extension_contracts.THREAD_LIFECYCLE_METHODS["fork"],
-                "params": {"thread_id": "thr-1", "request": {"ephemeral": True}},
-            },
-        },
-        "thread_archive": {
-            "summary": "Archive a Codex thread",
-            "value": {
-                "jsonrpc": "2.0",
-                "id": 272,
-                "method": extension_contracts.THREAD_LIFECYCLE_METHODS["archive"],
-                "params": {"thread_id": "thr-1"},
-            },
-        },
-        "thread_unarchive": {
-            "summary": "Restore an archived Codex thread",
-            "value": {
-                "jsonrpc": "2.0",
-                "id": 273,
-                "method": extension_contracts.THREAD_LIFECYCLE_METHODS["unarchive"],
-                "params": {"thread_id": "thr-1"},
-            },
-        },
-        "thread_metadata_update": {
-            "summary": "Patch persisted Codex thread git metadata",
-            "value": {
-                "jsonrpc": "2.0",
-                "id": 274,
-                "method": extension_contracts.THREAD_LIFECYCLE_METHODS["metadata_update"],
-                "params": {
-                    "thread_id": "thr-1",
-                    "request": {"git_info": {"branch": "feature/thread-lifecycle"}},
-                },
-            },
-        },
-        "thread_watch": {
-            "summary": "Watch thread lifecycle signals through a task stream",
-            "value": {
-                "jsonrpc": "2.0",
-                "id": 275,
-                "method": extension_contracts.THREAD_LIFECYCLE_METHODS["watch"],
-                "params": {
-                    "request": {
-                        "events": ["thread.started", "thread.status.changed"],
-                        "thread_ids": ["thr-1"],
-                    }
-                },
-            },
-        },
-        "thread_watch_release": {
-            "summary": "Release an owned thread lifecycle watch task",
-            "value": {
-                "jsonrpc": "2.0",
-                "id": 276,
-                "method": extension_contracts.THREAD_LIFECYCLE_METHODS["watch_release"],
-                "params": {"task_id": "task-thread-watch-1"},
-            },
-        },
-        "interrupts_list": {
-            "summary": "List active pending interrupts for the current caller",
-            "value": {
-                "jsonrpc": "2.0",
-                "id": 277,
-                "method": extension_contracts.INTERRUPT_RECOVERY_METHODS["list"],
-                "params": {"type": "permission"},
-            },
-        },
+    del runtime_profile
+    return {
         "permission_reply": {
             "summary": "Reply to permission interrupt request",
             "value": {
@@ -332,101 +163,6 @@ def build_extension_jsonrpc_openapi_examples(
             },
         },
     }
-    if runtime_profile.turn_control_enabled:
-        examples["turn_steer"] = {
-            "summary": "Append user input to the active regular turn",
-            "value": {
-                "jsonrpc": "2.0",
-                "id": 276,
-                "method": extension_contracts.TURN_CONTROL_METHODS["steer"],
-                "params": {
-                    "thread_id": "thr-1",
-                    "expected_turn_id": "turn-9",
-                    "request": {
-                        "parts": [{"type": "text", "text": "Focus on the failing tests first."}]
-                    },
-                },
-            },
-        }
-    if runtime_profile.review_control_enabled:
-        examples["review_start"] = {
-            "summary": "Start a provider-private review turn",
-            "value": {
-                "jsonrpc": "2.0",
-                "id": 277,
-                "method": extension_contracts.REVIEW_CONTROL_METHODS["start"],
-                "params": {
-                    "thread_id": "thr-1",
-                    "delivery": "inline",
-                    "target": {
-                        "type": "commit",
-                        "sha": "commit-demo-123",
-                        "title": "Polish tui colors",
-                    },
-                },
-            },
-        }
-        examples["review_watch"] = {
-            "summary": "Watch coarse-grained review lifecycle signals through a task stream",
-            "value": {
-                "jsonrpc": "2.0",
-                "id": 278,
-                "method": extension_contracts.REVIEW_CONTROL_METHODS["watch"],
-                "params": {
-                    "thread_id": "thr-1",
-                    "review_thread_id": "thr-1-review",
-                    "turn_id": "turn-review-1",
-                    "request": {"events": ["review.started", "review.completed", "review.failed"]},
-                },
-            },
-        }
-    if runtime_profile.exec_control_enabled:
-        examples["exec_start"] = {
-            "summary": "Start standalone interactive command execution",
-            "value": {
-                "jsonrpc": "2.0",
-                "id": 28,
-                "method": extension_contracts.EXEC_CONTROL_METHODS["exec_start"],
-                "params": {
-                    "request": {
-                        "command": "bash",
-                        "arguments": "-lc 'printf hello && sleep 1'",
-                        "process_id": "exec-1",
-                        "tty": True,
-                        "rows": 24,
-                        "cols": 80,
-                    }
-                },
-            },
-        }
-        examples["exec_write"] = {
-            "summary": "Write stdin bytes to an interactive exec session",
-            "value": {
-                "jsonrpc": "2.0",
-                "id": 29,
-                "method": extension_contracts.EXEC_CONTROL_METHODS["exec_write"],
-                "params": {"request": {"process_id": "exec-1", "delta_base64": "cHdkCg=="}},
-            },
-        }
-        examples["exec_resize"] = {
-            "summary": "Resize the interactive exec PTY",
-            "value": {
-                "jsonrpc": "2.0",
-                "id": 30,
-                "method": extension_contracts.EXEC_CONTROL_METHODS["exec_resize"],
-                "params": {"request": {"process_id": "exec-1", "rows": 40, "cols": 120}},
-            },
-        }
-        examples["exec_terminate"] = {
-            "summary": "Terminate an interactive exec session",
-            "value": {
-                "jsonrpc": "2.0",
-                "id": 31,
-                "method": extension_contracts.EXEC_CONTROL_METHODS["exec_terminate"],
-                "params": {"request": {"process_id": "exec-1"}},
-            },
-        }
-    return examples
 
 
 def build_rest_message_openapi_examples() -> dict[str, Any]:

--- a/tests/contracts/test_extension_contract_consistency.py
+++ b/tests/contracts/test_extension_contract_consistency.py
@@ -4,6 +4,11 @@ import httpx
 import pytest
 
 from codex_a2a.contracts.extension_registry import build_openapi_extension_contracts_from_registry
+from codex_a2a.contracts.extension_specs import (
+    ALL_EXTENSION_URIS,
+    EXTENSION_SPEC_DOCUMENT_PATHS_BY_URI,
+    EXTENSION_URI_NAMESPACE,
+)
 from codex_a2a.contracts.extensions import (
     COMPATIBILITY_PROFILE_EXTENSION_URI,
     CORE_JSONRPC_PATH,
@@ -389,6 +394,25 @@ def test_openapi_and_agent_card_contract_partitions_match() -> None:
         core_codex_contract["compatibility_profile"]
         == extension_codex_contract["compatibility_profile"]
     )
+
+
+def test_extension_uris_map_to_repository_spec_index() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    index_path = repo_root / "docs" / "extension-specifications.md"
+    index_text = index_path.read_text(encoding="utf-8")
+
+    spec_paths = {repo_root / path for path in EXTENSION_SPEC_DOCUMENT_PATHS_BY_URI.values()}
+    assert spec_paths == {index_path}
+
+    for uri in ALL_EXTENSION_URIS:
+        assert uri.startswith(EXTENSION_URI_NAMESPACE), (
+            "Extension URI drifted away from the repository-governed permanent URN namespace."
+        )
+        local_spec_path = repo_root / EXTENSION_SPEC_DOCUMENT_PATHS_BY_URI[uri]
+        assert local_spec_path.is_file(), (
+            f"Extension URI {uri!r} does not map to a checked-in spec document."
+        )
+        assert uri in index_text
 
 
 def test_guide_mentions_declared_streaming_contract_fields() -> None:

--- a/tests/contracts/test_extension_contract_consistency.py
+++ b/tests/contracts/test_extension_contract_consistency.py
@@ -28,11 +28,9 @@ from codex_a2a.contracts.extensions import (
     build_capability_snapshot,
     build_compatibility_profile_params,
     build_discovery_extension_params,
-    build_exec_control_extension_params,
     build_interrupt_callback_extension_params,
     build_interrupt_recovery_extension_params,
     build_review_control_extension_params,
-    build_session_binding_extension_params,
     build_session_query_extension_params,
     build_streaming_extension_params,
     build_thread_lifecycle_extension_params,
@@ -40,7 +38,7 @@ from codex_a2a.contracts.extensions import (
     build_wire_contract_extension_params,
 )
 from codex_a2a.profile.runtime import build_runtime_profile
-from codex_a2a.server.agent_card import build_authenticated_extended_agent_card
+from codex_a2a.server.agent_card import build_agent_card, build_authenticated_extended_agent_card
 from codex_a2a.server.application import create_app
 from tests.support.dummy_clients import DummySessionQueryCodexClient as DummyCodexClient
 from tests.support.settings import make_settings
@@ -74,6 +72,16 @@ def _codex_contracts(settings) -> dict[str, dict[str, object]]:  # noqa: ANN001
         settings=settings,
         runtime_profile=runtime_profile,
         group="codex",
+    )
+
+
+def _public_a2a_contracts(settings) -> dict[str, dict[str, object]]:  # noqa: ANN001
+    runtime_profile = build_runtime_profile(settings)
+    return build_openapi_extension_contracts_from_registry(
+        settings=settings,
+        runtime_profile=runtime_profile,
+        group="a2a",
+        public=True,
     )
 
 
@@ -231,149 +239,38 @@ def test_session_query_result_envelope_omits_method_level_contracts() -> None:
     assert session_query["result_envelope"] == {}
 
 
-def test_openapi_jsonrpc_contract_extension_matches_ssot() -> None:
+def test_openapi_jsonrpc_contract_extension_matches_public_ssot() -> None:
     settings = make_settings(a2a_bearer_token="test-token")
-    runtime_profile = build_runtime_profile(settings)
     app = create_app(settings)
     openapi = app.openapi()
     core_contract = openapi["paths"][CORE_JSONRPC_PATH]["post"].get("x-a2a-extension-contracts")
     assert isinstance(core_contract, dict), (
         "POST / OpenAPI is missing x-a2a-extension-contracts metadata."
     )
-    codex_contract = openapi["paths"][EXTENSION_JSONRPC_PATH]["post"].get("x-codex-contracts")
-    assert isinstance(codex_contract, dict), (
-        f"POST {EXTENSION_JSONRPC_PATH} OpenAPI is missing x-codex-contracts metadata."
-    )
-
-    session_binding = core_contract["session_binding"]
-    streaming = core_contract["streaming"]
-    session_query = codex_contract["session_query"]
-    discovery = codex_contract["discovery"]
-    interrupt_recovery = codex_contract["interrupt_recovery"]
-    interrupt_callback = codex_contract["interrupt_callback"]
-    exec_control = codex_contract["exec_control"]
-    thread_lifecycle = codex_contract["thread_lifecycle"]
-    turn_control = codex_contract["turn_control"]
-    review_control = codex_contract["review_control"]
-    wire_contract = codex_contract["wire_contract"]
-    compatibility_profile = codex_contract["compatibility_profile"]
-    expected_session_binding = build_session_binding_extension_params(
-        runtime_profile=runtime_profile,
-    )
-    expected_streaming = build_streaming_extension_params()
-    expected_session_query = build_session_query_extension_params(
-        runtime_profile=runtime_profile,
-    )
-    expected_discovery = build_discovery_extension_params(
-        runtime_profile=runtime_profile,
-    )
-    expected_interrupt_recovery = build_interrupt_recovery_extension_params(
-        runtime_profile=runtime_profile,
-    )
-    expected_interrupt_callback = build_interrupt_callback_extension_params(
-        runtime_profile=runtime_profile,
-    )
-    expected_exec_control = build_exec_control_extension_params(
-        runtime_profile=runtime_profile,
-    )
-    expected_thread_lifecycle = build_thread_lifecycle_extension_params(
-        runtime_profile=runtime_profile,
-    )
-    expected_turn_control = build_turn_control_extension_params(
-        runtime_profile=runtime_profile,
-    )
-    expected_review_control = build_review_control_extension_params(
-        runtime_profile=runtime_profile,
-    )
-    expected_wire_contract = build_wire_contract_extension_params(
-        protocol_version=settings.a2a_protocol_version,
-        runtime_profile=runtime_profile,
-    )
-    expected_compatibility_profile = build_compatibility_profile_params(
-        protocol_version=settings.a2a_protocol_version,
-        runtime_profile=runtime_profile,
-    )
-
-    assert session_binding == expected_session_binding, (
-        "OpenAPI session binding contract drifted from extension_contracts SSOT."
-    )
-    assert streaming == expected_streaming, (
-        "OpenAPI streaming contract drifted from extension_contracts SSOT."
-    )
-    assert session_query == expected_session_query, (
-        "OpenAPI session query contract drifted from extension_contracts SSOT."
-    )
-    assert discovery == expected_discovery, (
-        "OpenAPI discovery contract drifted from extension_contracts SSOT."
-    )
-    assert interrupt_recovery == expected_interrupt_recovery, (
-        "OpenAPI interrupt recovery contract drifted from extension_contracts SSOT."
-    )
-    assert interrupt_callback == expected_interrupt_callback, (
-        "OpenAPI interrupt callback contract drifted from extension_contracts SSOT."
-    )
-    assert exec_control == expected_exec_control, (
-        "OpenAPI exec control contract drifted from extension_contracts SSOT."
-    )
-    assert thread_lifecycle == expected_thread_lifecycle, (
-        "OpenAPI thread lifecycle contract drifted from extension_contracts SSOT."
-    )
-    assert turn_control == expected_turn_control, (
-        "OpenAPI turn control contract drifted from extension_contracts SSOT."
-    )
-    assert review_control == expected_review_control, (
-        "OpenAPI review control contract drifted from extension_contracts SSOT."
-    )
-    assert wire_contract == expected_wire_contract, (
-        "OpenAPI wire contract drifted from extension_contracts SSOT."
-    )
-    assert compatibility_profile == expected_compatibility_profile, (
-        "OpenAPI compatibility profile drifted from extension_contracts SSOT."
-    )
-    assert (
-        compatibility_profile["protocol_compatibility"] == wire_contract["protocol_compatibility"]
-    ), "OpenAPI protocol compatibility summary drifted between profile and wire contract."
+    assert openapi["paths"][EXTENSION_JSONRPC_PATH]["post"].get("x-codex-contracts") is None
+    assert core_contract == _public_a2a_contracts(settings)
 
 
 def test_openapi_and_agent_card_contract_partitions_match() -> None:
     settings = make_settings(a2a_bearer_token="test-token")
+    public_card = build_agent_card(settings)
     card = build_authenticated_extended_agent_card(settings)
+    public_ext_by_uri = {ext.uri: ext for ext in public_card.capabilities.extensions or []}
     ext_by_uri = {ext.uri: ext for ext in card.capabilities.extensions or []}
     openapi = create_app(settings).openapi()
     core_contract = openapi["paths"][CORE_JSONRPC_PATH]["post"]["x-a2a-extension-contracts"]
-    core_codex_contract = openapi["paths"][CORE_JSONRPC_PATH]["post"]["x-codex-contracts"]
-    extension_codex_contract = openapi["paths"][EXTENSION_JSONRPC_PATH]["post"]["x-codex-contracts"]
+    assert (
+        create_app(settings).openapi()["paths"][CORE_JSONRPC_PATH]["post"].get("x-codex-contracts")
+        is None
+    )
 
-    assert core_contract["session_binding"] == ext_by_uri[SESSION_BINDING_EXTENSION_URI].params
-    assert core_contract["streaming"] == ext_by_uri[STREAMING_EXTENSION_URI].params
     assert (
-        extension_codex_contract["session_query"] == ext_by_uri[SESSION_QUERY_EXTENSION_URI].params
+        core_contract["session_binding"] == public_ext_by_uri[SESSION_BINDING_EXTENSION_URI].params
     )
-    assert extension_codex_contract["discovery"] == ext_by_uri[DISCOVERY_EXTENSION_URI].params
+    assert core_contract["streaming"] == public_ext_by_uri[STREAMING_EXTENSION_URI].params
     assert (
-        extension_codex_contract["thread_lifecycle"]
-        == ext_by_uri[THREAD_LIFECYCLE_EXTENSION_URI].params
-    )
-    assert (
-        extension_codex_contract["interrupt_recovery"]
-        == ext_by_uri[INTERRUPT_RECOVERY_EXTENSION_URI].params
-    )
-    assert extension_codex_contract["turn_control"] == ext_by_uri[TURN_CONTROL_EXTENSION_URI].params
-    assert (
-        extension_codex_contract["review_control"]
-        == ext_by_uri[REVIEW_CONTROL_EXTENSION_URI].params
-    )
-    assert extension_codex_contract["exec_control"] == ext_by_uri[EXEC_CONTROL_EXTENSION_URI].params
-    assert (
-        extension_codex_contract["interrupt_callback"]
-        == ext_by_uri[INTERRUPT_CALLBACK_EXTENSION_URI].params
-    )
-    assert (
-        extension_codex_contract["wire_contract"] == ext_by_uri[WIRE_CONTRACT_EXTENSION_URI].params
-    )
-    assert (
-        extension_codex_contract["compatibility_profile"]
-        == ext_by_uri[COMPATIBILITY_PROFILE_EXTENSION_URI].params
+        core_contract["interrupt_callback"]
+        == public_ext_by_uri[INTERRUPT_CALLBACK_EXTENSION_URI].params
     )
     assert set(ext_by_uri) == {
         SESSION_BINDING_EXTENSION_URI,
@@ -389,10 +286,41 @@ def test_openapi_and_agent_card_contract_partitions_match() -> None:
         WIRE_CONTRACT_EXTENSION_URI,
         COMPATIBILITY_PROFILE_EXTENSION_URI,
     }
-    assert core_codex_contract["wire_contract"] == extension_codex_contract["wire_contract"]
     assert (
-        core_codex_contract["compatibility_profile"]
-        == extension_codex_contract["compatibility_profile"]
+        ext_by_uri[SESSION_QUERY_EXTENSION_URI].params
+        == _codex_contracts(settings)["session_query"]
+    )
+    assert ext_by_uri[DISCOVERY_EXTENSION_URI].params == _codex_contracts(settings)["discovery"]
+    assert (
+        ext_by_uri[THREAD_LIFECYCLE_EXTENSION_URI].params
+        == _codex_contracts(settings)["thread_lifecycle"]
+    )
+    assert (
+        ext_by_uri[INTERRUPT_RECOVERY_EXTENSION_URI].params
+        == _codex_contracts(settings)["interrupt_recovery"]
+    )
+    assert (
+        ext_by_uri[TURN_CONTROL_EXTENSION_URI].params == _codex_contracts(settings)["turn_control"]
+    )
+    assert (
+        ext_by_uri[REVIEW_CONTROL_EXTENSION_URI].params
+        == _codex_contracts(settings)["review_control"]
+    )
+    assert (
+        ext_by_uri[EXEC_CONTROL_EXTENSION_URI].params == _codex_contracts(settings)["exec_control"]
+    )
+    assert ext_by_uri[
+        INTERRUPT_CALLBACK_EXTENSION_URI
+    ].params == build_interrupt_callback_extension_params(
+        runtime_profile=build_runtime_profile(settings)
+    )
+    assert (
+        ext_by_uri[WIRE_CONTRACT_EXTENSION_URI].params
+        == _codex_contracts(settings)["wire_contract"]
+    )
+    assert (
+        ext_by_uri[COMPATIBILITY_PROFILE_EXTENSION_URI].params
+        == _codex_contracts(settings)["compatibility_profile"]
     )
 
 
@@ -562,27 +490,11 @@ def test_openapi_jsonrpc_examples_match_declared_extension_contracts() -> None:
     settings = make_settings(a2a_bearer_token="test-token")
     openapi = create_app(settings).openapi()
     post = openapi["paths"][EXTENSION_JSONRPC_PATH]["post"]
-    extension_contracts = post["x-codex-contracts"]
-    session_method_contracts = extension_contracts["session_query"]["method_contracts"]
-    discovery_method_contracts = extension_contracts["discovery"]["method_contracts"]
-    interrupt_recovery_method_contracts = extension_contracts["interrupt_recovery"][
-        "method_contracts"
-    ]
-    turn_control_method_contracts = extension_contracts["turn_control"]["method_contracts"]
-    review_control_method_contracts = extension_contracts["review_control"]["method_contracts"]
-    exec_method_contracts = extension_contracts["exec_control"]["method_contracts"]
-    thread_lifecycle_method_contracts = extension_contracts["thread_lifecycle"]["method_contracts"]
-    interrupt_method_contracts = extension_contracts["interrupt_callback"]["method_contracts"]
-    declared_extension_methods = (
-        set(session_method_contracts)
-        | set(discovery_method_contracts)
-        | set(thread_lifecycle_method_contracts)
-        | set(interrupt_recovery_method_contracts)
-        | set(turn_control_method_contracts)
-        | set(review_control_method_contracts)
-        | set(exec_method_contracts)
-        | set(interrupt_method_contracts)
-    )
+    public_interrupt_contract = post["x-a2a-extension-contracts"]["interrupt_callback"]
+    interrupt_method_contracts = build_interrupt_callback_extension_params(
+        runtime_profile=build_runtime_profile(settings)
+    )["method_contracts"]
+    declared_extension_methods = set(public_interrupt_contract["methods"].values())
     examples = post["requestBody"]["content"]["application/json"]["examples"]
 
     for example in examples.values():
@@ -600,16 +512,7 @@ def test_openapi_jsonrpc_examples_match_declared_extension_contracts() -> None:
         )
 
         params = payload.get("params", {})
-        method_contract = (
-            session_method_contracts.get(method)
-            or discovery_method_contracts.get(method)
-            or thread_lifecycle_method_contracts.get(method)
-            or interrupt_recovery_method_contracts.get(method)
-            or turn_control_method_contracts.get(method)
-            or review_control_method_contracts.get(method)
-            or exec_method_contracts.get(method)
-            or interrupt_method_contracts[method]
-        )
+        method_contract = interrupt_method_contracts[method]
         required_fields = method_contract["params"].get("required", [])
         for field in required_fields:
             assert _example_params_include_field(params, field), (
@@ -617,34 +520,30 @@ def test_openapi_jsonrpc_examples_match_declared_extension_contracts() -> None:
             )
 
 
-def test_openapi_jsonrpc_examples_drop_removed_session_control_methods() -> None:
+def test_openapi_jsonrpc_examples_do_not_disclose_provider_private_methods() -> None:
     settings = make_settings(a2a_bearer_token="test-token")
     openapi = create_app(settings).openapi()
     post = openapi["paths"][EXTENSION_JSONRPC_PATH]["post"]
     examples = post["requestBody"]["content"]["application/json"]["examples"]
     methods = {example["value"]["method"] for example in examples.values()}
-    session_contracts = post["x-codex-contracts"]["session_query"]["method_contracts"]
 
+    assert post.get("x-codex-contracts") is None
     assert "codex.sessions.command" not in methods
+    assert "codex.sessions.list" not in methods
+    assert "codex.discovery.skills.list" not in methods
+    assert "codex.exec.start" not in methods
     assert "codex.sessions.prompt_async" not in methods
-    assert "codex.sessions.shell" not in session_contracts
-    assert "codex.sessions.command" not in session_contracts
-    assert "codex.sessions.prompt_async" not in session_contracts
-    assert "control_methods" not in post["x-codex-contracts"]["session_query"]
 
 
-def test_openapi_exec_examples_declare_task_streaming_contract() -> None:
+def test_authenticated_extended_agent_card_keeps_exec_contract_canonical() -> None:
     settings = make_settings(a2a_bearer_token="test-token")
-    openapi = create_app(settings).openapi()
-    post = openapi["paths"][EXTENSION_JSONRPC_PATH]["post"]
-    examples = post["requestBody"]["content"]["application/json"]["examples"]
-    exec_contracts = post["x-codex-contracts"]["exec_control"]["method_contracts"]
-    streaming_contract = post["x-codex-contracts"]["exec_control"]["task_streaming"]
+    card = build_authenticated_extended_agent_card(settings)
+    ext_by_uri = {ext.uri: ext for ext in card.capabilities.extensions or []}
+    exec_contract = ext_by_uri[EXEC_CONTROL_EXTENSION_URI].params
+    assert exec_contract is not None
+    exec_contracts = exec_contract["method_contracts"]
+    streaming_contract = exec_contract["task_streaming"]
 
-    assert examples["exec_start"]["value"]["method"] == "codex.exec.start"
-    assert examples["exec_write"]["value"]["method"] == "codex.exec.write"
-    assert examples["exec_resize"]["value"]["method"] == "codex.exec.resize"
-    assert examples["exec_terminate"]["value"]["method"] == "codex.exec.terminate"
     assert exec_contracts["codex.exec.start"]["execution_binding"] == (
         "standalone_interactive_command_exec"
     )
@@ -652,12 +551,12 @@ def test_openapi_exec_examples_declare_task_streaming_contract() -> None:
     assert "process_id" in exec_contracts["codex.exec.start"]["result"]["fields"]
 
 
-def test_openapi_jsonrpc_examples_use_declared_default_session_limit() -> None:
+def test_public_openapi_omits_provider_private_session_examples() -> None:
     settings = make_settings(a2a_bearer_token="test-token")
     openapi = create_app(settings).openapi()
     examples = openapi["paths"][EXTENSION_JSONRPC_PATH]["post"]["requestBody"]["content"][
         "application/json"
     ]["examples"]
 
-    assert examples["session_list"]["value"]["params"]["limit"] == SESSION_QUERY_DEFAULT_LIMIT
-    assert examples["session_messages"]["value"]["params"]["limit"] == SESSION_QUERY_DEFAULT_LIMIT
+    assert "session_list" not in examples
+    assert "session_messages" not in examples

--- a/tests/contracts/test_extension_registry.py
+++ b/tests/contracts/test_extension_registry.py
@@ -57,7 +57,7 @@ def test_extension_registry_captures_phase1_inventory() -> None:
     authenticated_keys = [
         descriptor.key for descriptor in descriptors if descriptor.authenticated_agent_card
     ]
-    assert public_keys == ["session_binding", "streaming"]
+    assert public_keys == ["session_binding", "streaming", "interrupt_callback"]
     assert authenticated_keys == [
         "session_binding",
         "streaming",
@@ -117,6 +117,7 @@ def test_registry_builds_agent_card_extensions_for_current_phase1_surface() -> N
     assert [extension.uri for extension in public_extensions] == [
         SESSION_BINDING_EXTENSION_URI,
         STREAMING_EXTENSION_URI,
+        INTERRUPT_CALLBACK_EXTENSION_URI,
     ]
     assert [extension.uri for extension in authenticated_extensions] == [
         SESSION_BINDING_EXTENSION_URI,
@@ -149,7 +150,7 @@ def test_registry_builds_openapi_contract_groups() -> None:
         group="codex",
     )
 
-    assert list(shared_contracts) == ["session_binding", "streaming"]
+    assert list(shared_contracts) == ["session_binding", "streaming", "interrupt_callback"]
     assert list(codex_contracts) == [
         "session_query",
         "discovery",
@@ -158,7 +159,6 @@ def test_registry_builds_openapi_contract_groups() -> None:
         "turn_control",
         "review_control",
         "exec_control",
-        "interrupt_callback",
         "wire_contract",
         "compatibility_profile",
     ]
@@ -169,10 +169,9 @@ def test_extension_taxonomy_is_derived_from_registry() -> None:
         "shared_agent_card_extensions": [
             SESSION_BINDING_EXTENSION_URI,
             STREAMING_EXTENSION_URI,
-        ],
-        "shared_provider_private_contracts": [
             INTERRUPT_CALLBACK_EXTENSION_URI,
         ],
+        "shared_provider_private_contracts": [],
         "codex_provider_private_contracts": [
             SESSION_QUERY_EXTENSION_URI,
             DISCOVERY_EXTENSION_URI,

--- a/tests/server/test_agent_card.py
+++ b/tests/server/test_agent_card.py
@@ -53,6 +53,11 @@ AUTHENTICATED_EXTENSION_URIS = {
     WIRE_CONTRACT_EXTENSION_URI,
     COMPATIBILITY_PROFILE_EXTENSION_URI,
 }
+PUBLIC_EXTENSION_URIS = {
+    SESSION_BINDING_EXTENSION_URI,
+    STREAMING_EXTENSION_URI,
+    INTERRUPT_CALLBACK_EXTENSION_URI,
+}
 
 
 def _require_params(extension: AgentExtension) -> dict[str, Any]:
@@ -87,7 +92,7 @@ def test_public_agent_card_description_reflects_discovery_surface() -> None:
 
     assert "HTTP+JSON and JSON-RPC transports" in card.description
     assert "authenticated extended Agent Card discovery" in card.description
-    assert "OpenAPI-based provider-private contract discovery" in card.description
+    assert "OpenAPI-based provider-private contract discovery" not in card.description
     assert "single-tenant deployment" in card.description.lower()
     assert "machine-readable wire contract" not in card.description
     assert card.capabilities.extended_agent_card is True
@@ -100,6 +105,9 @@ def test_authenticated_extended_agent_card_description_reflects_detailed_contrac
     assert "GetTask, ListTasks, CancelTask, SubscribeToTask" in card.description
     assert "GetExtendedAgentCard" in card.description
     assert "Provider-private control surfaces are declared through authenticated extended" in (
+        card.description
+    )
+    assert "anonymous OpenAPI stays limited to minimal shared-contract disclosure" in (
         card.description
     )
     assert "interactive exec" in card.description
@@ -255,10 +263,7 @@ def test_public_agent_card_minimizes_provider_private_contracts() -> None:
     card = build_agent_card(make_settings(a2a_bearer_token="test-token"))
     ext_by_uri = {ext.uri: ext for ext in card.capabilities.extensions or []}
 
-    assert set(ext_by_uri) == {
-        SESSION_BINDING_EXTENSION_URI,
-        STREAMING_EXTENSION_URI,
-    }
+    assert set(ext_by_uri) == PUBLIC_EXTENSION_URIS
 
     session_binding = ext_by_uri[SESSION_BINDING_EXTENSION_URI]
     session_binding_params = _require_params(session_binding)
@@ -282,6 +287,26 @@ def test_public_agent_card_minimizes_provider_private_contracts() -> None:
     assert "reasoning_tokens" not in streaming_params["usage_fields"]
     assert streaming_params["usage_fields"]["total_tokens"] == "metadata.shared.usage.total_tokens"
     assert "tool_call_payload_contract" not in streaming_params
+
+    interrupt_callback = ext_by_uri[INTERRUPT_CALLBACK_EXTENSION_URI]
+    interrupt_params = _require_params(interrupt_callback)
+    assert interrupt_params == {
+        "methods": {
+            "reply_permission": "a2a.interrupt.permission.reply",
+            "reply_question": "a2a.interrupt.question.reply",
+            "reject_question": "a2a.interrupt.question.reject",
+            "reply_permissions": "a2a.interrupt.permissions.reply",
+            "reply_elicitation": "a2a.interrupt.elicitation.reply",
+        },
+        "supported_interrupt_events": [
+            "permission.asked",
+            "question.asked",
+            "permissions.asked",
+            "elicitation.asked",
+        ],
+        "interrupt_metadata_field": "metadata.shared.interrupt",
+        "request_id_field": "metadata.shared.interrupt.request_id",
+    }
 
 
 def test_authenticated_extended_agent_card_injects_profile_into_extensions() -> None:
@@ -637,7 +662,11 @@ def test_authenticated_extended_agent_card_injects_profile_into_extensions() -> 
     ]
     assert any("codex.review.watch" in note for note in review_control_params["consumer_guidance"])
 
-    interrupt_params = codex_contracts["interrupt_callback"]
+    interrupt_params = build_openapi_extension_contracts_from_registry(
+        settings=settings,
+        runtime_profile=build_runtime_profile(settings),
+        group="a2a",
+    )["interrupt_callback"]
     assert interrupt_params["jsonrpc_endpoint"]["url_path"] == EXTENSION_JSONRPC_PATH
     assert interrupt_params["profile"] == profile
     assert interrupt_params["request_id_field"] == "metadata.shared.interrupt.request_id"
@@ -737,10 +766,9 @@ def test_authenticated_extended_agent_card_injects_profile_into_extensions() -> 
     assert compatibility_params["extension_taxonomy"]["shared_agent_card_extensions"] == [
         SESSION_BINDING_EXTENSION_URI,
         STREAMING_EXTENSION_URI,
-    ]
-    assert compatibility_params["extension_taxonomy"]["shared_provider_private_contracts"] == [
         INTERRUPT_CALLBACK_EXTENSION_URI,
     ]
+    assert compatibility_params["extension_taxonomy"]["shared_provider_private_contracts"] == []
     assert compatibility_params["extension_taxonomy"]["provider_private_metadata"] == [
         "codex.directory",
         "codex.execution",

--- a/tests/server/test_agent_card.py
+++ b/tests/server/test_agent_card.py
@@ -759,7 +759,9 @@ def test_authenticated_extended_agent_card_injects_profile_into_extensions() -> 
         "single-tenant, shared-workspace coding profile" in note
         for note in compatibility_params["consumer_guidance"]
     )
-    assert any("urn:a2a:*" in note for note in compatibility_params["consumer_guidance"])
+    assert any(
+        "urn:codex-a2a:extension:" in note for note in compatibility_params["consumer_guidance"]
+    )
     assert any(
         "execution_environment" in note for note in compatibility_params["consumer_guidance"]
     )
@@ -780,36 +782,36 @@ def test_authenticated_extended_agent_card_injects_profile_into_extensions() -> 
     interrupt_recovery_policy = compatibility_params["method_retention"]["codex.interrupts.list"]
     assert interrupt_recovery_policy["availability"] == "always"
     assert interrupt_recovery_policy["retention"] == "stable"
-    assert interrupt_recovery_policy["extension_uri"] == "urn:codex-a2a:codex-interrupt-recovery/v1"
+    assert interrupt_recovery_policy["extension_uri"] == INTERRUPT_RECOVERY_EXTENSION_URI
     assert compatibility_params["method_retention"]["codex.sessions.list"] == {
         "surface": "extension",
         "availability": "always",
         "retention": "stable",
-        "extension_uri": "urn:codex-a2a:codex-session-query/v1",
+        "extension_uri": SESSION_QUERY_EXTENSION_URI,
     }
     exec_policy = compatibility_params["method_retention"]["codex.exec.start"]
     assert exec_policy["availability"] == "enabled"
     assert exec_policy["retention"] == "deployment-conditional"
-    assert exec_policy["extension_uri"] == "urn:codex-a2a:codex-exec/v1"
+    assert exec_policy["extension_uri"] == EXEC_CONTROL_EXTENSION_URI
     assert exec_policy["toggle"] == "A2A_ENABLE_EXEC_CONTROL"
     thread_policy = compatibility_params["method_retention"]["codex.threads.watch"]
     assert thread_policy["availability"] == "always"
     assert thread_policy["retention"] == "stable"
-    assert thread_policy["extension_uri"] == "urn:codex-a2a:codex-thread-lifecycle/v1"
+    assert thread_policy["extension_uri"] == THREAD_LIFECYCLE_EXTENSION_URI
     turn_policy = compatibility_params["method_retention"]["codex.turns.steer"]
     assert turn_policy["availability"] == "enabled"
     assert turn_policy["retention"] == "deployment-conditional"
-    assert turn_policy["extension_uri"] == "urn:codex-a2a:codex-turn-control/v1"
+    assert turn_policy["extension_uri"] == TURN_CONTROL_EXTENSION_URI
     assert turn_policy["toggle"] == "A2A_ENABLE_TURN_CONTROL"
     review_policy = compatibility_params["method_retention"]["codex.review.start"]
     assert review_policy["availability"] == "enabled"
     assert review_policy["retention"] == "deployment-conditional"
-    assert review_policy["extension_uri"] == "urn:codex-a2a:codex-review/v1"
+    assert review_policy["extension_uri"] == REVIEW_CONTROL_EXTENSION_URI
     assert review_policy["toggle"] == "A2A_ENABLE_REVIEW_CONTROL"
     review_watch_policy = compatibility_params["method_retention"]["codex.review.watch"]
     assert review_watch_policy["availability"] == "enabled"
     assert review_watch_policy["retention"] == "deployment-conditional"
-    assert review_watch_policy["extension_uri"] == "urn:codex-a2a:codex-review/v1"
+    assert review_watch_policy["extension_uri"] == REVIEW_CONTROL_EXTENSION_URI
     assert review_watch_policy["toggle"] == "A2A_ENABLE_REVIEW_CONTROL"
 
 

--- a/tests/server/test_transport_contract.py
+++ b/tests/server/test_transport_contract.py
@@ -56,6 +56,11 @@ AUTHENTICATED_EXTENSION_URIS = {
     WIRE_CONTRACT_EXTENSION_URI,
     COMPATIBILITY_PROFILE_EXTENSION_URI,
 }
+PUBLIC_EXTENSION_URIS = {
+    SESSION_BINDING_EXTENSION_URI,
+    STREAMING_EXTENSION_URI,
+    INTERRUPT_CALLBACK_EXTENSION_URI,
+}
 
 
 async def _empty_async_stream():
@@ -400,26 +405,15 @@ def test_openapi_rest_message_routes_include_schema_examples_and_extension_contr
 
     stream_contract = paths["/v1/message:stream"]["post"].get("x-a2a-streaming")
     assert isinstance(stream_contract, dict)
-    stream_codex_contracts = paths["/v1/message:stream"]["post"].get("x-codex-contracts")
-    assert isinstance(stream_codex_contracts, dict)
-    assert "interrupt_callback" in stream_codex_contracts
+    assert paths["/v1/message:stream"]["post"].get("x-codex-contracts") is None
 
     root_contracts = paths[CORE_JSONRPC_PATH]["post"].get("x-a2a-extension-contracts")
     assert isinstance(root_contracts, dict)
     assert "session_binding" in root_contracts
     assert "streaming" in root_contracts
-    root_codex_contracts = paths[CORE_JSONRPC_PATH]["post"].get("x-codex-contracts")
-    assert isinstance(root_codex_contracts, dict)
-    assert "wire_contract" in root_codex_contracts
-    assert "compatibility_profile" in root_codex_contracts
-
-    extension_contracts = paths[EXTENSION_JSONRPC_PATH]["post"].get("x-codex-contracts")
-    assert isinstance(extension_contracts, dict)
-    assert "discovery" in extension_contracts
-    assert "thread_lifecycle" in extension_contracts
-    assert "interrupt_recovery" in extension_contracts
-    assert "turn_control" in extension_contracts
-    assert "review_control" in extension_contracts
+    assert "interrupt_callback" in root_contracts
+    assert paths[CORE_JSONRPC_PATH]["post"].get("x-codex-contracts") is None
+    assert paths[EXTENSION_JSONRPC_PATH]["post"].get("x-codex-contracts") is None
 
 
 def test_openapi_jsonrpc_examples_include_core_and_extension_methods() -> None:
@@ -449,24 +443,12 @@ def test_openapi_jsonrpc_examples_include_core_and_extension_methods() -> None:
         .values()
     )
     methods = {value.get("value", {}).get("method") for value in extension_example_values}
-    assert "codex.sessions.list" in methods
-    assert "codex.sessions.messages.list" in methods
-    assert "codex.discovery.skills.list" in methods
-    assert "codex.discovery.apps.list" in methods
-    assert "codex.discovery.plugins.list" in methods
-    assert "codex.discovery.plugins.read" in methods
-    assert "codex.discovery.watch" in methods
-    assert "codex.threads.fork" in methods
-    assert "codex.threads.archive" in methods
-    assert "codex.threads.unarchive" in methods
-    assert "codex.threads.metadata.update" in methods
-    assert "codex.threads.watch" in methods
-    assert "codex.threads.watch.release" in methods
-    assert "codex.interrupts.list" in methods
-    assert "codex.turns.steer" in methods
-    assert "codex.review.start" in methods
-    assert "codex.review.watch" in methods
     assert "a2a.interrupt.permission.reply" in methods
+    assert "a2a.interrupt.permissions.reply" in methods
+    assert "a2a.interrupt.elicitation.reply" in methods
+    assert "codex.sessions.list" not in methods
+    assert "codex.discovery.skills.list" not in methods
+    assert "codex.exec.start" not in methods
 
 
 @pytest.mark.asyncio
@@ -521,10 +503,7 @@ async def test_agent_card_routes_split_public_and_authenticated_extended_contrac
         extended_extensions = {
             item["uri"]: item for item in extended_card.json()["capabilities"]["extensions"]
         }
-        assert set(public_extensions) == {
-            SESSION_BINDING_EXTENSION_URI,
-            STREAMING_EXTENSION_URI,
-        }
+        assert set(public_extensions) == PUBLIC_EXTENSION_URIS
         assert set(extended_extensions) == AUTHENTICATED_EXTENSION_URIS
         assert len(public_card.content) < len(extended_card.content)
         public_skill_ids = {item["id"] for item in public_card.json()["skills"]}


### PR DESCRIPTION
## 背景

围绕 #278，这个分支先完成了 extension URI 治理评估，再进一步把 discovery surface 收敛到当前 `a2a-sdk==1.0.2` / A2A 1.0 语义下更清晰的一套做法。

本次结论不是把现有 `urn:` 当作短期过渡，而是：
- 统一使用 repository-governed、versioned 的 `urn:codex-a2a:extension:{shared|private}:...:v1`
- 以 authenticated extended Agent Card 作为 provider-private contract 的 canonical machine-readable discovery surface
- 将匿名 OpenAPI 收敛为最小 shared disclosure，而不是继续承担 full provider-private contract catalog

## 本次改动

- 统一 extension URI namespace，并补齐 registry / taxonomy / spec index / 测试守护
- 将 `shared interactive interrupt` 提升到 shared discovery 面，消除“语义 shared、披露 private”的边界不一致
- 调整 Agent Card / OpenAPI / compatibility docs / guide 的 discovery 责任分层
- 重写相关契约测试，确保 public shared surface 与 authenticated provider-private surface 各自稳定一致
- 在 #278 评论区补充本次从“评估”到“落地”的思路追溯，便于后续复盘

## 相关提交

- `420d12e` `docs: record canonical extension URI strategy (#278)`
- `22c8857` `chore: unify extension URI governance (#278)`
- `523bd93` `chore: promote extended card as canonical discovery surface (#278)`

## 验证

- `uv run pytest tests/contracts/test_extension_registry.py tests/contracts/test_extension_contract_consistency.py tests/server/test_agent_card.py tests/server/test_transport_contract.py -q --no-cov`
- `bash ./scripts/validate_baseline.sh`

## Issue 关系

- Closes #278

本 PR 不额外补挂其它 related issues；当前变更已经完整覆盖 #278 在本仓的评估与落地方向。
