### PR TITLE
chore: Refine success and extension contracts

### DIFF
--- a/docs/a2a-extension-baseline.md
+++ b/docs/a2a-extension-baseline.md
@@ -2,7 +2,7 @@
 
 This document defines the phase-1 baseline for how `codex-a2a` classifies, documents, and publishes A2A 1.0 extensions and extension-like contracts.
 
-Phase 1 is intentionally internal-facing. It does not change the external extension URI strategy yet. The goal is to establish a single source of truth for extension inventory, disclosure surfaces, and negotiation posture before any breaking URI migration or Agent Card expansion.
+Phase 1 is intentionally internal-facing. The goal is to establish a single source of truth for extension inventory, disclosure surfaces, and negotiation posture before any later Agent Card expansion or compatibility-line change.
 
 ## Goals
 
@@ -23,7 +23,7 @@ Phase 1 is intentionally internal-facing. It does not change the external extens
 
 2. Provider-private extensions
 
-- These are adapter-managed `codex.*` or shared-repo callback contracts that remain specific to this deployment family.
+- These are adapter-managed `codex.*` contracts that remain specific to this deployment family.
 - They are still treated as extensions conceptually, but their public disclosure remains conservative.
 - They should be declared through authenticated extended Agent Card `capabilities.extensions`.
 - Their detailed contract payloads should stay machine-readable on the authenticated extended card, with authenticated skill inventory remaining additive discovery guidance.
@@ -60,7 +60,8 @@ Phase 1 is intentionally internal-facing. It does not change the external extens
 
 - Shared request/response extensions are the only extensions treated as negotiated by default in phase 1.
 - Shared request/response extensions use request-level `A2A-Extensions` activation only when the request depends on that negotiated behavior.
-- Provider-private `codex.*` contracts and shared callback contracts marked `declaration_only` are discovered through the authenticated extended Agent Card, then used by directly invoking their documented provider-private methods. They do not require a separate `A2A-Extensions` activation header.
+- Provider-private `codex.*` contracts and shared callback contracts marked `declaration_only` are used by directly invoking their documented methods. They do not require a separate `A2A-Extensions` activation header.
+- Shared callback contracts may publish minimal public discovery metadata, but their detailed method contracts and reply schemas remain on authenticated discovery surfaces.
 - Compatibility and wire-profile documents are not negotiable extensions.
 
 ## Inventory Rules

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -170,7 +170,7 @@ Discovery note:
 - `codex.review.watch` is the declared review lifecycle watch-task bridge for `review.started`, `review.status.changed`, `review.completed`, and `review.failed`.
 - `codex.review.start` remains a control-handle surface; clients should use `codex.review.watch` plus `SubscribeToTask` for review lifecycle observation.
 - `codex.interrupts.list` is always-on but adapter-local and identity-scoped. `codex.turns.steer`, `codex.review.*`, and `codex.exec.*` remain deployment-conditional surfaces and should be discovered from machine-readable contracts before use.
-- `a2a.interrupt.*` reply methods remain shared repo-family callback contracts. They are declared on authenticated discovery surfaces, mirrored in OpenAPI, and used directly rather than through `A2A-Extensions` activation.
+- `a2a.interrupt.*` reply methods remain shared repo-family callback contracts. Minimal metadata is declared on public discovery surfaces and mirrored in OpenAPI, while detailed method contracts stay on authenticated discovery surfaces. These methods are used directly rather than through `A2A-Extensions` activation.
 - `thread/unsubscribe` is intentionally excluded from the stable public contract until this service exposes connection-safe subscription ownership.
 - This repository does not claim a generic standalone server-push JSON-RPC transport for those notifications; the compatibility contract is the watch-task bridge published through Agent Card and OpenAPI.
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -170,7 +170,7 @@ Discovery note:
 - `codex.review.watch` is the declared review lifecycle watch-task bridge for `review.started`, `review.status.changed`, `review.completed`, and `review.failed`.
 - `codex.review.start` remains a control-handle surface; clients should use `codex.review.watch` plus `SubscribeToTask` for review lifecycle observation.
 - `codex.interrupts.list` is always-on but adapter-local and identity-scoped. `codex.turns.steer`, `codex.review.*`, and `codex.exec.*` remain deployment-conditional surfaces and should be discovered from machine-readable contracts before use.
-- `a2a.interrupt.*` reply methods remain shared repo-family callback contracts. Minimal metadata is declared on public discovery surfaces and mirrored in OpenAPI, while detailed method contracts stay on authenticated discovery surfaces. These methods are used directly rather than through `A2A-Extensions` activation.
+- `a2a.interrupt.*` reply methods remain shared callback contracts. Minimal metadata is declared on public discovery surfaces and mirrored in OpenAPI, while detailed method contracts stay on authenticated discovery surfaces. These methods are used directly rather than through `A2A-Extensions` activation.
 - `thread/unsubscribe` is intentionally excluded from the stable public contract until this service exposes connection-safe subscription ownership.
 - This repository does not claim a generic standalone server-push JSON-RPC transport for those notifications; the compatibility contract is the watch-task bridge published through Agent Card and OpenAPI.
 

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -4,7 +4,7 @@ This repository keeps internal regression and external interoperability experime
 
 ## Scope
 
-- `./scripts/doctor.sh` and `./scripts/validate_baseline.sh` remain the default internal regression entrypoints.
+- `./scripts/validate_baseline.sh` remains the default internal regression entrypoint.
 - `./scripts/conformance.sh` is a local/manual experiment entrypoint for official external tooling.
 - External conformance output is investigation input, not an automatic merge gate.
 

--- a/docs/extension-specifications.md
+++ b/docs/extension-specifications.md
@@ -27,7 +27,7 @@ Negotiation note:
 Canonical URI note:
 
 - The `urn:codex-a2a:extension:...` identifiers listed below are the canonical extension URIs for the current repository contract line.
-- URI paths do not encode disclosure or auth semantics. Contract family, public Agent Card visibility, authenticated extended-card visibility, and negotiation mode are registry metadata.
+- URI paths do not encode disclosure or auth semantics. Scope, public Agent Card visibility, authenticated extended-card visibility, and negotiation mode define the disclosure and activation boundaries.
 - This document is the stable repository-owned specification index for those URIs, but the project does not currently claim "spec hosting at the extension URI" for them.
 - The current strategy treats this repository-owned URN namespace as the long-lived canonical identity layer rather than as a temporary bridge to a planned HTTPS migration.
 - Any future namespace change should be handled as an explicit compatibility-line decision, not as an indefinitely dual-advertised runtime identity.
@@ -132,7 +132,7 @@ URI: `urn:codex-a2a:extension:interactive-interrupt:v1`
 - Negotiation: declaration-only; discover first, then invoke the documented methods directly
 - Public disclosure: method aliases, supported interrupt event names, shared interrupt metadata field names, and the authentication/request-id scope summary only
 - Authenticated disclosure: full JSON-RPC endpoint metadata, method contracts, reply schemas, provider-private metadata, success result fields, errors, and runtime profile
-- Note: this URI identifies a shared repo-family callback contract and is published on both anonymous and authenticated discovery surfaces. Anonymous publication does not imply anonymous invocation; callback methods require configured transport authentication and an active pending interrupt `request_id`, with session-owner validation when session binding is available.
+- Note: this URI identifies a shared interrupt callback contract and is published on both anonymous and authenticated discovery surfaces. Anonymous publication does not imply anonymous invocation; callback methods require configured transport authentication and an active pending interrupt `request_id`, with session-owner validation when session binding is available.
 
 ## A2A Compatibility Profile v1
 

--- a/docs/extension-specifications.md
+++ b/docs/extension-specifications.md
@@ -130,7 +130,9 @@ URI: `urn:codex-a2a:extension:interactive-interrupt:v1`
 - Discovery surface: public Agent Card, authenticated extended card `capabilities.extensions`, and anonymous OpenAPI `x-a2a-extension-contracts.interrupt_callback`
 - Transport: provider-private JSON-RPC methods on `POST /`
 - Negotiation: declaration-only; discover first, then invoke the documented methods directly
-- Note: this URI identifies a shared repo-family callback contract and is published on both anonymous and authenticated discovery surfaces
+- Public disclosure: method aliases, supported interrupt event names, shared interrupt metadata field names, and the authentication/request-id scope summary only
+- Authenticated disclosure: full JSON-RPC endpoint metadata, method contracts, reply schemas, provider-private metadata, success result fields, errors, and runtime profile
+- Note: this URI identifies a shared repo-family callback contract and is published on both anonymous and authenticated discovery surfaces. Anonymous publication does not imply anonymous invocation; callback methods require configured transport authentication and an active pending interrupt `request_id`, with session-owner validation when session binding is available.
 
 ## A2A Compatibility Profile v1
 

--- a/docs/extension-specifications.md
+++ b/docs/extension-specifications.md
@@ -1,6 +1,6 @@
 # Extension Specifications
 
-This document is the stable specification index for the shared-extension and provider-private contract URIs used by `codex-a2a`. It is intentionally a compact URI/spec map, not the main consumer guide. For the phase-1 extension classification and disclosure baseline, see [a2a-extension-baseline.md](./a2a-extension-baseline.md). For runtime behavior, request examples, and operational setup, see [guide.md](./guide.md). For compatibility promises and stability expectations, see [compatibility.md](./compatibility.md).
+This document is the stable specification index for the shared-contract, provider-private, and machine-readable contract URIs used by `codex-a2a`. It is intentionally a compact URI/spec map, not the main consumer guide. For the phase-1 extension classification and disclosure baseline, see [a2a-extension-baseline.md](./a2a-extension-baseline.md). For runtime behavior, request examples, and operational setup, see [guide.md](./guide.md). For compatibility promises and stability expectations, see [compatibility.md](./compatibility.md).
 
 ## Discovery Surface Note
 
@@ -20,20 +20,21 @@ Provider-private contract note:
 
 Negotiation note:
 
-- `urn:codex-a2a:extension:shared:session-binding:v1` and `urn:codex-a2a:extension:shared:stream-hints:v1` are the only current request-level negotiated extensions in this repository family.
+- `urn:codex-a2a:extension:session-binding:v1` and `urn:codex-a2a:extension:stream-hints:v1` are the only current request-level negotiated extensions in this repository family.
 - Provider-private `codex.*` extension URIs and the shared interrupt callback URI are declaration-only contracts. Discover them from the authenticated extended Agent Card (with the interrupt callback also summarized on public anonymous surfaces), then invoke the documented JSON-RPC methods directly; no additional `A2A-Extensions` activation header is required for those methods.
 - `wire_contract` and `compatibility_profile` are descriptive metadata contracts, not activatable runtime extensions.
 
 Canonical URI note:
 
 - The `urn:codex-a2a:extension:...` identifiers listed below are the canonical extension URIs for the current repository contract line.
+- URI paths do not encode disclosure or auth semantics. Contract family, public Agent Card visibility, authenticated extended-card visibility, and negotiation mode are registry metadata.
 - This document is the stable repository-owned specification index for those URIs, but the project does not currently claim "spec hosting at the extension URI" for them.
 - The current strategy treats this repository-owned URN namespace as the long-lived canonical identity layer rather than as a temporary bridge to a planned HTTPS migration.
 - Any future namespace change should be handled as an explicit compatibility-line decision, not as an indefinitely dual-advertised runtime identity.
 
 ## Shared Session Binding v1
 
-URI: `urn:codex-a2a:extension:shared:session-binding:v1`
+URI: `urn:codex-a2a:extension:session-binding:v1`
 
 - Scope: shared A2A request metadata for rebinding to an existing upstream session
 - Public Agent Card: capability declaration plus minimal routing metadata for `shared.session.id` only
@@ -43,7 +44,7 @@ URI: `urn:codex-a2a:extension:shared:session-binding:v1`
 
 ## Shared Stream Hints v1
 
-URI: `urn:codex-a2a:extension:shared:stream-hints:v1`
+URI: `urn:codex-a2a:extension:stream-hints:v1`
 
 - Scope: shared canonical metadata for block, usage, interrupt, and session hints
 - Public Agent Card: metadata roots plus the minimum discoverability fields for block identity, status source, interrupt lifecycle, session identity, and basic token usage
@@ -53,7 +54,7 @@ URI: `urn:codex-a2a:extension:shared:stream-hints:v1`
 
 ## Codex Session Query v1
 
-URI: `urn:codex-a2a:extension:private:session-query:v1`
+URI: `urn:codex-a2a:extension:session-query:v1`
 
 - Scope: provider-private Codex session history and low-risk control methods
 - Discovery surface: authenticated extended card `capabilities.extensions` plus skill inventory
@@ -63,7 +64,7 @@ URI: `urn:codex-a2a:extension:private:session-query:v1`
 
 ## Codex Discovery v1
 
-URI: `urn:codex-a2a:extension:private:discovery:v1`
+URI: `urn:codex-a2a:extension:discovery:v1`
 
 - Scope: provider-private skills/apps/plugins discovery methods and discovery watch bridge
 - Discovery surface: authenticated extended card `capabilities.extensions` plus skill inventory
@@ -73,7 +74,7 @@ URI: `urn:codex-a2a:extension:private:discovery:v1`
 
 ## Codex Thread Lifecycle v1
 
-URI: `urn:codex-a2a:extension:private:thread-lifecycle:v1`
+URI: `urn:codex-a2a:extension:thread-lifecycle:v1`
 
 - Scope: provider-private thread lifecycle control and lifecycle watch bridge
 - Discovery surface: authenticated extended card `capabilities.extensions` plus skill inventory
@@ -83,7 +84,7 @@ URI: `urn:codex-a2a:extension:private:thread-lifecycle:v1`
 
 ## Codex Interrupt Recovery v1
 
-URI: `urn:codex-a2a:extension:private:interrupt-recovery:v1`
+URI: `urn:codex-a2a:extension:interrupt-recovery:v1`
 
 - Scope: provider-private interrupt rediscovery contract for authenticated callers
 - Discovery surface: authenticated extended card `capabilities.extensions` plus skill inventory
@@ -93,7 +94,7 @@ URI: `urn:codex-a2a:extension:private:interrupt-recovery:v1`
 
 ## Codex Turn Control v1
 
-URI: `urn:codex-a2a:extension:private:turn-control:v1`
+URI: `urn:codex-a2a:extension:turn-control:v1`
 
 - Scope: provider-private active-turn steering for already-running regular turns
 - Discovery surface: authenticated extended card `capabilities.extensions` plus skill inventory
@@ -103,7 +104,7 @@ URI: `urn:codex-a2a:extension:private:turn-control:v1`
 
 ## Codex Review Control v1
 
-URI: `urn:codex-a2a:extension:private:review-control:v1`
+URI: `urn:codex-a2a:extension:review-control:v1`
 
 - Scope: provider-private review-start control and review lifecycle watch bridge for uncommitted changes, branches, commits, and custom reviewer instructions
 - Discovery surface: authenticated extended card `capabilities.extensions` plus skill inventory
@@ -113,7 +114,7 @@ URI: `urn:codex-a2a:extension:private:review-control:v1`
 
 ## Codex Exec v1
 
-URI: `urn:codex-a2a:extension:private:exec-control:v1`
+URI: `urn:codex-a2a:extension:exec-control:v1`
 
 - Scope: provider-private standalone interactive command execution
 - Discovery surface: authenticated extended card `capabilities.extensions` plus skill inventory
@@ -123,7 +124,7 @@ URI: `urn:codex-a2a:extension:private:exec-control:v1`
 
 ## Shared Interactive Interrupt v1
 
-URI: `urn:codex-a2a:extension:shared:interactive-interrupt:v1`
+URI: `urn:codex-a2a:extension:interactive-interrupt:v1`
 
 - Scope: shared interrupt callback reply methods
 - Discovery surface: public Agent Card, authenticated extended card `capabilities.extensions`, and anonymous OpenAPI `x-a2a-extension-contracts.interrupt_callback`
@@ -133,7 +134,7 @@ URI: `urn:codex-a2a:extension:shared:interactive-interrupt:v1`
 
 ## A2A Compatibility Profile v1
 
-URI: `urn:codex-a2a:extension:private:compatibility-profile:v1`
+URI: `urn:codex-a2a:extension:compatibility-profile:v1`
 
 - Scope: compatibility profile describing core baselines, extension retention, and declared service behaviors
 - Discovery surface: authenticated extended card `capabilities.extensions`
@@ -143,7 +144,7 @@ URI: `urn:codex-a2a:extension:private:compatibility-profile:v1`
 
 ## A2A Wire Contract v1
 
-URI: `urn:codex-a2a:extension:private:wire-contract:v1`
+URI: `urn:codex-a2a:extension:wire-contract:v1`
 
 - Scope: wire-level contract for supported methods, endpoints, and error semantics
 - Discovery surface: authenticated extended card `capabilities.extensions`

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -470,6 +470,8 @@ On the current npm global install layout for Linux x64, the command above resolv
 - Completed chat turns are persisted as `completed`; `input-required` is reserved for active interrupt asks that still need a reply.
 - Non-streaming requests return a `Task` directly.
 - Non-streaming `message:send` responses may include normalized token usage at `Task.metadata.shared.usage` with the same field schema.
+- Successful terminal chat results are artifact-first. Non-streaming terminal `Task` objects carry the completed answer in `Task.artifacts`; streaming terminal status updates carry lifecycle state and metadata but do not repeat the final answer in `status.message`.
+- `status.message` remains reserved for user-facing status, interrupt, or error details. Clients should not treat it as the canonical completed-result carrier on successful terminal surfaces.
 - `SubscribeToTask` remains part of the core A2A method baseline, but this deployment's terminal-task replay-once policy is a declared service-level behavior rather than a generic A2A guarantee.
 - Task persistence also applies a service-level resilience policy: once a task has been durably stored in a terminal state, later conflicting writes are dropped instead of overwriting that terminal snapshot.
 
@@ -502,6 +504,7 @@ On the current npm global install layout for Linux x64, the command above resolv
 - For Codex app-server approval and `tool/requestUserInput` requests, user-visible approval/question/permissions/elicitation details are normalized into `metadata.shared.interrupt.details`, including readable `display_message`, resolved `patterns`, requested permission subsets, elicitation form/url payloads, and `questions` when available.
 - HTTP streaming responses send transport-level SSE ping comments on a default keepalive interval from the underlying SDK / `sse-starlette` response without adding synthetic A2A business events.
 - Interrupt status events no longer mirror the asked payload under `metadata.codex.interrupt`; downstream consumers should treat `metadata.shared.interrupt` as the single interrupt rendering contract.
+- Review watch lifecycle payloads are emitted as artifacts. Terminal review-watch status updates only carry the terminal state and watch metadata; the review payload or error details remain in the final review artifact update.
 
 ### Tool Call Payload Contract
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -481,7 +481,7 @@ On the current npm global install layout for Linux x64, the command above resolv
 - If task persistence fails while processing a request, the service maps that failure to a stable failed task or failed final status instead of leaking raw task-store exceptions.
 - Those task-store failure surfaces use `metadata.codex.error` with `type=TASK_STORE_UNAVAILABLE` and an `operation` field such as `get` or `save`.
 - Stream artifacts carry `artifact.metadata.shared.stream.block_type` with values `text`, `reasoning`, and `tool_call`.
-- The published `urn:codex-a2a:extension:shared:stream-hints:v1` contract also declares the emitted A2A part type per block: `text` and `reasoning` use `Part(text)`, while `tool_call` uses `Part(data)`.
+- The published `urn:codex-a2a:extension:stream-hints:v1` contract also declares the emitted A2A part type per block: `text` and `reasoning` use `Part(text)`, while `tool_call` uses `Part(data)`.
 - All chunks share one stream artifact ID and preserve original timeline via `artifact.metadata.shared.stream.sequence`.
 - Advanced correlation fields such as `metadata.shared.stream.message_id` and `metadata.shared.stream.event_id` may still appear on detailed/runtime surfaces, but the public shared contract only exposes the minimum stable discovery fields.
 - Session projections are normalized under `metadata.shared.session`, with `id` as the canonical shared field.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -12,7 +12,6 @@ This document only explains the remaining repository-local maintainer scripts. U
 
 ## Which Script to Use
 
-- [`scripts/doctor.sh`](./doctor.sh): run the default local validation baseline through the shortest maintainer entrypoint.
 - [`scripts/validate_baseline.sh`](./validate_baseline.sh): run the default local validation baseline used by contributors and CI.
 - [`scripts/check_dead_code.py`](./check_dead_code.py): run the conservative private dead-code guard used by the default validation baseline.
 - [`scripts/audit_low_call_sites.py`](./audit_low_call_sites.py): report low-call-count function and method candidates for manual wrapper/abstraction review.
@@ -32,7 +31,6 @@ The `Publish` workflow now separates build, PyPI publish, and GitHub Release syn
 
 ## Notes
 
-- `doctor.sh` is a thin alias for the default local regression baseline; `validate_baseline.sh` remains the CI-facing script name.
 - `conformance.sh` intentionally stays outside the default regression gate. Use it to gather external compatibility evidence, then triage results in [`docs/conformance-triage.md`](../docs/conformance-triage.md).
 - `validate_baseline.sh` and `dependency_health.sh` intentionally remain separate entrypoints and share common prerequisites through [`health_common.sh`](./health_common.sh).
 - `validate_baseline.sh` now includes a conservative private dead-code check before type-checking and test execution.

--- a/scripts/conformance.sh
+++ b/scripts/conformance.sh
@@ -12,7 +12,7 @@ Usage:
 
 Purpose:
   Run the official A2A TCK as a local/manual experiment.
-  This script is intentionally separate from doctor.sh, validate_baseline.sh, and CI gates.
+  This script is intentionally separate from validate_baseline.sh and CI gates.
 
 Category:
   Defaults to "mandatory". Any category supported by a2aproject/a2a-tck run_tck.py is accepted.

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-# Run the default repository validation entrypoint.
-set -euo pipefail
-
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-
-exec bash "${SCRIPT_DIR}/validate_baseline.sh" "$@"

--- a/src/codex_a2a/contracts/extension_registry.py
+++ b/src/codex_a2a/contracts/extension_registry.py
@@ -17,6 +17,8 @@ class ExtensionContractDescriptor:
     uri: str
     title: str
     description: str
+    # family describes contract portability, not auth or disclosure.
+    # Disclosure is controlled by the explicit surface flags below.
     family: Literal["shared", "provider_private", "machine_readable"]
     # negotiated: request-level activation via A2A-Extensions is meaningful
     # declaration_only: discover through Agent Card/OpenAPI and invoke directly
@@ -272,6 +274,7 @@ EXTENSION_CONTRACT_REGISTRY: tuple[ExtensionContractDescriptor, ...] = (
             "supported_interrupt_events",
             "interrupt_metadata_field",
             "request_id_field",
+            "authorization",
         ),
     ),
     ExtensionContractDescriptor(

--- a/src/codex_a2a/contracts/extension_registry.py
+++ b/src/codex_a2a/contracts/extension_registry.py
@@ -17,9 +17,6 @@ class ExtensionContractDescriptor:
     uri: str
     title: str
     description: str
-    # family describes contract portability, not auth or disclosure.
-    # Disclosure is controlled by the explicit surface flags below.
-    family: Literal["shared", "provider_private", "machine_readable"]
     # negotiated: request-level activation via A2A-Extensions is meaningful
     # declaration_only: discover through Agent Card/OpenAPI and invoke directly
     # not_applicable: descriptive metadata, not an activatable runtime extension
@@ -126,7 +123,6 @@ EXTENSION_CONTRACT_REGISTRY: tuple[ExtensionContractDescriptor, ...] = (
             "metadata.codex.execution fields remain available as Codex-private "
             "request overrides under server-side validation."
         ),
-        family="shared",
         negotiation_mode="negotiated",
         public_agent_card=True,
         authenticated_agent_card=True,
@@ -148,7 +144,6 @@ EXTENSION_CONTRACT_REGISTRY: tuple[ExtensionContractDescriptor, ...] = (
             "Shared streaming metadata contract for canonical block hints, "
             "timeline identity, usage, and interactive interrupt metadata."
         ),
-        family="shared",
         negotiation_mode="negotiated",
         public_agent_card=True,
         authenticated_agent_card=True,
@@ -163,7 +158,6 @@ EXTENSION_CONTRACT_REGISTRY: tuple[ExtensionContractDescriptor, ...] = (
         uri=extension_specs.SESSION_QUERY_EXTENSION_URI,
         title="Codex Session Query v1",
         description="Provider-private Codex session history and low-risk control methods.",
-        family="provider_private",
         negotiation_mode="declaration_only",
         public_agent_card=False,
         authenticated_agent_card=True,
@@ -177,7 +171,6 @@ EXTENSION_CONTRACT_REGISTRY: tuple[ExtensionContractDescriptor, ...] = (
         uri=extension_specs.DISCOVERY_EXTENSION_URI,
         title="Codex Discovery v1",
         description="Provider-private skills, apps, plugins, and watch bridge methods.",
-        family="provider_private",
         negotiation_mode="declaration_only",
         public_agent_card=False,
         authenticated_agent_card=True,
@@ -191,7 +184,6 @@ EXTENSION_CONTRACT_REGISTRY: tuple[ExtensionContractDescriptor, ...] = (
         uri=extension_specs.THREAD_LIFECYCLE_EXTENSION_URI,
         title="Codex Thread Lifecycle v1",
         description="Provider-private thread lifecycle control and watch bridge methods.",
-        family="provider_private",
         negotiation_mode="declaration_only",
         public_agent_card=False,
         authenticated_agent_card=True,
@@ -205,7 +197,6 @@ EXTENSION_CONTRACT_REGISTRY: tuple[ExtensionContractDescriptor, ...] = (
         uri=extension_specs.INTERRUPT_RECOVERY_EXTENSION_URI,
         title="Codex Interrupt Recovery v1",
         description="Provider-private interrupt rediscovery contract for authenticated callers.",
-        family="provider_private",
         negotiation_mode="declaration_only",
         public_agent_card=False,
         authenticated_agent_card=True,
@@ -219,7 +210,6 @@ EXTENSION_CONTRACT_REGISTRY: tuple[ExtensionContractDescriptor, ...] = (
         uri=extension_specs.TURN_CONTROL_EXTENSION_URI,
         title="Codex Turn Control v1",
         description="Provider-private active-turn steering for already-running regular turns.",
-        family="provider_private",
         negotiation_mode="declaration_only",
         public_agent_card=False,
         authenticated_agent_card=True,
@@ -233,7 +223,6 @@ EXTENSION_CONTRACT_REGISTRY: tuple[ExtensionContractDescriptor, ...] = (
         uri=extension_specs.REVIEW_CONTROL_EXTENSION_URI,
         title="Codex Review Control v1",
         description="Provider-private review control and lifecycle watch bridge.",
-        family="provider_private",
         negotiation_mode="declaration_only",
         public_agent_card=False,
         authenticated_agent_card=True,
@@ -247,7 +236,6 @@ EXTENSION_CONTRACT_REGISTRY: tuple[ExtensionContractDescriptor, ...] = (
         uri=extension_specs.EXEC_CONTROL_EXTENSION_URI,
         title="Codex Exec v1",
         description="Provider-private standalone interactive command execution.",
-        family="provider_private",
         negotiation_mode="declaration_only",
         public_agent_card=False,
         authenticated_agent_card=True,
@@ -260,8 +248,7 @@ EXTENSION_CONTRACT_REGISTRY: tuple[ExtensionContractDescriptor, ...] = (
         key="interrupt_callback",
         uri=extension_specs.INTERRUPT_CALLBACK_EXTENSION_URI,
         title="Shared Interactive Interrupt v1",
-        description="Shared repo-family interrupt callback reply methods.",
-        family="shared",
+        description="Shared interrupt callback reply methods.",
         negotiation_mode="declaration_only",
         public_agent_card=True,
         authenticated_agent_card=True,
@@ -282,7 +269,6 @@ EXTENSION_CONTRACT_REGISTRY: tuple[ExtensionContractDescriptor, ...] = (
         uri=extension_specs.WIRE_CONTRACT_EXTENSION_URI,
         title="A2A Wire Contract v1",
         description="Machine-readable wire-level contract metadata.",
-        family="machine_readable",
         negotiation_mode="not_applicable",
         public_agent_card=False,
         authenticated_agent_card=True,
@@ -296,7 +282,6 @@ EXTENSION_CONTRACT_REGISTRY: tuple[ExtensionContractDescriptor, ...] = (
         uri=extension_specs.COMPATIBILITY_PROFILE_EXTENSION_URI,
         title="A2A Compatibility Profile v1",
         description="Machine-readable compatibility profile metadata.",
-        family="machine_readable",
         negotiation_mode="not_applicable",
         public_agent_card=False,
         authenticated_agent_card=True,

--- a/src/codex_a2a/contracts/extension_specs.py
+++ b/src/codex_a2a/contracts/extension_specs.py
@@ -18,18 +18,18 @@ def _extension_uri(*segments: str) -> str:
     return f"{EXTENSION_URI_NAMESPACE}{':'.join(normalized_segments)}"
 
 
-COMPATIBILITY_PROFILE_EXTENSION_URI = _extension_uri("private", "compatibility-profile", "v1")
-WIRE_CONTRACT_EXTENSION_URI = _extension_uri("private", "wire-contract", "v1")
-SESSION_BINDING_EXTENSION_URI = _extension_uri("shared", "session-binding", "v1")
-STREAMING_EXTENSION_URI = _extension_uri("shared", "stream-hints", "v1")
-SESSION_QUERY_EXTENSION_URI = _extension_uri("private", "session-query", "v1")
-DISCOVERY_EXTENSION_URI = _extension_uri("private", "discovery", "v1")
-THREAD_LIFECYCLE_EXTENSION_URI = _extension_uri("private", "thread-lifecycle", "v1")
-INTERRUPT_RECOVERY_EXTENSION_URI = _extension_uri("private", "interrupt-recovery", "v1")
-TURN_CONTROL_EXTENSION_URI = _extension_uri("private", "turn-control", "v1")
-REVIEW_CONTROL_EXTENSION_URI = _extension_uri("private", "review-control", "v1")
-EXEC_CONTROL_EXTENSION_URI = _extension_uri("private", "exec-control", "v1")
-INTERRUPT_CALLBACK_EXTENSION_URI = _extension_uri("shared", "interactive-interrupt", "v1")
+COMPATIBILITY_PROFILE_EXTENSION_URI = _extension_uri("compatibility-profile", "v1")
+WIRE_CONTRACT_EXTENSION_URI = _extension_uri("wire-contract", "v1")
+SESSION_BINDING_EXTENSION_URI = _extension_uri("session-binding", "v1")
+STREAMING_EXTENSION_URI = _extension_uri("stream-hints", "v1")
+SESSION_QUERY_EXTENSION_URI = _extension_uri("session-query", "v1")
+DISCOVERY_EXTENSION_URI = _extension_uri("discovery", "v1")
+THREAD_LIFECYCLE_EXTENSION_URI = _extension_uri("thread-lifecycle", "v1")
+INTERRUPT_RECOVERY_EXTENSION_URI = _extension_uri("interrupt-recovery", "v1")
+TURN_CONTROL_EXTENSION_URI = _extension_uri("turn-control", "v1")
+REVIEW_CONTROL_EXTENSION_URI = _extension_uri("review-control", "v1")
+EXEC_CONTROL_EXTENSION_URI = _extension_uri("exec-control", "v1")
+INTERRUPT_CALLBACK_EXTENSION_URI = _extension_uri("interactive-interrupt", "v1")
 
 PUBLIC_EXTENSION_URIS: tuple[str, ...] = (
     SESSION_BINDING_EXTENSION_URI,

--- a/src/codex_a2a/contracts/extensions.py
+++ b/src/codex_a2a/contracts/extensions.py
@@ -129,18 +129,7 @@ def build_wire_contract_extension_params(
             },
             "jsonrpc_methods": list(snapshot.extension_jsonrpc_methods),
             "conditionally_available_methods": dict(snapshot.conditional_methods),
-            "extension_uris": [
-                extension_specs.SESSION_BINDING_EXTENSION_URI,
-                extension_specs.STREAMING_EXTENSION_URI,
-                extension_specs.SESSION_QUERY_EXTENSION_URI,
-                extension_specs.DISCOVERY_EXTENSION_URI,
-                extension_specs.THREAD_LIFECYCLE_EXTENSION_URI,
-                extension_specs.INTERRUPT_RECOVERY_EXTENSION_URI,
-                extension_specs.TURN_CONTROL_EXTENSION_URI,
-                extension_specs.REVIEW_CONTROL_EXTENSION_URI,
-                extension_specs.EXEC_CONTROL_EXTENSION_URI,
-                extension_specs.INTERRUPT_CALLBACK_EXTENSION_URI,
-            ],
+            "extension_uris": list(extension_specs.ALL_EXTENSION_URIS),
         },
         "all_jsonrpc_methods": list(snapshot.supported_jsonrpc_methods),
         "unsupported_method_error": {
@@ -342,6 +331,16 @@ def build_compatibility_profile_params(
         },
         extension_specs.INTERRUPT_CALLBACK_EXTENSION_URI: {
             "surface": "jsonrpc-extension",
+            "availability": "always",
+            "retention": "stable",
+        },
+        extension_specs.WIRE_CONTRACT_EXTENSION_URI: {
+            "surface": "machine-readable-metadata",
+            "availability": "always",
+            "retention": "stable",
+        },
+        extension_specs.COMPATIBILITY_PROFILE_EXTENSION_URI: {
+            "surface": "machine-readable-metadata",
             "availability": "always",
             "retention": "stable",
         },

--- a/src/codex_a2a/contracts/extensions.py
+++ b/src/codex_a2a/contracts/extensions.py
@@ -1263,6 +1263,11 @@ def build_interrupt_callback_extension_params(
             ),
         },
         "request_id_field": f"{extension_specs.SHARED_INTERRUPT_METADATA_FIELD}.request_id",
+        "authorization": {
+            "transport_auth": "required",
+            "request_id_scope": "active_pending_interrupt_request",
+            "owner_validation": "session_owner_match_when_session_binding_available",
+        },
         "supported_metadata": ["codex.directory"],
         "provider_private_metadata": ["codex.directory"],
         "context_fields": {

--- a/src/codex_a2a/execution/executor.py
+++ b/src/codex_a2a/execution/executor.py
@@ -378,7 +378,6 @@ class CodexAgentExecutor(AgentExecutor):
                         context_id=context_id,
                         response_text=response_text,
                         session_id=response.session_id,
-                        resolved_message_id=resolved_message_id,
                         resolved_token_usage=resolved_token_usage,
                     )
                 break

--- a/src/codex_a2a/execution/response_emitter.py
+++ b/src/codex_a2a/execution/response_emitter.py
@@ -13,7 +13,6 @@ from codex_a2a.contracts.runtime_output import (
     build_status_stream_metadata,
 )
 from codex_a2a.execution.output_mapping import (
-    build_assistant_message,
     build_history,
     enqueue_artifact_update,
 )
@@ -99,12 +98,7 @@ async def emit_non_stream_completion(
     resolved_token_usage: dict[str, Any] | None,
 ) -> None:
     normalized_text = response_text or "(No text content returned by Codex.)"
-    assistant_message = build_assistant_message(
-        task_id=task_id,
-        context_id=context_id,
-        text=normalized_text,
-        message_id=resolved_message_id,
-    )
+    del resolved_message_id
     artifact = Artifact(
         artifact_id=str(uuid.uuid4()),
         name="response",
@@ -115,7 +109,6 @@ async def emit_non_stream_completion(
         context_id=context_id,
         status=TaskStatus(
             state=TaskState.TASK_STATE_COMPLETED,
-            message=assistant_message,
         ),
         history=build_history(context),
         artifacts=[artifact],

--- a/src/codex_a2a/execution/response_emitter.py
+++ b/src/codex_a2a/execution/response_emitter.py
@@ -94,11 +94,9 @@ async def emit_non_stream_completion(
     context_id: str,
     response_text: str,
     session_id: str,
-    resolved_message_id: str,
     resolved_token_usage: dict[str, Any] | None,
 ) -> None:
     normalized_text = response_text or "(No text content returned by Codex.)"
-    del resolved_message_id
     artifact = Artifact(
         artifact_id=str(uuid.uuid4()),
         name="response",

--- a/src/codex_a2a/execution/review_runtime.py
+++ b/src/codex_a2a/execution/review_runtime.py
@@ -160,20 +160,6 @@ class CodexReviewRuntime:
                                 if payload["event"] == "review.completed"
                                 else TaskState.TASK_STATE_FAILED
                             ),
-                            message=build_assistant_message(
-                                handle.task_id,
-                                handle.context_id,
-                                (
-                                    "Review completed."
-                                    if payload["event"] == "review.completed"
-                                    else "Review failed."
-                                ),
-                                message_id=(
-                                    f"{handle.task_id}:status:completed"
-                                    if payload["event"] == "review.completed"
-                                    else f"{handle.task_id}:status:failed"
-                                ),
-                            ),
                         ),
                         metadata=metadata,
                     )

--- a/tests/contracts/test_extension_contract_consistency.py
+++ b/tests/contracts/test_extension_contract_consistency.py
@@ -340,6 +340,38 @@ def test_openapi_and_agent_card_contract_partitions_match() -> None:
     )
 
 
+def test_interrupt_callback_public_contract_keeps_detailed_matrix_authenticated() -> None:
+    settings = make_settings(a2a_bearer_token="test-token")
+    public_card = build_agent_card(settings)
+    authenticated_card = build_authenticated_extended_agent_card(settings)
+    public_ext_by_uri = {ext.uri: ext for ext in public_card.capabilities.extensions or []}
+    authenticated_ext_by_uri = {
+        ext.uri: ext for ext in authenticated_card.capabilities.extensions or []
+    }
+
+    public_params = public_ext_by_uri[INTERRUPT_CALLBACK_EXTENSION_URI].params
+    authenticated_params = authenticated_ext_by_uri[INTERRUPT_CALLBACK_EXTENSION_URI].params
+
+    assert set(public_params) == {
+        "methods",
+        "supported_interrupt_events",
+        "interrupt_metadata_field",
+        "request_id_field",
+        "authorization",
+    }
+    assert public_params["authorization"] == {
+        "transport_auth": "required",
+        "request_id_scope": "active_pending_interrupt_request",
+        "owner_validation": "session_owner_match_when_session_binding_available",
+    }
+    assert "method_contracts" not in public_params
+    assert "jsonrpc_endpoint" not in public_params
+    assert "permission_reply_values" not in public_params
+    assert "method_contracts" in authenticated_params
+    assert "jsonrpc_endpoint" in authenticated_params
+    assert "permission_reply_values" in authenticated_params
+
+
 def test_extension_uris_map_to_repository_spec_index() -> None:
     repo_root = Path(__file__).resolve().parents[2]
     index_path = repo_root / "docs" / "extension-specifications.md"

--- a/tests/contracts/test_extension_contract_consistency.py
+++ b/tests/contracts/test_extension_contract_consistency.py
@@ -120,6 +120,22 @@ def test_provider_private_contract_builders_reject_non_1_0_protocol_version() ->
         )
 
 
+def test_machine_readable_contracts_use_canonical_extension_uri_inventory() -> None:
+    runtime_profile = build_runtime_profile(make_settings(a2a_bearer_token="test-token"))
+
+    wire_contract = build_wire_contract_extension_params(
+        protocol_version="1.0",
+        runtime_profile=runtime_profile,
+    )
+    compatibility_profile = build_compatibility_profile_params(
+        protocol_version="1.0",
+        runtime_profile=runtime_profile,
+    )
+
+    assert wire_contract["extensions"]["extension_uris"] == list(ALL_EXTENSION_URIS)
+    assert set(compatibility_profile["extension_retention"]) == set(ALL_EXTENSION_URIS)
+
+
 def test_session_query_contract_ssot_matches_openapi_contract() -> None:
     settings = make_settings(a2a_bearer_token="test-token")
     runtime_profile = build_runtime_profile(settings)
@@ -329,12 +345,30 @@ def test_extension_uris_map_to_repository_spec_index() -> None:
     index_path = repo_root / "docs" / "extension-specifications.md"
     index_text = index_path.read_text(encoding="utf-8")
 
+    assert ALL_EXTENSION_URIS == (
+        "urn:codex-a2a:extension:session-binding:v1",
+        "urn:codex-a2a:extension:stream-hints:v1",
+        "urn:codex-a2a:extension:session-query:v1",
+        "urn:codex-a2a:extension:discovery:v1",
+        "urn:codex-a2a:extension:thread-lifecycle:v1",
+        "urn:codex-a2a:extension:interrupt-recovery:v1",
+        "urn:codex-a2a:extension:turn-control:v1",
+        "urn:codex-a2a:extension:review-control:v1",
+        "urn:codex-a2a:extension:exec-control:v1",
+        "urn:codex-a2a:extension:interactive-interrupt:v1",
+        "urn:codex-a2a:extension:wire-contract:v1",
+        "urn:codex-a2a:extension:compatibility-profile:v1",
+    )
     spec_paths = {repo_root / path for path in EXTENSION_SPEC_DOCUMENT_PATHS_BY_URI.values()}
     assert spec_paths == {index_path}
 
     for uri in ALL_EXTENSION_URIS:
         assert uri.startswith(EXTENSION_URI_NAMESPACE), (
             "Extension URI drifted away from the repository-governed permanent URN namespace."
+        )
+        uri_suffix = uri.removeprefix(EXTENSION_URI_NAMESPACE)
+        assert uri_suffix.split(":")[0] not in {"shared", "private"}, (
+            "Extension URI must not encode disclosure or auth semantics in the URI path."
         )
         local_spec_path = repo_root / EXTENSION_SPEC_DOCUMENT_PATHS_BY_URI[uri]
         assert local_spec_path.is_file(), (

--- a/tests/contracts/test_extension_registry.py
+++ b/tests/contracts/test_extension_registry.py
@@ -164,14 +164,13 @@ def test_registry_builds_openapi_contract_groups() -> None:
     ]
 
 
-def test_interrupt_callback_family_does_not_imply_anonymous_invocation() -> None:
+def test_interrupt_callback_public_disclosure_does_not_imply_anonymous_invocation() -> None:
     interrupt_descriptor = next(
         descriptor
         for descriptor in EXTENSION_CONTRACT_REGISTRY
         if descriptor.uri == INTERRUPT_CALLBACK_EXTENSION_URI
     )
 
-    assert interrupt_descriptor.family == "shared"
     assert interrupt_descriptor.negotiation_mode == "declaration_only"
     assert interrupt_descriptor.public_agent_card is True
     assert interrupt_descriptor.authenticated_agent_card is True

--- a/tests/contracts/test_extension_registry.py
+++ b/tests/contracts/test_extension_registry.py
@@ -164,6 +164,27 @@ def test_registry_builds_openapi_contract_groups() -> None:
     ]
 
 
+def test_interrupt_callback_family_does_not_imply_anonymous_invocation() -> None:
+    interrupt_descriptor = next(
+        descriptor
+        for descriptor in EXTENSION_CONTRACT_REGISTRY
+        if descriptor.uri == INTERRUPT_CALLBACK_EXTENSION_URI
+    )
+
+    assert interrupt_descriptor.family == "shared"
+    assert interrupt_descriptor.negotiation_mode == "declaration_only"
+    assert interrupt_descriptor.public_agent_card is True
+    assert interrupt_descriptor.authenticated_agent_card is True
+    assert interrupt_descriptor.openapi_group == "a2a"
+    assert interrupt_descriptor.public_params_keys == (
+        "methods",
+        "supported_interrupt_events",
+        "interrupt_metadata_field",
+        "request_id_field",
+        "authorization",
+    )
+
+
 def test_extension_taxonomy_is_derived_from_registry() -> None:
     assert build_extension_taxonomy_from_registry() == {
         "shared_agent_card_extensions": [

--- a/tests/execution/test_codex_agent_session_binding.py
+++ b/tests/execution/test_codex_agent_session_binding.py
@@ -283,9 +283,9 @@ async def test_agent_uses_stable_fallback_message_id_when_upstream_missing_messa
     task = _terminal_task(q)
     assert task.status.state == TaskState.TASK_STATE_COMPLETED
     assert task.metadata is not None
-    assert task.status.message is not None
+    assert not task.status.HasField("message")
     assert "message_id" not in task.metadata["shared"]["session"]
-    assert task.status.message.message_id == "t-fallback:c-fallback:assistant"
+    assert part_text(task.artifacts[0].parts[0]) == "echo:hello"
 
 
 @pytest.mark.asyncio
@@ -469,8 +469,8 @@ async def test_agent_supports_tool_loop_and_merges_stream_output() -> None:
 
     assert client.call_count == 2
     task = _terminal_task(queue)
-    assert task.status.message is not None
-    assert part_text(task.status.message.parts[0]) == "done"
+    assert not task.status.HasField("message")
+    assert part_text(task.artifacts[0].parts[0]) == "done"
 
 
 def test_executor_merge_streamed_a2a_tool_output() -> None:

--- a/tests/execution/test_review_runtime.py
+++ b/tests/execution/test_review_runtime.py
@@ -114,6 +114,7 @@ async def test_review_runtime_start_bridges_lifecycle_notifications() -> None:
     statuses = _status_updates(queue)
     assert len(statuses) == 1
     assert statuses[0].status.state == TaskState.TASK_STATE_COMPLETED
+    assert not statuses[0].status.HasField("message")
 
 
 @pytest.mark.asyncio
@@ -158,6 +159,7 @@ async def test_review_runtime_maps_failed_turns_to_failed_terminal_status() -> N
     statuses = _status_updates(queue)
     assert len(statuses) == 1
     assert statuses[0].status.state == TaskState.TASK_STATE_FAILED
+    assert not statuses[0].status.HasField("message")
 
 
 @pytest.mark.asyncio

--- a/tests/execution/test_streaming_output_contract.py
+++ b/tests/execution/test_streaming_output_contract.py
@@ -2079,5 +2079,6 @@ async def test_non_streaming_task_metadata_matches_declared_output_contract() ->
     )
 
     task = _terminal_task(queue)
+    assert not task.status.HasField("message")
     assert task.metadata is not None
     _assert_shared_metadata_matches_streaming_contract(_task_metadata(task))

--- a/tests/package/test_release_distribution_contract.py
+++ b/tests/package/test_release_distribution_contract.py
@@ -102,7 +102,7 @@ def test_dependency_health_workflow_runs_as_a_standalone_check() -> None:
 
 
 def test_scripts_index_exposes_built_cli_smoke_test() -> None:
-    assert "doctor.sh" in SCRIPTS_README_TEXT
+    assert "doctor.sh" not in SCRIPTS_README_TEXT
     assert "conformance.sh" in SCRIPTS_README_TEXT
     assert "validate_runtime_matrix.sh" in SCRIPTS_README_TEXT
     assert "dependency_health.sh" in SCRIPTS_README_TEXT

--- a/tests/scripts/test_script_health_contract.py
+++ b/tests/scripts/test_script_health_contract.py
@@ -4,7 +4,6 @@ DEPENDENCY_HEALTH_TEXT = Path("scripts/dependency_health.sh").read_text()
 CONFORMANCE_TEXT = Path("scripts/conformance.sh").read_text()
 HEALTH_COMMON_TEXT = Path("scripts/health_common.sh").read_text()
 SCRIPTS_INDEX_TEXT = Path("scripts/README.md").read_text()
-DOCTOR_TEXT = Path("scripts/doctor.sh").read_text()
 VALIDATE_BASELINE_TEXT = Path("scripts/validate_baseline.sh").read_text()
 CHECK_DEAD_CODE_TEXT = Path("scripts/check_dead_code.py").read_text()
 AUDIT_LOW_CALL_SITES_TEXT = Path("scripts/audit_low_call_sites.py").read_text()
@@ -48,13 +47,6 @@ def test_low_call_audit_stays_manual_and_non_blocking() -> None:
     assert "No low-call-count function wrappers detected" in AUDIT_LOW_CALL_SITES_TEXT
 
 
-def test_doctor_is_thin_default_regression_alias() -> None:
-    assert 'exec bash "${SCRIPT_DIR}/validate_baseline.sh" "$@"' in DOCTOR_TEXT
-    assert "uv run pytest" not in DOCTOR_TEXT
-    assert "uv run mypy" not in DOCTOR_TEXT
-    assert "uv run pip-audit" not in DOCTOR_TEXT
-
-
 def test_conformance_keeps_external_tck_experiment_scope() -> None:
     assert "Run the official A2A TCK as a local/manual experiment." in CONFORMANCE_TEXT
     assert 'run_shared_repo_health_prerequisites "conformance"' in CONFORMANCE_TEXT
@@ -80,10 +72,9 @@ def test_dependency_health_keeps_dependency_review_scope() -> None:
 
 
 def test_scripts_index_documents_split_health_entrypoints() -> None:
-    assert "doctor.sh" in SCRIPTS_INDEX_TEXT
+    assert "doctor.sh" not in SCRIPTS_INDEX_TEXT
     assert "conformance.sh" in SCRIPTS_INDEX_TEXT
     assert "audit_low_call_sites.py" in SCRIPTS_INDEX_TEXT
-    assert "shortest maintainer entrypoint" in SCRIPTS_INDEX_TEXT
     assert "outside the default regression gate" in SCRIPTS_INDEX_TEXT
     assert "default local validation baseline used by contributors and CI" in SCRIPTS_INDEX_TEXT
     assert "standalone dependency review flow" in SCRIPTS_INDEX_TEXT

--- a/tests/server/test_agent_card.py
+++ b/tests/server/test_agent_card.py
@@ -306,6 +306,11 @@ def test_public_agent_card_minimizes_provider_private_contracts() -> None:
         ],
         "interrupt_metadata_field": "metadata.shared.interrupt",
         "request_id_field": "metadata.shared.interrupt.request_id",
+        "authorization": {
+            "transport_auth": "required",
+            "request_id_scope": "active_pending_interrupt_request",
+            "owner_validation": "session_owner_match_when_session_binding_available",
+        },
     }
 
 


### PR DESCRIPTION
## 背景

本 PR 覆盖四个相邻的 contract 收敛任务，并包含一次不新建 issue 的收尾死代码清理：

- #309：收敛 success terminal surface 中 `status.message` 的语义边界。
- #312：移除 extension URI 中的 `shared` / `private` 语义占位层，使用更扁平的 canonical URI。
- #311：在 #312 之后保留其仍有价值的 disclosure 提议，明确 `interactive-interrupt` 的 public/authenticated 披露边界。
- #313：移除本地 extension registry 的非标准 `family` 字段。
- 收尾清理：删除 `scripts/doctor.sh` 这个仅转发到 `scripts/validate_baseline.sh` 的薄壳入口。

Closes #309
Closes #311
Closes #312
Closes #313

## 变更内容

- non-stream terminal `Task` 不再把完整回答复制到 `status.message`，完整回答仅放在 `Task.artifacts`。
- review watch terminal `TaskStatusUpdateEvent` 不再携带 `Review completed.` / `Review failed.` message，终态 review payload 或错误详情保留在 final artifact update。
- 移除 non-stream success emitter 已不再需要的 `resolved_message_id` 参数传递。
- 将 extension canonical URI 从 `urn:codex-a2a:extension:{shared|private}:name:v1` 收敛为 `urn:codex-a2a:extension:name:v1`。
- 保留 registry 中的 disclosure、negotiation、OpenAPI group、taxonomy metadata，不改变 `metadata.shared.*` payload namespace。
- machine-readable wire contract 的 `extension_uris` 使用统一 `ALL_EXTENSION_URIS`；compatibility profile 的 extension retention 覆盖全部 canonical extension URI。
- 明确 `interactive-interrupt` 的 public disclosure 不表示匿名可调用；callback 方法仍要求 transport auth、active pending interrupt `request_id`，并在可用时执行 session-owner validation。
- public Agent Card / anonymous OpenAPI 仅暴露 interrupt callback 的方法别名、事件名、共享 metadata 字段和 auth/request_id scope summary；完整 method contracts、reply schemas、provider-private metadata、errors 和 runtime profile 仍保留在 authenticated extended card。
- 移除 `ExtensionContractDescriptor.family` 及 registry entries 中的 `family=...`，避免把本地自定义分类误认为 A2A SDK / wire shape 字段。
- 删除 `scripts/doctor.sh` 纯转发脚本，默认本地回归入口统一为 `scripts/validate_baseline.sh`，并同步脚本文档与契约测试。
- 更新英文文档与合约一致性测试，显式防止 `shared` / `private` URI path segment 回流，并防止 interrupt callback 公开披露面扩大。

## 相关 commits

- `b06ce6c` Refine success status message boundaries (#309)
- `bbba3bf` Remove unused non-stream message id plumbing (#309)
- `aec4898` Flatten extension URI namespace (#312)
- `8d9bf3e` Remove redundant doctor script alias
- `9fe67ee` Clarify interrupt callback disclosure boundaries (#311)
- `78238b4` Remove extension registry family field (#313)

## 评估结论

- #309 仍然有效，属于仓库 success terminal surface 语义收敛；本 PR 选择 artifact/result 优先，避免 success result 在 `status.message` 与 artifact 中重复承载。
- #312 仍然有效；URI ownership 已由 `urn:codex-a2a:*` 表达，`shared/private` 不应继续作为 URI path segment 暗示 disclosure/auth。
- #311 早于 #312 创建，其中关于 URI path 中 `shared/private` 的建议已被 #312 取代；本 PR 只保留仍有价值的部分：明确 `interactive-interrupt` 的 public/authenticated 披露边界，并用测试锁住 public minimal projection。
- #313 直接移除本地 `family` 字段；扩展分类和披露边界继续由 URI、Scope、Disclosure flags、OpenAPI group、negotiation mode、taxonomy group 和 params 表达。
- `scripts/doctor.sh` 是高确信死代码/薄壳清理对象；删除后保留 `scripts/validate_baseline.sh` 作为唯一默认回归入口。
- downstream consumer 适配由 `a2a-client-hub` issue 跟踪：https://github.com/liujuanjuan1984/a2a-client-hub/issues/913

## 验证

- `uv run pytest --no-cov tests/execution/test_codex_agent_session_binding.py tests/execution/test_review_runtime.py tests/execution/test_streaming_output_contract.py`
- `uv run pytest --no-cov tests/contracts/test_extension_contract_consistency.py tests/contracts/test_extension_registry.py tests/server/test_agent_card.py tests/server/test_transport_contract.py tests/client/test_request_context.py tests/client/test_client_manager.py tests/client/test_client_flow.py`
- `uv run pytest --no-cov tests/scripts/test_script_health_contract.py tests/package/test_release_distribution_contract.py`
- `uv run pytest --no-cov tests/contracts/test_extension_contract_consistency.py tests/contracts/test_extension_registry.py tests/server/test_agent_card.py`
- `uv run python scripts/check_dead_code.py`
- `uv run python scripts/audit_low_call_sites.py`（仅人工候选审查，未发现更多高确信清理项）
- `bash ./scripts/validate_baseline.sh`
