### PR TITLE
fix(agent-card): advertise HTTP+JSON interface URL with /v1 prefix

### DIFF
--- a/src/codex_a2a/server/agent_card.py
+++ b/src/codex_a2a/server/agent_card.py
@@ -14,6 +14,7 @@ from a2a.utils.constants import TransportProtocol
 from codex_a2a.auth import has_configured_auth_scheme
 from codex_a2a.config import Settings
 from codex_a2a.contracts.extension_registry import build_agent_card_extensions_from_registry
+from codex_a2a.contracts.extensions import REST_API_PATH_PREFIX
 from codex_a2a.media_modes import (
     DEFAULT_INPUT_MEDIA_MODES,
     DEFAULT_OUTPUT_MEDIA_MODES,
@@ -387,7 +388,13 @@ def _build_agent_card(
 
     supported_interfaces = [
         AgentInterface(
-            url=public_url,
+            # The HTTP+JSON surface lives under /v1 (REST_API_PATH_PREFIX), so
+            # the advertised interface URL must carry that prefix: A2A clients
+            # resolve REST paths relative to the advertised URL (e.g. the
+            # official JS SDK appends `/message:send` to it). Advertising the
+            # bare base URL made conforming clients call the root path, which
+            # this server does not serve.
+            url=public_url + REST_API_PATH_PREFIX,
             protocol_binding=TransportProtocol.HTTP_JSON,
             protocol_version=settings.a2a_protocol_version,
         ),

--- a/tests/server/test_agent_card.py
+++ b/tests/server/test_agent_card.py
@@ -125,11 +125,11 @@ def test_agent_card_declares_bearer_only_security() -> None:
     assert _security_requirements(card) == [{"schemes": {"bearerAuth": {}}}]
 
 
-def test_agent_card_supported_interfaces_share_same_public_url() -> None:
+def test_agent_card_http_json_interface_advertises_v1_prefix() -> None:
     card = build_agent_card(make_settings(a2a_bearer_token="test-token"))
 
     assert [interface.url for interface in card.supported_interfaces] == [
-        "http://127.0.0.1:8000",
+        "http://127.0.0.1:8000/v1",
         "http://127.0.0.1:8000",
     ]
 

--- a/tests/server/test_transport_contract.py
+++ b/tests/server/test_transport_contract.py
@@ -73,7 +73,7 @@ def test_agent_card_declares_dual_stack_with_http_json_preferred() -> None:
 
     transports = {iface.protocol_binding for iface in card.supported_interfaces}
     assert card.supported_interfaces[0].protocol_binding == TransportProtocol.HTTP_JSON
-    assert card.supported_interfaces[0].url == "http://127.0.0.1:8000"
+    assert card.supported_interfaces[0].url == "http://127.0.0.1:8000/v1"
     assert card.supported_interfaces[1].url == "http://127.0.0.1:8000"
     assert TransportProtocol.HTTP_JSON in transports
     assert TransportProtocol.JSONRPC in transports


### PR DESCRIPTION
## 关联 Issue

Closes #339

## 变更内容

- `src/codex_a2a/server/agent_card.py`：HTTP+JSON interface URL 改为 `public_url + REST_API_PATH_PREFIX`（`/v1`），避免符合规范的 A2A 客户端基于裸 base URL 请求根路径而得到 404。
- `tests/server/test_agent_card.py`：接口 URL 断言更新为 `http://127.0.0.1:8000/v1`。
- `tests/server/test_transport_contract.py`：同步更新双栈契约断言。

## 验证

- `bash ./scripts/validate_baseline.sh` 通过：pre-commit、mypy、613 项 pytest、覆盖率 85.64%（阈值 84%）、diff-cover 100%、pip-audit 无已知漏洞、wheel 构建与冒烟测试成功。
