### PR TITLE
fix(server): serve HTTP+JSON at A2A spec root instead of adapter /v1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ CODEX_WORKSPACE_ROOT=/abs/path/to/workspace uv run codex-a2a serve
 5. Inspect the discovery surfaces:
 
 - `http://127.0.0.1:8000/.well-known/agent-card.json`
-- `curl -H "Authorization: Bearer ${DEMO_BEARER_TOKEN}" http://127.0.0.1:8000/v1/card`
+- `curl -H "Authorization: Bearer ${DEMO_BEARER_TOKEN}" http://127.0.0.1:8000/extendedAgentCard`
 
 ## Validation Baseline
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Agent Card: `http://127.0.0.1:8000/.well-known/agent-card.json`
 
 Authenticated extended card:
 - JSON-RPC: `agent/getAuthenticatedExtendedCard`
-- HTTP: `GET /v1/card`
+- HTTP: `GET /extendedAgentCard`
 
 Outbound peer auth is configured with `A2A_CLIENT_BEARER_TOKEN` or `A2A_CLIENT_BASIC_AUTH`; see the Usage Guide for the complete client-side matrix.
 
@@ -138,7 +138,7 @@ Look elsewhere if:
 
 ## Highlights
 
-- A2A HTTP+JSON endpoints such as `/v1/message:send` and `/v1/message:stream`
+- A2A HTTP+JSON endpoints such as `/message:send` and `/message:stream`
 - A2A JSON-RPC support on `POST /`
 - Embedded client access through `codex-a2a call`
 - Autonomous outbound peer calls through the `a2a_call` tool

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -83,7 +83,7 @@ The current service profile is intentionally:
 
 One deployed instance should be treated as a single-tenant trust boundary, not as a secure multi-tenant runtime boundary.
 
-The supported HTTP+JSON contract is rooted at `/v1/...` only. Tenant-prefixed REST aliases such as `/{tenant}/v1/...` are intentionally not part of the supported surface for this single-tenant deployment profile.
+The supported HTTP+JSON contract is rooted at the service root (A2A 1.0 resolves REST paths from the advertised interface URL, and protocol version is negotiated via the `A2A-Version` header rather than a URL prefix). Tenant-prefixed REST aliases such as `/{tenant}/...` are intentionally not part of the supported surface for this single-tenant deployment profile.
 
 The compatibility surface distinguishes between:
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -5,14 +5,14 @@ This guide covers runtime configuration, transport contracts, streaming/session/
 ## Transport Contracts
 
 - The service supports both transports:
-  - HTTP+JSON (REST endpoints such as `/v1/message:send`)
+  - HTTP+JSON (REST endpoints such as `/message:send`)
   - Shared JSON-RPC (`POST /`) for both core A2A methods and provider-private extension methods
 - Agent Card publishes both HTTP+JSON and JSON-RPC endpoints through `supported_interfaces[]`.
-- Both supported interfaces now publish the same `public_url`. For HTTP+JSON, that URL is the REST service root; concrete REST methods remain under `/v1/...`.
+- Both supported interfaces publish the same `public_url`. For HTTP+JSON, that URL is the REST service root: per A2A 1.0 the concrete REST methods (`/message:send`, `/tasks/...`) live at that root, and the protocol version is negotiated via the `A2A-Version` header rather than a URL prefix.
 - The public Agent Card at `/.well-known/agent-card.json` is intentionally slimmed to the minimum discovery surface.
 - The authenticated extended card exposes the authenticated provider-private skill inventory and deployment-aware examples:
   - preferred: JSON-RPC `GetExtendedAgentCard`
-  - HTTP core route: `GET /v1/extendedAgentCard`
+  - HTTP core route: `GET /extendedAgentCard`
 - Anonymous shared-contract hints are available through OpenAPI metadata:
   - `GET /openapi.json`
   - `x-a2a-extension-contracts` for negotiated shared extensions and shared interrupt callback hints
@@ -20,7 +20,7 @@ This guide covers runtime configuration, transport contracts, streaming/session/
 - Agent Card responses publish `ETag` and `Cache-Control`; clients should revalidate instead of repeatedly fetching full payloads.
 - Larger discovery documents support gzip compression on these HTTP GET routes:
   - `/.well-known/agent-card.json`
-  - `GET /v1/extendedAgentCard`
+  - `GET /extendedAgentCard`
   - `GET /openapi.json`
 - Streaming and task routes do not rely on this gzip behavior.
 - Payload schema is transport-specific and should not be mixed:
@@ -48,9 +48,9 @@ Current behavior:
   - `CancelTask`
   - `SubscribeToTask`
 - core HTTP endpoints:
-  - `/v1/message:send`
-  - `/v1/message:stream`
-  - `/v1/tasks/{id}:subscribe`
+  - `/message:send`
+  - `/message:stream`
+  - `/tasks/{id}:subscribe`
 - extension JSON-RPC methods are declared separately from the core baseline even though they share the same `POST /` endpoint
 - `codex.interrupts.list` is an always-on adapter-local recovery surface for pending interrupt request IDs
 - `codex.turns.steer` becomes deployment-conditional when `A2A_ENABLE_TURN_CONTROL=false`
@@ -130,9 +130,9 @@ Current profile shape:
   - `CancelTask`
   - `SubscribeToTask`
 - core HTTP endpoints:
-  - `/v1/message:send`
-  - `/v1/message:stream`
-  - `/v1/tasks/{id}:subscribe`
+  - `/message:send`
+  - `/message:stream`
+  - `/tasks/{id}:subscribe`
 
 Retention guidance:
 
@@ -460,7 +460,7 @@ On the current npm global install layout for Linux x64, the command above resolv
 ### Session and Task Behavior
 
 - The service forwards A2A `message:send` requests and `SendMessage` JSON-RPC calls to Codex session/message flows.
-- Streaming is always enabled for this service surface. `/v1/message:stream` and JSON-RPC `SendStreamingMessage` are compatibility-sensitive core capabilities rather than deployment-time toggles.
+- Streaming is always enabled for this service surface. `/message:stream` and JSON-RPC `SendStreamingMessage` are compatibility-sensitive core capabilities rather than deployment-time toggles.
 - `codex.exec.start`, `codex.exec.write`, `codex.exec.resize`, and `codex.exec.terminate` expose a standalone interactive `command/exec` runtime when `A2A_ENABLE_EXEC_CONTROL=true`. This surface is intended for internal or tightly controlled deployments where interactive terminal control is an explicit part of the adapter contract. `codex.exec.start` returns process/task handles immediately, while stdout/stderr deltas and the final result flow through normal A2A task streaming and `SubscribeToTask`.
 - Rich input is supported on two surfaces:
   - core A2A `SendMessage` and `SendStreamingMessage` keep standard A2A parts and map `Part(text)`, image `Part(url|raw)`, and `Part(data={"type":"mention"|"skill", ...})` into Codex turn input
@@ -485,7 +485,7 @@ On the current npm global install layout for Linux x64, the command above resolv
 
 ### Streaming and Interrupt Contract
 
-- Streaming (`/v1/message:stream`) emits an initial working `Task`, then incremental `TaskArtifactUpdateEvent` / `TaskStatusUpdateEvent` updates, and finally a terminal `Task`.
+- Streaming (`/message:stream`) emits an initial working `Task`, then incremental `TaskArtifactUpdateEvent` / `TaskStatusUpdateEvent` updates, and finally a terminal `Task`.
 - If task persistence fails while processing a request, the service maps that failure to a stable failed task or failed final status instead of leaking raw task-store exceptions.
 - Those task-store failure surfaces use `metadata.codex.error` with `type=TASK_STORE_UNAVAILABLE` and an `operation` field such as `get` or `save`.
 - Stream artifacts carry `artifact.metadata.shared.stream.block_type` with values `text`, `reasoning`, and `tool_call`.
@@ -573,7 +573,7 @@ Server behavior:
 Minimal example:
 
 ```bash
-curl -sS http://127.0.0.1:8000/v1/message:send \
+curl -sS http://127.0.0.1:8000/message:send \
   -H 'content-type: application/json' \
   -H "Authorization: Bearer ${DEMO_BEARER_TOKEN}" \
   -d '{
@@ -763,7 +763,7 @@ curl -sS http://127.0.0.1:8000/ \
 The JSON-RPC result returns `task_id` and `context_id`. Then use the standard task stream:
 
 ```bash
-curl -sS http://127.0.0.1:8000/v1/tasks/<task_id>:subscribe \
+curl -sS http://127.0.0.1:8000/tasks/<task_id>:subscribe \
   -H "Authorization: Bearer ${DEMO_BEARER_TOKEN}"
 ```
 
@@ -894,7 +894,7 @@ curl -sS http://127.0.0.1:8000/ \
 The JSON-RPC result returns `task_id` and `context_id`. Then use the standard task stream:
 
 ```bash
-curl -sS http://127.0.0.1:8000/v1/tasks/<task_id>:subscribe \
+curl -sS http://127.0.0.1:8000/tasks/<task_id>:subscribe \
   -H "Authorization: Bearer ${DEMO_BEARER_TOKEN}"
 ```
 
@@ -1173,7 +1173,7 @@ curl -sS http://127.0.0.1:8000/ \
 ## Authentication Example (curl)
 
 ```bash
-curl -sS http://127.0.0.1:8000/v1/message:send \
+curl -sS http://127.0.0.1:8000/message:send \
   -H 'content-type: application/json' \
   -H "Authorization: Bearer ${DEMO_BEARER_TOKEN}" \
   -d '{
@@ -1207,7 +1207,7 @@ curl -sS http://127.0.0.1:8000/ \
 
 ## Streaming Re-Subscription (`subscribe`)
 
-If an SSE connection drops, use `GET /v1/tasks/{task_id}:subscribe` to re-subscribe while the task is still non-terminal.
+If an SSE connection drops, use `GET /tasks/{task_id}:subscribe` to re-subscribe while the task is still non-terminal.
 
 Terminal-task note:
 

--- a/docs/maintainer-architecture.md
+++ b/docs/maintainer-architecture.md
@@ -33,7 +33,7 @@ flowchart TD
 
 ### Inbound Message (Send/Stream)
 
-1.  **FastAPI Route**: `POST /v1/message:send` or `POST /v1/message:stream` (or JSON-RPC equivalent).
+1.  **FastAPI Route**: `POST /message:send` or `POST /message:stream` (or JSON-RPC equivalent).
 2.  **Handler**: Validates auth and maps transport-specific payloads into `RequestContext`.
 3.  **Executor (`CodexAgentExecutor.execute`)**:
     -   Maps A2A parts to Codex-compatible items.

--- a/src/codex_a2a/client/agent_card.py
+++ b/src/codex_a2a/client/agent_card.py
@@ -10,7 +10,7 @@ from a2a.utils.constants import AGENT_CARD_WELL_KNOWN_PATH
 from .config import A2AClientConfig
 from .errors import A2AClientConfigError
 
-EXTENDED_AGENT_CARD_PATH = "/v1/extendedAgentCard"
+EXTENDED_AGENT_CARD_PATH = "/extendedAgentCard"
 
 
 @dataclass(frozen=True)

--- a/src/codex_a2a/contracts/extension_specs.py
+++ b/src/codex_a2a/contracts/extension_specs.py
@@ -53,7 +53,7 @@ EXTENSION_SPEC_DOCUMENT_PATHS_BY_URI = MappingProxyType(
 )
 
 TASKS_RESUBSCRIBE_METHOD = "SubscribeToTask"
-TASKS_SUBSCRIBE_HTTP_ENDPOINT = "/v1/tasks/{id}:subscribe"
+TASKS_SUBSCRIBE_HTTP_ENDPOINT = "/tasks/{id}:subscribe"
 
 SHARED_SESSION_BINDING_FIELD = "metadata.shared.session.id"
 SHARED_SESSION_METADATA_FIELD = "metadata.shared.session"
@@ -822,16 +822,16 @@ INTERRUPT_INVALID_PARAMS_DATA_FIELDS: tuple[str, ...] = (
 
 CORE_JSONRPC_METHODS: tuple[str, ...] = tuple(JsonRpcDispatcher.METHOD_TO_MODEL)
 CORE_HTTP_ENDPOINTS: tuple[str, ...] = (
-    "POST /v1/message:send",
-    "POST /v1/message:stream",
-    "GET /v1/tasks",
-    "GET /v1/tasks/{id}",
-    "POST /v1/tasks/{id}:cancel",
-    "GET /v1/tasks/{id}:subscribe",
-    "GET /v1/tasks/{id}/pushNotificationConfigs",
-    "POST /v1/tasks/{id}/pushNotificationConfigs",
-    "GET /v1/tasks/{id}/pushNotificationConfigs/{push_id}",
-    "GET /v1/extendedAgentCard",
+    "POST /message:send",
+    "POST /message:stream",
+    "GET /tasks",
+    "GET /tasks/{id}",
+    "POST /tasks/{id}:cancel",
+    "GET /tasks/{id}:subscribe",
+    "GET /tasks/{id}/pushNotificationConfigs",
+    "POST /tasks/{id}/pushNotificationConfigs",
+    "GET /tasks/{id}/pushNotificationConfigs/{push_id}",
+    "GET /extendedAgentCard",
 )
 WIRE_CONTRACT_UNSUPPORTED_METHOD_DATA_FIELDS: tuple[str, ...] = (
     "method",

--- a/src/codex_a2a/contracts/extensions.py
+++ b/src/codex_a2a/contracts/extensions.py
@@ -24,12 +24,6 @@ from .extension_registry import build_extension_taxonomy_from_registry
 
 CORE_JSONRPC_PATH = "/"
 EXTENSION_JSONRPC_PATH = CORE_JSONRPC_PATH
-# A2A 1.0 locates the HTTP+JSON surface at the service root: version is
-# negotiated via the A2A-Version header, not a URL path prefix (spec 8.5.1).
-# The adapter therefore passes an empty prefix to the SDK's create_rest_routes
-# so that /message:send, /tasks/... and /extendedAgentCard are served at the
-# same root the Agent Card advertises.
-REST_API_PATH_PREFIX = ""
 
 # Explicit re-exports preserve the public contracts surface without wildcard imports.
 COMPATIBILITY_PROFILE_EXTENSION_URI = extension_specs.COMPATIBILITY_PROFILE_EXTENSION_URI
@@ -109,7 +103,10 @@ def build_wire_contract_extension_params(
             {
                 "protocol_binding": "HTTP+JSON",
                 "protocol_version": declared_protocol_version,
-                "url_path_prefix": REST_API_PATH_PREFIX,
+                # A2A 1.0 roots the HTTP+JSON surface at the interface URL;
+                # version is negotiated via the A2A-Version header (spec 8.5.1),
+                # so there is no URL path prefix to advertise.
+                "url_path_prefix": "",
             },
             {
                 "protocol_binding": "JSON-RPC",

--- a/src/codex_a2a/contracts/extensions.py
+++ b/src/codex_a2a/contracts/extensions.py
@@ -103,10 +103,6 @@ def build_wire_contract_extension_params(
             {
                 "protocol_binding": "HTTP+JSON",
                 "protocol_version": declared_protocol_version,
-                # A2A 1.0 roots the HTTP+JSON surface at the interface URL;
-                # version is negotiated via the A2A-Version header (spec 8.5.1),
-                # so there is no URL path prefix to advertise.
-                "url_path_prefix": "",
             },
             {
                 "protocol_binding": "JSON-RPC",

--- a/src/codex_a2a/contracts/extensions.py
+++ b/src/codex_a2a/contracts/extensions.py
@@ -24,7 +24,12 @@ from .extension_registry import build_extension_taxonomy_from_registry
 
 CORE_JSONRPC_PATH = "/"
 EXTENSION_JSONRPC_PATH = CORE_JSONRPC_PATH
-REST_API_PATH_PREFIX = "/v1"
+# A2A 1.0 locates the HTTP+JSON surface at the service root: version is
+# negotiated via the A2A-Version header, not a URL path prefix (spec 8.5.1).
+# The adapter therefore passes an empty prefix to the SDK's create_rest_routes
+# so that /message:send, /tasks/... and /extendedAgentCard are served at the
+# same root the Agent Card advertises.
+REST_API_PATH_PREFIX = ""
 
 # Explicit re-exports preserve the public contracts surface without wildcard imports.
 COMPATIBILITY_PROFILE_EXTENSION_URI = extension_specs.COMPATIBILITY_PROFILE_EXTENSION_URI

--- a/src/codex_a2a/protocol_versions.py
+++ b/src/codex_a2a/protocol_versions.py
@@ -17,7 +17,7 @@ PROVIDER_PRIVATE_PROTOCOL_VERSION = SUPPORTED_PROTOCOL_VERSION
 
 V1_SUPPORTED_FEATURES: tuple[str, ...] = (
     "A2A-Version request-time negotiation and response header echo.",
-    "Official A2A 1.0 JSON-RPC methods and /v1 HTTP endpoints.",
+    "Official A2A 1.0 JSON-RPC methods and spec-rooted HTTP+JSON endpoints.",
     "Unified Part(text|data|url|raw) payloads, task streaming, and protocol-aware error shaping.",
 )
 

--- a/src/codex_a2a/server/application.py
+++ b/src/codex_a2a/server/application.py
@@ -60,8 +60,10 @@ def _is_sdk_tenant_mount(route: BaseRoute) -> bool:
 
 def _create_single_tenant_rest_routes(**kwargs: Any) -> list[BaseRoute]:
     # The SDK exposes a tenant-prefixed REST alias by default. This service's
-    # supported HTTP+JSON contract is the documented single-tenant `/v1/...`
-    # surface, so the application assembly narrows the route set explicitly.
+    # supported HTTP+JSON contract is the spec-rooted single-tenant surface
+    # (A2A 1.0 resolves REST paths from the advertised interface URL, with no
+    # version prefix in the URL), so the application assembly narrows the route
+    # set explicitly.
     return [route for route in create_rest_routes(**kwargs) if not _is_sdk_tenant_mount(route)]
 
 

--- a/src/codex_a2a/server/application.py
+++ b/src/codex_a2a/server/application.py
@@ -227,7 +227,9 @@ def create_app(settings: Settings) -> FastAPI:
         _create_single_tenant_rest_routes(
             request_handler=handler,
             context_builder=context_builder,
-            path_prefix=extension_contracts.REST_API_PATH_PREFIX,
+            # A2A 1.0 roots the HTTP+JSON surface at the service root; the SDK
+            # default prefix is empty, matching the URL the Agent Card advertises.
+            path_prefix="",
         )
     )
     app.state.codex_client = client

--- a/src/codex_a2a/server/call_context.py
+++ b/src/codex_a2a/server/call_context.py
@@ -17,10 +17,10 @@ def _is_stream_request(request: Request) -> bool:
     if isinstance(raw_path, (bytes, bytearray)):
         raw_value = raw_path.decode(errors="ignore")
     return (
-        path.endswith("/v1/message:stream")
-        or path.endswith("/v1/message%3Astream")
-        or raw_value.endswith("/v1/message:stream")
-        or raw_value.endswith("/v1/message%3Astream")
+        path.endswith("/message:stream")
+        or path.endswith("/message%3Astream")
+        or raw_value.endswith("/message:stream")
+        or raw_value.endswith("/message%3Astream")
     )
 
 

--- a/src/codex_a2a/server/http_middlewares.py
+++ b/src/codex_a2a/server/http_middlewares.py
@@ -210,14 +210,28 @@ def _is_jsonrpc_path(path: str) -> bool:
     }
 
 
+def _is_rest_path(path: str) -> bool:
+    return (
+        path in _REST_MESSAGE_PATHS
+        or path in _AUTHENTICATED_EXTENDED_CARD_PATHS
+        or path == "/tasks"
+        or path.startswith("/tasks/")
+    )
+
+
 def _canonical_rest_path(path: str) -> str:
-    rest_prefix = extension_contracts.REST_API_PATH_PREFIX
-    if path == rest_prefix or path.startswith(f"{rest_prefix}/"):
+    # The HTTP+JSON surface is rooted at the service root (A2A 1.0 resolves
+    # REST paths from the advertised interface URL, with no version prefix in
+    # the URL). A single leading tenant segment from the SDK's legacy alias
+    # layout is canonicalized away for middleware classification; the route
+    # layer still rejects those aliases.
+    if _is_rest_path(path):
         return path
-    marker = f"{rest_prefix}/"
-    marker_index = path.find(marker, 1)
-    if marker_index > 0 and "/" not in path[1:marker_index]:
-        return path[marker_index:]
+    tenant_end = path.find("/", 1)
+    if tenant_end > 0 and "/" not in path[1:tenant_end]:
+        candidate = path[tenant_end:]
+        if _is_rest_path(candidate):
+            return candidate
     return path
 
 
@@ -225,7 +239,7 @@ def _requires_protocol_negotiation(request: Request) -> bool:
     path = _canonical_rest_path(request.url.path)
     if request.method == "OPTIONS":
         return False
-    return _is_jsonrpc_path(path) or path.startswith(f"{extension_contracts.REST_API_PATH_PREFIX}/")
+    return _is_jsonrpc_path(path) or _is_rest_path(path)
 
 
 def _jsonrpc_request_id(payload: dict | None) -> str | int | None:
@@ -437,10 +451,10 @@ def _install_subscribe_task_guard(app: FastAPI, *, task_store: TaskStore) -> Non
     @app.middleware("http")
     async def guard_missing_subscribe_task(request: Request, call_next):
         path = _canonical_rest_path(request.url.path)
-        if not path.startswith("/v1/tasks/") or not path.endswith(":subscribe"):
+        if not path.startswith("/tasks/") or not path.endswith(":subscribe"):
             return await call_next(request)
 
-        encoded_task_id = path.removeprefix("/v1/tasks/").removesuffix(":subscribe")
+        encoded_task_id = path.removeprefix("/tasks/").removesuffix(":subscribe")
         task_id = unquote(encoded_task_id).strip()
         if not task_id:
             return JSONResponse({"error": "Task not found"}, status_code=404)

--- a/src/codex_a2a/server/http_middlewares.py
+++ b/src/codex_a2a/server/http_middlewares.py
@@ -50,14 +50,14 @@ _PUBLIC_AGENT_CARD_PATHS = {
     "/.well-known/agent-card.json",
 }
 _AUTHENTICATED_EXTENDED_CARD_PATHS = {
-    f"{extension_contracts.REST_API_PATH_PREFIX}/extendedAgentCard",
+    "/extendedAgentCard",
 }
 _OPENAPI_PATHS = {
     "/openapi.json",
 }
 _REST_MESSAGE_PATHS = {
-    f"{extension_contracts.REST_API_PATH_PREFIX}/message:send",
-    f"{extension_contracts.REST_API_PATH_PREFIX}/message:stream",
+    "/message:send",
+    "/message:stream",
 }
 GZIP_COMPRESSIBLE_PATHS = (
     _PUBLIC_AGENT_CARD_PATHS | _AUTHENTICATED_EXTENDED_CARD_PATHS | _OPENAPI_PATHS

--- a/src/codex_a2a/server/openapi.py
+++ b/src/codex_a2a/server/openapi.py
@@ -196,7 +196,7 @@ def patch_openapi_contract(
                         }
 
             rest_post_contracts: dict[str, dict[str, Any]] = {
-                "/v1/message:send": {
+                "/message:send": {
                     "summary": "Send Message (HTTP+JSON)",
                     "description": (
                         "A2A HTTP+JSON message send endpoint. "
@@ -207,7 +207,7 @@ def patch_openapi_contract(
                         "session_binding": a2a_extension_contracts["session_binding"],
                     },
                 },
-                "/v1/message:stream": {
+                "/message:stream": {
                     "summary": "Stream Message (HTTP+JSON)",
                     "description": (
                         "A2A HTTP+JSON streaming endpoint. "
@@ -232,7 +232,7 @@ def patch_openapi_contract(
                 rest_post["description"] = contract["description"]
                 rest_post["x-a2a-extension-contracts"] = contract["contracts"]
                 rest_post.setdefault("responses", {"200": {"description": "A2A response"}})
-                if rest_path == "/v1/message:stream":
+                if rest_path == "/message:stream":
                     rest_post["x-a2a-streaming"] = a2a_extension_contracts["streaming"]
 
                 request_body = rest_post.setdefault("requestBody", {})

--- a/src/codex_a2a/server/runtime_limits.py
+++ b/src/codex_a2a/server/runtime_limits.py
@@ -128,7 +128,7 @@ def _is_capacity_managed_request(scope: Scope) -> bool:
     method = scope.get("method", "")
     path = scope.get("path", "")
     return method == "POST" or (
-        method == "GET" and path.startswith("/v1/tasks/") and path.endswith(":subscribe")
+        method == "GET" and path.startswith("/tasks/") and path.endswith(":subscribe")
     )
 
 

--- a/tests/server/test_agent_card.py
+++ b/tests/server/test_agent_card.py
@@ -12,7 +12,6 @@ from codex_a2a.contracts.extensions import (
     EXTENSION_JSONRPC_PATH,
     INTERRUPT_CALLBACK_EXTENSION_URI,
     INTERRUPT_RECOVERY_EXTENSION_URI,
-    REST_API_PATH_PREFIX,
     REVIEW_CONTROL_EXTENSION_URI,
     SESSION_BINDING_EXTENSION_URI,
     SESSION_QUERY_DEFAULT_LIMIT,
@@ -720,14 +719,8 @@ def test_authenticated_extended_agent_card_injects_profile_into_extensions() -> 
     )
     assert "GetExtendedAgentCard" in wire_contract_params["all_jsonrpc_methods"]
     assert "CreateTaskPushNotificationConfig" in wire_contract_params["all_jsonrpc_methods"]
-    assert (
-        f"POST {REST_API_PATH_PREFIX}/message:send"
-        in wire_contract_params["core"]["http_endpoints"]
-    )
-    assert (
-        f"GET {REST_API_PATH_PREFIX}/extendedAgentCard"
-        in wire_contract_params["core"]["http_endpoints"]
-    )
+    assert "POST /message:send" in wire_contract_params["core"]["http_endpoints"]
+    assert "GET /extendedAgentCard" in wire_contract_params["core"]["http_endpoints"]
     assert wire_contract_params["core"]["jsonrpc_endpoint"] == {
         "protocol_binding": "JSON-RPC",
         "protocol_version": "1.0",
@@ -742,7 +735,7 @@ def test_authenticated_extended_agent_card_injects_profile_into_extensions() -> 
         {
             "protocol_binding": "HTTP+JSON",
             "protocol_version": "1.0",
-            "url_path_prefix": REST_API_PATH_PREFIX,
+            "url_path_prefix": "",
         },
         {
             "protocol_binding": "JSON-RPC",

--- a/tests/server/test_agent_card.py
+++ b/tests/server/test_agent_card.py
@@ -735,7 +735,6 @@ def test_authenticated_extended_agent_card_injects_profile_into_extensions() -> 
         {
             "protocol_binding": "HTTP+JSON",
             "protocol_version": "1.0",
-            "url_path_prefix": "",
         },
         {
             "protocol_binding": "JSON-RPC",

--- a/tests/server/test_call_context_builder.py
+++ b/tests/server/test_call_context_builder.py
@@ -35,13 +35,13 @@ def test_builder_sets_identity_for_non_stream_request():
 
 def test_builder_marks_rest_stream_request():
     builder = IdentityAwareCallContextBuilder()
-    context = builder.build(_request("/v1/message:stream"))
+    context = builder.build(_request("/message:stream"))
     assert context.state.get("identity") == "opaque:test-id"
     assert context.state.get("a2a_streaming_request") is True
 
 
 def test_builder_marks_encoded_stream_request():
     builder = IdentityAwareCallContextBuilder()
-    context = builder.build(_request("/v1/message%3Astream", raw_path=b"/v1/message%3Astream"))
+    context = builder.build(_request("/message%3Astream", raw_path=b"/message%3Astream"))
     assert context.state.get("identity") == "opaque:test-id"
     assert context.state.get("a2a_streaming_request") is True

--- a/tests/server/test_transport_contract.py
+++ b/tests/server/test_transport_contract.py
@@ -153,8 +153,8 @@ async def test_streaming_route_uses_sdk_default_sse_keepalive() -> None:
             "http_version": "1.1",
             "method": "POST",
             "scheme": "http",
-            "path": "/v1/message:stream",
-            "raw_path": b"/v1/message:stream",
+            "path": "/message:stream",
+            "raw_path": b"/message:stream",
             "query_string": b"",
             "headers": [],
             "client": ("127.0.0.1", 12345),
@@ -399,8 +399,8 @@ def test_openapi_rest_message_routes_include_schema_examples_and_extension_contr
     paths = openapi["paths"]
 
     expected: dict[str, str] = {
-        "/v1/message:send": "#/components/schemas/SendMessageRequest",
-        "/v1/message:stream": "#/components/schemas/SendStreamingMessageRequest",
+        "/message:send": "#/components/schemas/SendMessageRequest",
+        "/message:stream": "#/components/schemas/SendStreamingMessageRequest",
     }
     for path, expected_schema_ref in expected.items():
         post = paths[path]["post"]
@@ -418,9 +418,9 @@ def test_openapi_rest_message_routes_include_schema_examples_and_extension_contr
     role_enum = openapi["components"]["schemas"]["A2AMessage"]["properties"]["role"]["enum"]
     assert role_enum == ["ROLE_UNSPECIFIED", "ROLE_USER", "ROLE_AGENT"]
 
-    stream_contract = paths["/v1/message:stream"]["post"].get("x-a2a-streaming")
+    stream_contract = paths["/message:stream"]["post"].get("x-a2a-streaming")
     assert isinstance(stream_contract, dict)
-    assert paths["/v1/message:stream"]["post"].get("x-codex-contracts") is None
+    assert paths["/message:stream"]["post"].get("x-codex-contracts") is None
 
     root_contracts = paths[CORE_JSONRPC_PATH]["post"].get("x-a2a-extension-contracts")
     assert isinstance(root_contracts, dict)
@@ -492,10 +492,10 @@ async def test_agent_card_routes_split_public_and_authenticated_extended_contrac
         assert public_cached.status_code == 304
         assert public_cached.headers["vary"] == "Accept-Encoding"
 
-        unauthorized_extended = await client.get("/v1/extendedAgentCard")
+        unauthorized_extended = await client.get("/extendedAgentCard")
         assert unauthorized_extended.status_code == 401
 
-        extended_card = await client.get("/v1/extendedAgentCard", headers=headers)
+        extended_card = await client.get("/extendedAgentCard", headers=headers)
         assert extended_card.status_code == 200
         assert extended_card.headers["cache-control"] == AUTHENTICATED_EXTENDED_CARD_CACHE_CONTROL
         assert {
@@ -504,7 +504,7 @@ async def test_agent_card_routes_split_public_and_authenticated_extended_contrac
         assert extended_card.headers["etag"]
 
         extended_cached = await client.get(
-            "/v1/extendedAgentCard",
+            "/extendedAgentCard",
             headers={
                 **headers,
                 "If-None-Match": extended_card.headers["etag"],
@@ -557,7 +557,7 @@ async def test_targeted_gzip_applies_to_card_and_openapi_routes(monkeypatch) -> 
             headers={"Accept-Encoding": "gzip"},
         )
         extended_card = await client.get(
-            "/v1/extendedAgentCard",
+            "/extendedAgentCard",
             headers={
                 "Authorization": "Bearer test-token",
                 "Accept-Encoding": "gzip",
@@ -755,7 +755,7 @@ async def test_authenticated_extended_card_accepts_basic_auth(monkeypatch) -> No
 
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
         response = await client.get(
-            "/v1/extendedAgentCard",
+            "/extendedAgentCard",
             headers=_basic_auth_header("operator", "op-pass"),
         )
 
@@ -1391,7 +1391,7 @@ async def test_subscribe_task_store_failure_returns_controlled_503(monkeypatch) 
     headers = {"Authorization": "Bearer test-token"}
 
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
-        response = await client.get("/v1/tasks/task-broken:subscribe", headers=headers)
+        response = await client.get("/tasks/task-broken:subscribe", headers=headers)
 
     assert response.status_code == 503
     assert response.json() == {"error": "Task store unavailable while loading task state."}
@@ -1434,7 +1434,7 @@ async def test_log_payloads_keeps_body_for_rest_handler(monkeypatch, caplog) -> 
     with caplog.at_level(logging.DEBUG, logger="codex_a2a.server.http_middlewares"):
         async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
             resp = await client.post(
-                "/v1/message:send",
+                "/message:send",
                 headers=headers,
                 json=_rest_message_payload(),
             )
@@ -1442,7 +1442,7 @@ async def test_log_payloads_keeps_body_for_rest_handler(monkeypatch, caplog) -> 
             assert resp.status_code == 200
 
     assert any(
-        "A2A request POST /v1/message:send body=" in record.message for record in caplog.records
+        "A2A request POST /message:send body=" in record.message for record in caplog.records
     )
 
 
@@ -1458,7 +1458,7 @@ async def test_log_payloads_streaming_response_path(monkeypatch, caplog) -> None
     with caplog.at_level(logging.DEBUG, logger="codex_a2a.server.http_middlewares"):
         async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
             async with client.stream(
-                "POST", "/v1/message:stream", headers=headers, json=_rest_message_payload()
+                "POST", "/message:stream", headers=headers, json=_rest_message_payload()
             ) as resp:
                 assert resp.status_code == 200
                 assert "text/event-stream" in resp.headers.get("content-type", "")
@@ -1467,8 +1467,8 @@ async def test_log_payloads_streaming_response_path(monkeypatch, caplog) -> None
                         break
 
     assert any(
-        "A2A response /v1/message:stream status=200" in record.message
-        or "A2A response /v1/message:stream streaming" in record.message
+        "A2A response /message:stream status=200" in record.message
+        or "A2A response /message:stream streaming" in record.message
         for record in caplog.records
     )
 
@@ -1618,7 +1618,7 @@ async def test_request_logs_reuse_supplied_correlation_id(monkeypatch, caplog) -
     with caplog.at_level(logging.DEBUG):
         async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
             response = await client.post(
-                "/v1/message:send",
+                "/message:send",
                 headers=headers,
                 json=_rest_message_payload(),
             )
@@ -1665,7 +1665,7 @@ async def test_request_logs_generate_correlation_id_for_stream_requests(
         async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
             async with client.stream(
                 "POST",
-                "/v1/message:stream",
+                "/message:stream",
                 headers=headers,
                 json=_rest_message_payload(),
             ) as response:

--- a/tests/server/test_transport_contract.py
+++ b/tests/server/test_transport_contract.py
@@ -22,7 +22,6 @@ from codex_a2a.contracts.extensions import (
     EXTENSION_JSONRPC_PATH,
     INTERRUPT_CALLBACK_EXTENSION_URI,
     INTERRUPT_RECOVERY_EXTENSION_URI,
-    REST_API_PATH_PREFIX,
     REVIEW_CONTROL_EXTENSION_URI,
     SESSION_BINDING_EXTENSION_URI,
     SESSION_QUERY_EXTENSION_URI,
@@ -88,12 +87,12 @@ def test_rest_subscription_route_matches_current_sdk_contract() -> None:
     assert "/health" in route_paths
     assert "/ready" in route_paths
     assert "/metrics" in route_paths
-    assert f"{REST_API_PATH_PREFIX}/tasks/{{id}}:subscribe" in route_paths
-    assert f"{REST_API_PATH_PREFIX}/tasks/{{id}}:resubscribe" not in route_paths
-    assert f"{REST_API_PATH_PREFIX}/extendedAgentCard" in route_paths
+    assert "/tasks/{id}:subscribe" in route_paths
+    assert "/tasks/{id}:resubscribe" not in route_paths
+    assert "/extendedAgentCard" in route_paths
     assert "/{tenant}" not in route_paths
     assert "/agent/authenticatedExtendedCard" not in route_paths
-    assert f"{REST_API_PATH_PREFIX}/card" not in route_paths
+    assert "/card" not in route_paths
 
 
 def test_health_route_can_be_disabled() -> None:
@@ -864,7 +863,7 @@ async def test_dual_stack_send_accepts_transport_native_payloads(monkeypatch) ->
 
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
         rest_resp = await client.post(
-            f"{REST_API_PATH_PREFIX}/message:send",
+            "/message:send",
             headers=headers,
             json=rest_payload,
         )
@@ -899,7 +898,7 @@ async def test_tenant_prefixed_rest_message_route_is_not_supported(monkeypatch) 
 
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
         response = await client.post(
-            f"/acme{REST_API_PATH_PREFIX}/message:send",
+            "/acme/message:send",
             headers=headers,
             json=_rest_message_payload(),
         )
@@ -918,7 +917,7 @@ async def test_tenant_prefixed_extended_card_route_is_not_supported(monkeypatch)
 
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
         response = await client.get(
-            f"/acme{REST_API_PATH_PREFIX}/extendedAgentCard",
+            "/acme/extendedAgentCard",
             headers=headers,
         )
 
@@ -936,8 +935,27 @@ async def test_tenant_subscribe_route_is_not_supported(monkeypatch) -> None:
 
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
         response = await client.get(
-            f"/acme{REST_API_PATH_PREFIX}/tasks/task-missing:subscribe",
+            "/acme/tasks/task-missing:subscribe",
             headers=headers,
+        )
+
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_legacy_v1_prefixed_rest_route_is_not_served(monkeypatch) -> None:
+    import codex_a2a.server.application as app_module
+
+    monkeypatch.setattr(app_module, "CodexClient", DummyChatCodexClient)
+    app = app_module.create_app(make_settings(a2a_bearer_token="test-token"))
+    transport = httpx.ASGITransport(app=app)
+    headers = {"Authorization": "Bearer test-token"}
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/v1/message:send",
+            headers=headers,
+            json=_rest_message_payload(),
         )
 
     assert response.status_code == 404
@@ -1171,7 +1189,7 @@ async def test_rest_unsupported_v1_protocol_version_uses_protocol_error_shape(
 
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
         response = await client.post(
-            f"{REST_API_PATH_PREFIX}/message:send",
+            "/message:send",
             headers=headers,
             json=_rest_message_payload(),
         )
@@ -1230,14 +1248,14 @@ async def test_dual_stack_send_rejects_cross_transport_payload_shapes(monkeypatc
 
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
         rest_resp = await client.post(
-            f"{REST_API_PATH_PREFIX}/message:send",
+            "/message:send",
             headers=headers,
             json=rest_with_legacy_shape,
         )
         assert rest_resp.status_code == 400
 
         rest_envelope_resp = await client.post(
-            f"{REST_API_PATH_PREFIX}/message:send",
+            "/message:send",
             headers=headers,
             json=full_jsonrpc_envelope,
         )
@@ -1348,7 +1366,7 @@ async def test_subscribe_missing_task_returns_controlled_404(monkeypatch) -> Non
 
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
         response = await client.get(
-            f"{REST_API_PATH_PREFIX}/tasks/task-missing:subscribe",
+            "/tasks/task-missing:subscribe",
             headers=headers,
         )
 


### PR DESCRIPTION
## 关联 Issue

Closes #339

## 背景

验证结论：`/v1` 不是 A2A 1.0 协议要求，也不是 a2a-sdk 的默认行为，而是本 adapter 自己的设计选择。A2A 1.0 的规范路径是根路径（如 `POST /message:send`），版本通过 `A2A-Version` header 协商（spec §8.5.1）；Python SDK 的 `create_rest_routes(path_prefix='')` 默认即根路径。此前服务端把 REST 路由挂在 `/v1`，Agent Card 却广告裸 `public_url`，导致符合规范的客户端（如官方 @a2a-js/sdk）按卡片 URL 拼出 `/message:send` 请求根路径而 404。

## 变更内容（commits: 4ecc96d、5c8d98a、5118387）

- `src/codex_a2a/server/application.py`：向 SDK 传入空 path_prefix，REST 路由回到规范根路径 `/message:send`、`/tasks/...`、`/extendedAgentCard`；继续过滤 SDK 的 `/{tenant}` 别名挂载。
- `src/codex_a2a/server/http_middlewares.py`：REST 路径判定改为显式根路径形状匹配（协议协商、扩展卡片缓存、订阅守卫），不再依赖前缀变量。
- `src/codex_a2a/server/call_context.py`、`runtime_limits.py`、`openapi.py`：流请求识别、容量管理、OpenAPI 补丁路径同步到根路径。
- `src/codex_a2a/contracts/extension_specs.py`、`extensions.py`、`protocol_versions.py`：wire contract 的 HTTP 端点改为根路径；移除 `REST_API_PATH_PREFIX` 空常量与 `transport_interfaces` 中恒为空的 `url_path_prefix` 字段，避免“半参数化”与冗余信息。
- `src/codex_a2a/client/agent_card.py`：`EXTENDED_AGENT_CARD_PATH` 改为 `/extendedAgentCard`。
- 测试：全量断言与示例改为根路径；新增回归测试断言 `/v1/message:send` 不再提供服务（404）。
- 文档（README、CONTRIBUTING、guide、compatibility、maintainer-architecture）：同步为根路径，全仓库无 `/v1` 与 `url_path_prefix` 引用。

## 验证

- `bash ./scripts/validate_baseline.sh` 通过：pre-commit、mypy、614 项 pytest、覆盖率 85.64%、diff-cover 100%、pip-audit 无已知漏洞、wheel 构建与冒烟测试成功。
- 修复后：Agent Card 广告裸 `public_url`，`POST /message:send` 返回 200；`/v1/...` 不再提供服务。

## 关联

- 取代方向错误的 #340（已关闭）。
- Closes #339。
