### PR TITLE
fix(client): enforce outbound A2A network policy and credential binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Authenticated extended card:
 - JSON-RPC: `agent/getAuthenticatedExtendedCard`
 - HTTP: `GET /extendedAgentCard`
 
-Outbound peer auth is configured with `A2A_CLIENT_BEARER_TOKEN` or `A2A_CLIENT_BASIC_AUTH`; see the Usage Guide for the complete client-side matrix.
+Outbound peer auth is configured with `A2A_CLIENT_BEARER_TOKEN` or `A2A_CLIENT_BASIC_AUTH`; credentials are only sent to hosts listed in `A2A_CLIENT_ALLOWED_HOSTS`. The embedded `a2a_call(...)` tool also rejects private/loopback targets unless `A2A_CLIENT_ALLOW_PRIVATE_HOSTS=true`; see the Usage Guide for the complete client-side matrix.
 
 ## When To Use It
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -217,6 +217,18 @@ These settings affect peer calls made through `codex-a2a call` or the embedded `
 - `A2A_CLIENT_SUPPORTED_TRANSPORTS`: comma-separated outbound transport preference list, default `JSONRPC,HTTP+JSON`
 - `A2A_CLIENT_BEARER_TOKEN`: optional bearer token for the target peer service
 - `A2A_CLIENT_BASIC_AUTH`: optional Basic auth credential for the target peer service when bearer auth is not configured
+- `A2A_CLIENT_ALLOWED_HOSTS`: comma-separated allowlist of outbound target hosts for `a2a_call(...)` (exact names or `*.example.com` wildcards). When configured, outbound calls are restricted to matching hosts, and outbound credentials (`A2A_CLIENT_BEARER_TOKEN` / `A2A_CLIENT_BASIC_AUTH`) are only sent to allowlisted hosts.
+- `A2A_CLIENT_ALLOW_PRIVATE_HOSTS`: default `false`. When `false`, outbound `a2a_call(...)` targets that resolve to private, loopback, link-local, reserved, or multicast addresses are rejected (SSRF / DNS-rebinding guard). Set to `true` only when the deployment intentionally targets A2A peers on the local network.
+
+### Outbound Network Policy
+
+The embedded `a2a_call(...)` tool lets the upstream model choose the target URL, so the adapter applies a fail-closed network policy before opening any connection:
+
+- only `http`/`https` schemes are accepted, and URLs carrying userinfo credentials are rejected;
+- when `A2A_CLIENT_ALLOWED_HOSTS` is set, the target host must match the allowlist (exact or `*.example.com` wildcard);
+- unless `A2A_CLIENT_ALLOW_PRIVATE_HOSTS=true`, the resolved addresses must be public; private/loopback/link-local/reserved addresses are rejected even when the hostname matches the allowlist (DNS rebinding defense);
+- outbound credentials are only attached to allowlisted hosts. If credentials are configured without an allowlist, they are never sent and a warning is logged;
+- the `codex-a2a call` CLI remains a manual operator action and is not subject to the allowlist, but still rejects non-http(s) schemes through the shared client URL handling.
 
 ### Upstream Codex Configuration
 
@@ -302,6 +314,8 @@ These variables are forwarded to the local `codex app-server` subprocess.
 | `A2A_CLIENT_CARD_FETCH_TIMEOUT_SECONDS` | Card fetch timeout |
 | `A2A_CLIENT_USE_CLIENT_PREFERENCE` | Transport preference |
 | `A2A_CLIENT_SUPPORTED_TRANSPORTS` | Supported transports |
+| `A2A_CLIENT_ALLOWED_HOSTS` | Outbound host allowlist (SSRF / credential binding) |
+| `A2A_CLIENT_ALLOW_PRIVATE_HOSTS` | Allow private/loopback outbound targets |
 | `A2A_INTERRUPT_REQUEST_TTL_SECONDS` | Interrupt TTL |
 | `A2A_EXECUTION_SANDBOX_MODE` | Discovery sandbox mode |
 | `A2A_EXECUTION_SANDBOX_FILESYSTEM_SCOPE` | Discovery FS scope |

--- a/src/codex_a2a/client/manager.py
+++ b/src/codex_a2a/client/manager.py
@@ -3,13 +3,17 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 
 from codex_a2a.config import Settings
 from codex_a2a.contracts import extensions as extension_contracts
 
 from .client import A2AClient
 from .config import A2AClientConfig
+from .network_policy import validate_agent_url
 from .request_context import build_default_headers
+
+logger = logging.getLogger(__name__)
 
 
 class A2AClientManager:
@@ -30,6 +34,23 @@ class A2AClientManager:
         normalized = agent_url.rstrip("/")
         if not normalized:
             raise ValueError("agent_url is required")
+        policy = await validate_agent_url(
+            normalized,
+            allowed_hosts=self._settings.a2a_client_allowed_hosts,
+            allow_private_hosts=self._settings.a2a_client_allow_private_hosts,
+        )
+        default_headers: dict[str, str] = {}
+        if policy.credentials_allowed:
+            default_headers = build_default_headers(
+                self._settings.a2a_client_bearer_token,
+                self._settings.a2a_client_basic_auth,
+            )
+        elif self._settings.a2a_client_bearer_token or self._settings.a2a_client_basic_auth:
+            logger.warning(
+                "Outbound A2A credentials are configured but host=%s is not in "
+                "A2A_CLIENT_ALLOWED_HOSTS; credentials will not be sent",
+                policy.host,
+            )
         async with self._lock:
             client = self._clients.get(normalized)
             if client is not None:
@@ -40,10 +61,7 @@ class A2AClientManager:
                     request_timeout_seconds=self._settings.a2a_client_timeout_seconds,
                     card_fetch_timeout_seconds=self._settings.a2a_client_card_fetch_timeout_seconds,
                     use_client_preference=self._settings.a2a_client_use_client_preference,
-                    default_headers=build_default_headers(
-                        self._settings.a2a_client_bearer_token,
-                        self._settings.a2a_client_basic_auth,
-                    ),
+                    default_headers=default_headers,
                     supported_transports=list(self._settings.a2a_client_supported_transports),
                     accepted_output_modes=["text/plain"],
                     extensions=[

--- a/src/codex_a2a/client/network_policy.py
+++ b/src/codex_a2a/client/network_policy.py
@@ -1,0 +1,156 @@
+"""Outbound A2A client network policy (SSRF guard and credential binding).
+
+The A2A client is used by the ``a2a_call`` tool, where the target URL is
+produced by the upstream model.  Without an explicit policy this creates a
+server-side request forgery surface: the adapter would happily connect to
+private/loopback/link-local addresses (cloud metadata, internal services) and
+would attach globally configured outbound credentials to any endpoint.
+
+This module centralizes the checks:
+
+- only ``http``/``https`` schemes are accepted;
+- userinfo credentials in the URL are rejected;
+- when ``A2A_CLIENT_ALLOWED_HOSTS`` is configured, the host must match the
+  allowlist (exact or ``*.example.com`` wildcard);
+- unless ``A2A_CLIENT_ALLOW_PRIVATE_HOSTS`` is set, DNS resolution results are
+  validated and private/loopback/link-local/reserved addresses are rejected
+  (this also defends against DNS rebinding at connect time);
+- outbound credentials may only be attached to hosts that match the allowlist.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import ipaddress
+import logging
+import socket
+from collections.abc import Sequence
+from dataclasses import dataclass
+from urllib.parse import urlsplit
+
+logger = logging.getLogger(__name__)
+
+_ALLOWED_SCHEMES = frozenset({"http", "https"})
+
+_Address = ipaddress.IPv4Address | ipaddress.IPv6Address
+
+
+class A2ANetworkPolicyError(ValueError):
+    """Raised when an outbound agent URL violates the network policy."""
+
+
+@dataclass(frozen=True)
+class NetworkPolicyDecision:
+    """Outcome of validating an outbound agent URL."""
+
+    host: str
+    allowed_host: bool
+    credentials_allowed: bool
+
+
+def matches_allowed_host(host: str, allowed_hosts: Sequence[str]) -> bool:
+    """Return whether ``host`` matches an allowlist entry.
+
+    Entries may be exact hostnames or ``*.example.com`` wildcards.  A wildcard
+    matches any number of subdomain labels but never the bare apex domain.
+    """
+
+    normalized = (host or "").strip().lower().rstrip(".")
+    if not normalized:
+        return False
+    for raw_entry in allowed_hosts or ():
+        entry = (raw_entry or "").strip().lower().rstrip(".")
+        if not entry:
+            continue
+        if entry.startswith("*."):
+            suffix = entry[1:]  # ".example.com"
+            apex = suffix[1:]  # "example.com"
+            if normalized != apex and normalized.endswith(suffix):
+                return True
+        elif normalized == entry:
+            return True
+    return False
+
+
+def _is_private_address(address: _Address) -> bool:
+    return bool(
+        address.is_private
+        or address.is_loopback
+        or address.is_link_local
+        or address.is_reserved
+        or address.is_multicast
+        or address.is_unspecified
+    )
+
+
+async def resolve_host_addresses(host: str) -> tuple[str, ...]:
+    """Resolve ``host`` to a de-duplicated tuple of IP address strings."""
+
+    loop = asyncio.get_running_loop()
+    try:
+        infos = await loop.getaddrinfo(host, None, type=socket.SOCK_STREAM)
+    except socket.gaierror as exc:
+        raise A2ANetworkPolicyError(f"Agent URL host could not be resolved: {host!r}") from exc
+    addresses: list[str] = []
+    for info in infos:
+        ip = str(info[4][0])
+        if ip not in addresses:
+            addresses.append(ip)
+    return tuple(addresses)
+
+
+async def validate_agent_url(
+    agent_url: str,
+    *,
+    allowed_hosts: Sequence[str] | None = None,
+    allow_private_hosts: bool = False,
+) -> NetworkPolicyDecision:
+    """Validate an outbound agent URL against the configured network policy."""
+
+    normalized = (agent_url or "").strip()
+    if not normalized:
+        raise A2ANetworkPolicyError("agent_url is required")
+
+    parsed = urlsplit(normalized)
+    scheme = (parsed.scheme or "").lower()
+    if scheme not in _ALLOWED_SCHEMES:
+        raise A2ANetworkPolicyError(
+            f"Agent URL scheme must be http or https, got {scheme or 'empty'}"
+        )
+    host = (parsed.hostname or "").strip().lower()
+    if not host:
+        raise A2ANetworkPolicyError("Agent URL must include a host")
+    if parsed.username or parsed.password:
+        raise A2ANetworkPolicyError("Agent URL must not include userinfo credentials")
+
+    allowlist = tuple(
+        (item or "").strip().lower().rstrip(".")
+        for item in allowed_hosts or ()
+        if (item or "").strip()
+    )
+    matched = matches_allowed_host(host, allowlist)
+    if allowlist and not matched:
+        raise A2ANetworkPolicyError(
+            f"Agent URL host {host!r} is not allowed by A2A_CLIENT_ALLOWED_HOSTS"
+        )
+
+    if not allow_private_hosts:
+        try:
+            addresses = await resolve_host_addresses(host)
+        except A2ANetworkPolicyError:
+            raise
+        except OSError as exc:
+            raise A2ANetworkPolicyError(f"Agent URL host could not be resolved: {host!r}") from exc
+        private = [
+            address for address in addresses if _is_private_address(ipaddress.ip_address(address))
+        ]
+        if private:
+            raise A2ANetworkPolicyError(
+                f"Agent URL host {host!r} resolves to a private/loopback address: {private[0]}"
+            )
+
+    return NetworkPolicyDecision(
+        host=host,
+        allowed_host=matched,
+        credentials_allowed=bool(allowlist) and matched,
+    )

--- a/src/codex_a2a/config.py
+++ b/src/codex_a2a/config.py
@@ -386,6 +386,14 @@ class Settings(BaseSettings):
         default_factory=lambda: ["JSONRPC", "HTTP+JSON"],
         alias="A2A_CLIENT_SUPPORTED_TRANSPORTS",
     )
+    a2a_client_allowed_hosts: Annotated[list[str], NoDecode] = Field(
+        default_factory=list,
+        alias="A2A_CLIENT_ALLOWED_HOSTS",
+    )
+    a2a_client_allow_private_hosts: bool = Field(
+        default=False,
+        alias="A2A_CLIENT_ALLOW_PRIVATE_HOSTS",
+    )
     a2a_interrupt_request_ttl_seconds: int = Field(
         default=3600,
         alias="A2A_INTERRUPT_REQUEST_TTL_SECONDS",
@@ -459,6 +467,7 @@ class Settings(BaseSettings):
         "codex_sandbox_workspace_write_writable_roots",
         "a2a_execution_sandbox_writable_roots",
         "a2a_execution_network_allowed_domains",
+        "a2a_client_allowed_hosts",
         mode="before",
     )
     @classmethod

--- a/tests/client/test_client_manager.py
+++ b/tests/client/test_client_manager.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from codex_a2a.client import A2AClientConfig, A2AClientManager
+from codex_a2a.client.network_policy import A2ANetworkPolicyError
 from codex_a2a.contracts.extensions import SESSION_BINDING_EXTENSION_URI, STREAMING_EXTENSION_URI
 from tests.support.settings import make_settings
 
@@ -26,13 +27,26 @@ class _Factory:
         return client
 
 
+def _patch_public_dns(monkeypatch: pytest.MonkeyPatch, *addresses: str) -> None:
+    async def fake_resolve(host: str) -> tuple[str, ...]:
+        del host
+        return tuple(addresses)
+
+    monkeypatch.setattr(
+        "codex_a2a.client.network_policy.resolve_host_addresses",
+        fake_resolve,
+    )
+
+
 @pytest.mark.asyncio
-async def test_manager_normalizes_config_and_transports() -> None:
+async def test_manager_normalizes_config_and_transports(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_public_dns(monkeypatch, "93.184.216.34")
     settings = make_settings(
         a2a_client_timeout_seconds=41.0,
         a2a_client_card_fetch_timeout_seconds=7.0,
         a2a_client_use_client_preference=True,
         a2a_client_bearer_token="peer-token",
+        a2a_client_allowed_hosts=("peer.example.com",),
         a2a_client_supported_transports=("http-json", "json-rpc"),
     )
     factory = _Factory()
@@ -51,9 +65,13 @@ async def test_manager_normalizes_config_and_transports() -> None:
 
 
 @pytest.mark.asyncio
-async def test_manager_uses_basic_auth_when_bearer_is_absent() -> None:
+async def test_manager_uses_basic_auth_when_bearer_is_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_public_dns(monkeypatch, "93.184.216.34")
     settings = make_settings(
         a2a_client_basic_auth="user:pass",
+        a2a_client_allowed_hosts=("peer.example.com",),
     )
     factory = _Factory()
     manager = A2AClientManager(settings, client_factory=factory)
@@ -63,7 +81,51 @@ async def test_manager_uses_basic_auth_when_bearer_is_absent() -> None:
 
 
 @pytest.mark.asyncio
-async def test_manager_caches_client_by_normalized_url() -> None:
+async def test_manager_does_not_send_credentials_without_allowlist(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_public_dns(monkeypatch, "93.184.216.34")
+    settings = make_settings(
+        a2a_client_bearer_token="peer-token",
+    )
+    factory = _Factory()
+    manager = A2AClientManager(settings, client_factory=factory)
+    client = await manager.get_client("https://peer.example.com/")
+
+    assert client.config.default_headers == {}
+
+
+@pytest.mark.asyncio
+async def test_manager_rejects_host_outside_allowlist(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_public_dns(monkeypatch, "93.184.216.34")
+    settings = make_settings(
+        a2a_client_allowed_hosts=("peer.example.com",),
+    )
+    manager = A2AClientManager(settings, client_factory=_Factory())
+
+    with pytest.raises(A2ANetworkPolicyError, match="not allowed"):
+        await manager.get_client("https://other.org/")
+
+
+@pytest.mark.asyncio
+async def test_manager_rejects_private_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_public_dns(monkeypatch, "169.254.169.254")
+    settings = make_settings()
+    manager = A2AClientManager(settings, client_factory=_Factory())
+
+    with pytest.raises(A2ANetworkPolicyError, match="private/loopback"):
+        await manager.get_client("https://peer.example.com/")
+
+
+@pytest.mark.asyncio
+async def test_manager_caches_client_by_normalized_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_public_dns(monkeypatch, "93.184.216.34")
     settings = make_settings()
     factory = _Factory()
     manager = A2AClientManager(settings, client_factory=factory)

--- a/tests/client/test_network_policy.py
+++ b/tests/client/test_network_policy.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import socket
+
+import pytest
+
+from codex_a2a.client.network_policy import (
+    A2ANetworkPolicyError,
+    matches_allowed_host,
+    validate_agent_url,
+)
+
+
+def test_matches_allowed_host_exact_and_wildcard() -> None:
+    assert matches_allowed_host("peer.example.com", ["peer.example.com"])
+    assert matches_allowed_host("a.example.com", ["*.example.com"])
+    assert matches_allowed_host("b.a.example.com", ["*.example.com"])
+    assert not matches_allowed_host("example.com", ["*.example.com"])
+    assert not matches_allowed_host("other.org", ["*.example.com"])
+    assert not matches_allowed_host("evil-example.com", ["*.example.com"])
+    assert not matches_allowed_host("", ["peer.example.com"])
+
+
+def _patch_public_dns(monkeypatch: pytest.MonkeyPatch, *addresses: str) -> None:
+    async def fake_resolve(host: str) -> tuple[str, ...]:
+        del host
+        return tuple(addresses)
+
+    monkeypatch.setattr(
+        "codex_a2a.client.network_policy.resolve_host_addresses",
+        fake_resolve,
+    )
+
+
+@pytest.mark.asyncio
+async def test_validate_rejects_non_http_schemes(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_public_dns(monkeypatch, "93.184.216.34")
+
+    with pytest.raises(A2ANetworkPolicyError, match="scheme"):
+        await validate_agent_url("file:///etc/passwd")
+    with pytest.raises(A2ANetworkPolicyError, match="scheme"):
+        await validate_agent_url("ftp://peer.example.com/")
+    with pytest.raises(A2ANetworkPolicyError, match="scheme"):
+        await validate_agent_url("peer.example.com/path")
+
+
+@pytest.mark.asyncio
+async def test_validate_rejects_missing_host_and_userinfo(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_public_dns(monkeypatch, "93.184.216.34")
+
+    with pytest.raises(A2ANetworkPolicyError, match="host"):
+        await validate_agent_url("https:///path")
+    with pytest.raises(A2ANetworkPolicyError, match="userinfo"):
+        await validate_agent_url(
+            "https://user:pass@peer.example.com/"  # pragma: allowlist secret
+        )
+
+
+@pytest.mark.asyncio
+async def test_validate_rejects_host_outside_allowlist(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_public_dns(monkeypatch, "93.184.216.34")
+
+    with pytest.raises(A2ANetworkPolicyError, match="not allowed"):
+        await validate_agent_url(
+            "https://other.org/",
+            allowed_hosts=["peer.example.com"],
+        )
+
+
+@pytest.mark.asyncio
+async def test_validate_accepts_allowlisted_public_host(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_public_dns(monkeypatch, "93.184.216.34")
+
+    decision = await validate_agent_url(
+        "https://peer.example.com/",
+        allowed_hosts=["*.example.com"],
+    )
+    assert decision.host == "peer.example.com"
+    assert decision.allowed_host is True
+    assert decision.credentials_allowed is True
+
+
+@pytest.mark.parametrize(
+    "address",
+    [
+        "127.0.0.1",
+        "10.0.0.1",
+        "169.254.169.254",
+        "192.168.1.1",
+        "172.16.0.1",
+        "0.0.0.0",
+        "::1",
+        "fd00::1",
+        "fe80::1",
+    ],
+)
+@pytest.mark.asyncio
+async def test_validate_rejects_private_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+    address: str,
+) -> None:
+    _patch_public_dns(monkeypatch, address)
+
+    with pytest.raises(A2ANetworkPolicyError, match="private/loopback"):
+        await validate_agent_url("https://peer.example.com/")
+
+
+@pytest.mark.asyncio
+async def test_allow_private_hosts_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_public_dns(monkeypatch, "127.0.0.1")
+
+    decision = await validate_agent_url(
+        "https://127.0.0.1:8000/",
+        allow_private_hosts=True,
+    )
+    assert decision.credentials_allowed is False
+
+
+@pytest.mark.asyncio
+async def test_validate_rejects_dns_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_resolve(host: str) -> tuple[str, ...]:
+        del host
+        raise socket.gaierror("no such host")
+
+    monkeypatch.setattr(
+        "codex_a2a.client.network_policy.resolve_host_addresses",
+        fake_resolve,
+    )
+
+    with pytest.raises(A2ANetworkPolicyError, match="could not be resolved"):
+        await validate_agent_url("https://peer.example.com/")

--- a/tests/client/test_network_policy.py
+++ b/tests/client/test_network_policy.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import socket
 
 import pytest
@@ -7,18 +8,65 @@ import pytest
 from codex_a2a.client.network_policy import (
     A2ANetworkPolicyError,
     matches_allowed_host,
+    resolve_host_addresses,
     validate_agent_url,
 )
 
 
 def test_matches_allowed_host_exact_and_wildcard() -> None:
+    assert not matches_allowed_host("", ["peer.example.com"])
+    assert not matches_allowed_host(None, ["peer.example.com"])
+    assert matches_allowed_host("peer.example.com", ["", "peer.example.com"])
     assert matches_allowed_host("peer.example.com", ["peer.example.com"])
     assert matches_allowed_host("a.example.com", ["*.example.com"])
     assert matches_allowed_host("b.a.example.com", ["*.example.com"])
     assert not matches_allowed_host("example.com", ["*.example.com"])
     assert not matches_allowed_host("other.org", ["*.example.com"])
     assert not matches_allowed_host("evil-example.com", ["*.example.com"])
-    assert not matches_allowed_host("", ["peer.example.com"])
+
+
+@pytest.mark.asyncio
+async def test_resolve_host_addresses_resolves_localhost() -> None:
+    addresses = await resolve_host_addresses("localhost")
+
+    assert addresses
+    assert all(address for address in addresses)
+
+
+@pytest.mark.asyncio
+async def test_resolve_host_addresses_deduplicates(monkeypatch: pytest.MonkeyPatch) -> None:
+    loop = asyncio.get_running_loop()
+    infos = [
+        (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 0)),
+        (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 0)),
+        (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.35", 0)),
+    ]
+
+    async def fake_getaddrinfo(*args: object, **kwargs: object) -> list[tuple]:
+        del args, kwargs
+        return infos
+
+    monkeypatch.setattr(loop, "getaddrinfo", fake_getaddrinfo)
+
+    addresses = await resolve_host_addresses("peer.example.com")
+
+    assert addresses == ("93.184.216.34", "93.184.216.35")
+
+
+@pytest.mark.asyncio
+async def test_resolve_host_addresses_rejects_dns_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    loop = asyncio.get_running_loop()
+
+    async def fake_getaddrinfo(*args: object, **kwargs: object) -> list[tuple]:
+        del args, kwargs
+        raise socket.gaierror("no such host")
+
+    monkeypatch.setattr(loop, "getaddrinfo", fake_getaddrinfo)
+
+    with pytest.raises(A2ANetworkPolicyError, match="could not be resolved"):
+        await resolve_host_addresses("peer.example.com")
 
 
 def _patch_public_dns(monkeypatch: pytest.MonkeyPatch, *addresses: str) -> None:
@@ -42,6 +90,14 @@ async def test_validate_rejects_non_http_schemes(monkeypatch: pytest.MonkeyPatch
         await validate_agent_url("ftp://peer.example.com/")
     with pytest.raises(A2ANetworkPolicyError, match="scheme"):
         await validate_agent_url("peer.example.com/path")
+
+
+@pytest.mark.asyncio
+async def test_validate_rejects_empty_url() -> None:
+    with pytest.raises(A2ANetworkPolicyError, match="agent_url is required"):
+        await validate_agent_url("")
+    with pytest.raises(A2ANetworkPolicyError, match="agent_url is required"):
+        await validate_agent_url("   ")
 
 
 @pytest.mark.asyncio
@@ -134,4 +190,21 @@ async def test_validate_rejects_dns_failure(monkeypatch: pytest.MonkeyPatch) -> 
     )
 
     with pytest.raises(A2ANetworkPolicyError, match="could not be resolved"):
+        await validate_agent_url("https://peer.example.com/")
+
+
+@pytest.mark.asyncio
+async def test_validate_propagates_resolver_policy_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_resolve(host: str) -> tuple[str, ...]:
+        del host
+        raise A2ANetworkPolicyError("resolver blocked")
+
+    monkeypatch.setattr(
+        "codex_a2a.client.network_policy.resolve_host_addresses",
+        fake_resolve,
+    )
+
+    with pytest.raises(A2ANetworkPolicyError, match="resolver blocked"):
         await validate_agent_url("https://peer.example.com/")


### PR DESCRIPTION
## 关联 Issue

- Closes #342
- Relates to #331（#331 审计拆解出的最高危项）

## 背景

`a2a_call` 工具允许上游模型选择出站目标 URL。原实现无 URL 白名单或私网地址校验，且全局出站凭据（`A2A_CLIENT_BEARER_TOKEN` / `A2A_CLIENT_BASIC_AUTH`）会随请求自动附加到任意端点，形成 SSRF 与凭据外泄风险。

## 变更内容

- 新增 `src/codex_a2a/client/network_policy.py`：出站 URL 网络策略
  - 仅允许 `http`/`https`，拒绝携带 userinfo 的 URL；
  - 配置 `A2A_CLIENT_ALLOWED_HOSTS` 后，目标 host 必须命中白名单（支持 `*.example.com` 通配符）；
  - 默认（`A2A_CLIENT_ALLOW_PRIVATE_HOSTS=false`）拒绝解析为私网/环回/链路本地/保留/组播地址的目标（DNS rebinding 防线）；
  - 返回凭据发放决策：仅白名单命中 host 可携带出站凭据。
- `src/codex_a2a/client/manager.py`：`get_client` 在创建/复用客户端前执行策略校验；未配置白名单时凭据 fail-closed（记录 warning），不再发送到任意端点。
- `src/codex_a2a/config.py`：新增 `A2A_CLIENT_ALLOWED_HOSTS`、`A2A_CLIENT_ALLOW_PRIVATE_HOSTS`。
- 测试：`tests/client/test_network_policy.py`（scheme/私网/白名单/凭据绑定/DNS 失败，diff-cover 100%），并更新 `tests/client/test_client_manager.py` 适配新语义。
- 文档：`docs/guide.md` 说明新配置与安全默认；明确 `codex-a2a call` CLI 为人工操作、不受白名单约束但共享 URL 处理。

## 验证

- `bash ./scripts/validate_baseline.sh` 通过（pre-commit、mypy、全量 pytest、diff-cover 100%、pip-audit、wheel 构建与冒烟）。
- CI：Validation Baseline 与 Runtime Matrix（Python 3.11/3.12/3.14）全部通过。

## 行为变更说明

- 默认（未配置白名单）且配置了出站凭据时，出站凭据将不再自动发送（fail-closed），需配置 `A2A_CLIENT_ALLOWED_HOSTS` 后才会发送。
- 默认拒绝解析为私网/环回地址的出站目标；内网 A2A 对端需显式设置 `A2A_CLIENT_ALLOW_PRIVATE_HOSTS=true`（仍受白名单约束）。
