### PR TITLE
chore: harden SQLite persistence file permissions, ownership, and symlink checks

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -193,6 +193,25 @@ Use the grouped sections below as the deployment-first reading order:
 - `A2A_DATABASE_URL` also owns the adapter-managed runtime-state schema lifecycle. On startup, `codex-a2a` auto-creates the runtime-state tables, records a schema version for the `runtime_state` scope, and applies in-place migrations for those tables only.
 - The adapter-managed runtime-state schema is limited to `a2a_session_bindings`, `a2a_session_owners`, `a2a_pending_session_claims`, `a2a_pending_interrupt_requests`, and `a2a_schema_version`. It does not own the A2A SDK task-store tables or any upstream Codex/provider-local state.
 - For deployment-specific durability constraints and migration-scope boundaries, see [compatibility.md](./compatibility.md).
+
+### SQLite Persistence Hardening
+
+File-backed SQLite databases are hardened at startup and on every new connection on POSIX systems:
+
+- the database file must be a regular file; symlinks are rejected and fail startup;
+- the file must be owned by the user running `codex-a2a`; a database owned by another user fails startup;
+- the database file is forced to mode `0600`, and existing SQLite sidecar files (`-wal`/`-shm`/`-journal`) are converged to the same mode;
+- the parent directory is created with mode `0700` when it does not exist; keep the `.codex-a2a` directory private (no group/world access);
+- if the database is replaced by a symlink, a special file, or a foreign-owned file while the service is running, the next connection fails closed.
+
+`A2A_DATABASE_URL` values that do not map to a plain file path are exempt: `:memory:` and `file:` URI-style database components (including in-memory shared-cache databases) are not hardened. Prefer a plain absolute file path for deployments that need the startup guarantees. Non-POSIX platforms rely on the user account ACLs of the hosting directory; the same private-directory requirement applies there.
+
+Deployment requirements:
+
+- run `codex-a2a` as a dedicated user and keep the database directory outside world-readable workspace trees;
+- do not place the SQLite file on network-mounted or sync-managed directories;
+- when migrating an existing database, fix ownership and mode before startup: `chown <service-user> <db>` and `chmod 600 <db>`, and ensure the parent directory is not group/world accessible.
+
 - `A2A_LOG_LEVEL`: `DEBUG/INFO/WARNING/ERROR`, default `WARNING`
 - `A2A_LOG_PAYLOADS`: log A2A/Codex payload bodies, default `false`
 - `A2A_LOG_BODY_LIMIT`: payload log body size limit, default `0` (no truncation)

--- a/src/codex_a2a/server/database.py
+++ b/src/codex_a2a/server/database.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import os
+import stat
+from functools import partial
 from pathlib import Path
 from typing import Any
 
@@ -12,9 +15,96 @@ from codex_a2a.config import Settings
 _SQLITE_JOURNAL_MODE = "WAL"
 _SQLITE_BUSY_TIMEOUT_MS = 30_000
 _SQLITE_SYNCHRONOUS_MODE = "NORMAL"
+_SQLITE_FILE_MODE = 0o600
+_SQLITE_DIR_MODE = 0o700
 
 
-def _configure_sqlite_connection(dbapi_connection: Any, _connection_record: Any) -> None:
+def _sqlite_database_path(database_url: str) -> Path | None:
+    """Return the filesystem path of a file-backed SQLite database URL.
+
+    Memory databases (``:memory:`` and in-memory ``file:`` URIs) are exempt
+    from filesystem hardening and return ``None``. The returned path is
+    absolute but does not resolve symlinks, so the final path component can
+    still be validated as a regular file.
+    """
+    database_path = make_url(database_url).database
+    if not database_path or database_path == ":memory:" or database_path.startswith("file:"):
+        return None
+    return Path(os.path.abspath(database_path))
+
+
+def _create_private_sqlite_file(path: Path) -> None:
+    flags = os.O_CREAT | os.O_EXCL | os.O_RDWR | getattr(os, "O_NOFOLLOW", 0)
+    fd = os.open(path, flags, _SQLITE_FILE_MODE)
+    try:
+        os.fchmod(fd, _SQLITE_FILE_MODE)
+    finally:
+        os.close(fd)
+
+
+def _hardened_sqlite_stat(path: Path) -> os.stat_result | None:
+    try:
+        return path.lstat()
+    except FileNotFoundError:
+        return None
+
+
+def _verify_sqlite_file_stat(path: Path, file_stat: os.stat_result) -> None:
+    if stat.S_ISLNK(file_stat.st_mode):
+        raise RuntimeError(
+            f"Refusing SQLite database path {path}: symlink is not allowed; "
+            "use a private regular file."
+        )
+    if not stat.S_ISREG(file_stat.st_mode):
+        raise RuntimeError(f"Refusing SQLite database path {path}: expected a regular file.")
+    if file_stat.st_uid != os.geteuid():
+        raise RuntimeError(
+            f"Refusing SQLite database path {path}: owned by uid {file_stat.st_uid}, "
+            f"expected {os.geteuid()}."
+        )
+
+
+def _apply_private_sqlite_modes(path: Path) -> None:
+    os.chmod(path, _SQLITE_FILE_MODE)
+    for suffix in ("-wal", "-shm", "-journal"):
+        sidecar = Path(str(path) + suffix)
+        sidecar_stat = _hardened_sqlite_stat(sidecar)
+        if sidecar_stat is None:
+            continue
+        if stat.S_ISLNK(sidecar_stat.st_mode) or not stat.S_ISREG(sidecar_stat.st_mode):
+            raise RuntimeError(
+                f"Refusing SQLite sidecar file {sidecar}: expected a regular file, "
+                "not a symlink or special file."
+            )
+        os.chmod(sidecar, _SQLITE_FILE_MODE)
+
+
+def _harden_sqlite_file(path: Path) -> None:
+    """Fail-closed POSIX hardening for a file-backed SQLite database."""
+    path.parent.mkdir(parents=True, exist_ok=True, mode=_SQLITE_DIR_MODE)
+    if os.name != "posix":
+        return
+    file_stat = _hardened_sqlite_stat(path)
+    if file_stat is None:
+        try:
+            _create_private_sqlite_file(path)
+        except FileExistsError:
+            pass
+        file_stat = _hardened_sqlite_stat(path)
+        if file_stat is None:
+            raise RuntimeError(f"Failed to create SQLite database file at {path}.")
+    _verify_sqlite_file_stat(path, file_stat)
+    _apply_private_sqlite_modes(path)
+
+
+def _configure_sqlite_connection(
+    dbapi_connection: Any,
+    _connection_record: Any,
+    *,
+    database_path: Path | None = None,
+) -> None:
+    if database_path is not None:
+        _harden_sqlite_file(database_path)
     cursor = dbapi_connection.cursor()
     try:
         cursor.execute(f"PRAGMA journal_mode={_SQLITE_JOURNAL_MODE}")
@@ -30,18 +120,20 @@ def build_database_engine(settings: Settings) -> AsyncEngine:
         raise ValueError("A2A_DATABASE_URL is required to build a database engine")
 
     url = make_url(database_url)
+    sqlite_path: Path | None = None
     if url.drivername.startswith("sqlite"):
-        database_path = url.database
-        if database_path and database_path != ":memory:" and not database_path.startswith("file:"):
-            path = Path(database_path)
-            if not path.is_absolute():
-                path = (Path.cwd() / path).resolve()
-            path.parent.mkdir(parents=True, exist_ok=True)
+        sqlite_path = _sqlite_database_path(database_url)
+        if sqlite_path is not None:
+            _harden_sqlite_file(sqlite_path)
 
     engine = create_async_engine(
         database_url,
         pool_pre_ping=not url.drivername.startswith("sqlite"),
     )
     if url.drivername.startswith("sqlite"):
-        event.listen(engine.sync_engine, "connect", _configure_sqlite_connection)
+        event.listen(
+            engine.sync_engine,
+            "connect",
+            partial(_configure_sqlite_connection, database_path=sqlite_path),
+        )
     return engine

--- a/src/codex_a2a/server/database.py
+++ b/src/codex_a2a/server/database.py
@@ -76,6 +76,11 @@ def _apply_private_sqlite_modes(path: Path) -> None:
                 f"Refusing SQLite sidecar file {sidecar}: expected a regular file, "
                 "not a symlink or special file."
             )
+        if sidecar_stat.st_uid != os.geteuid():
+            raise RuntimeError(
+                f"Refusing SQLite sidecar file {sidecar}: owned by uid "
+                f"{sidecar_stat.st_uid}, expected {os.geteuid()}."
+            )
         os.chmod(sidecar, _SQLITE_FILE_MODE)
 
 

--- a/tests/server/test_database.py
+++ b/tests/server/test_database.py
@@ -184,3 +184,40 @@ async def test_build_database_engine_rejects_symlink_wal_sidecar(tmp_path) -> No
 
     with pytest.raises(RuntimeError, match="sidecar"):
         build_database_engine(_settings_for(tmp_path))
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX file permission semantics")
+def test_apply_private_sqlite_modes_rejects_foreign_owned_sidecar(tmp_path, monkeypatch) -> None:
+    database_path = tmp_path / "runtime.db"
+    database_path.write_bytes(b"")
+    sidecar = tmp_path / "runtime.db-wal"
+    sidecar.write_bytes(b"")
+
+    current_euid = os.geteuid()
+    monkeypatch.setattr(database_module.os, "geteuid", lambda: current_euid + 100_000)
+
+    with pytest.raises(RuntimeError, match="owned by uid"):
+        database_module._apply_private_sqlite_modes(database_path)
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX file permission semantics")
+@pytest.mark.asyncio
+async def test_build_database_engine_rechecks_hardening_on_new_connection(tmp_path) -> None:
+    settings = _settings_for(tmp_path)
+    engine = build_database_engine(settings)
+    try:
+        async with engine.connect() as conn:
+            await conn.exec_driver_sql("CREATE TABLE sample (value INTEGER)")
+        await engine.dispose()
+
+        victim = tmp_path / "victim.db"
+        victim.write_bytes(b"")
+        database_path = tmp_path / "runtime.db"
+        database_path.unlink()
+        database_path.symlink_to(victim)
+
+        with pytest.raises(RuntimeError, match="symlink"):
+            async with engine.connect() as conn:
+                await conn.exec_driver_sql("SELECT 1")
+    finally:
+        await engine.dispose()

--- a/tests/server/test_database.py
+++ b/tests/server/test_database.py
@@ -1,9 +1,21 @@
 from __future__ import annotations
 
+import os
+import stat
+from pathlib import Path
+
 import pytest
 
+from codex_a2a.server import database as database_module
 from codex_a2a.server.database import build_database_engine
 from tests.support.settings import make_settings
+
+
+def _settings_for(tmp_path: Path, name: str = "runtime.db"):
+    return make_settings(
+        a2a_bearer_token="test-token",
+        a2a_database_url=f"sqlite+aiosqlite:///{tmp_path / name}",
+    )
 
 
 @pytest.mark.asyncio
@@ -25,3 +37,150 @@ async def test_build_database_engine_configures_sqlite_pragmas(tmp_path) -> None
     assert str(journal_mode).lower() == "wal"
     assert int(busy_timeout) == 30_000
     assert int(synchronous) == 1
+
+
+@pytest.mark.asyncio
+async def test_build_database_engine_skips_hardening_for_memory_database() -> None:
+    settings = make_settings(
+        a2a_bearer_token="test-token",
+        a2a_database_url="sqlite+aiosqlite:///:memory:",
+    )
+    engine = build_database_engine(settings)
+    try:
+        async with engine.connect() as conn:
+            assert (await conn.exec_driver_sql("SELECT 1")).scalar_one() == 1
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_build_database_engine_skips_hardening_for_inline_memory_file_uri() -> None:
+    settings = make_settings(
+        a2a_bearer_token="test-token",
+        a2a_database_url="sqlite+aiosqlite:///file:memdb_shared?mode=memory&cache=shared&uri=true",
+    )
+    engine = build_database_engine(settings)
+    try:
+        async with engine.connect() as conn:
+            assert (await conn.exec_driver_sql("SELECT 1")).scalar_one() == 1
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX file permission semantics")
+def test_build_database_engine_creates_private_database_file_and_directory(tmp_path) -> None:
+    database_dir = tmp_path / "private"
+    database_path = database_dir / "runtime.db"
+    settings = make_settings(
+        a2a_bearer_token="test-token",
+        a2a_database_url=f"sqlite+aiosqlite:///{database_path}",
+    )
+
+    build_database_engine(settings)
+
+    assert database_path.is_file()
+    assert stat.S_IMODE(database_path.stat().st_mode) == 0o600
+    assert stat.S_IMODE(database_dir.stat().st_mode) == 0o700
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX file permission semantics")
+def test_build_database_engine_hardens_existing_database_file(tmp_path) -> None:
+    database_path = tmp_path / "runtime.db"
+    database_path.write_bytes(b"")
+    database_path.chmod(0o644)
+
+    build_database_engine(_settings_for(tmp_path))
+
+    assert stat.S_IMODE(database_path.stat().st_mode) == 0o600
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX file permission semantics")
+def test_build_database_engine_rejects_symlink_database(tmp_path) -> None:
+    target = tmp_path / "target.db"
+    target.write_bytes(b"")
+    link = tmp_path / "runtime.db"
+    link.symlink_to(target)
+
+    with pytest.raises(RuntimeError, match="symlink"):
+        build_database_engine(_settings_for(tmp_path))
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX file permission semantics")
+def test_build_database_engine_rejects_symlink_for_relative_database_url(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    target = tmp_path / "target.db"
+    target.write_bytes(b"")
+    Path("runtime.db").symlink_to(target)
+
+    with pytest.raises(RuntimeError, match="symlink"):
+        build_database_engine(
+            make_settings(
+                a2a_bearer_token="test-token",
+                a2a_database_url="sqlite+aiosqlite:///runtime.db",
+            )
+        )
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX file permission semantics")
+def test_build_database_engine_rejects_foreign_owner_database(tmp_path, monkeypatch) -> None:
+    database_path = tmp_path / "runtime.db"
+    database_path.write_bytes(b"")
+
+    current_euid = os.geteuid()
+    monkeypatch.setattr(database_module.os, "geteuid", lambda: current_euid + 100_000)
+
+    with pytest.raises(RuntimeError, match="owned by uid"):
+        build_database_engine(_settings_for(tmp_path))
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX file permission semantics")
+def test_build_database_engine_rejects_directory_database_path(tmp_path) -> None:
+    (tmp_path / "runtime.db").mkdir()
+
+    with pytest.raises(RuntimeError, match="regular file"):
+        build_database_engine(_settings_for(tmp_path))
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX file permission semantics")
+@pytest.mark.asyncio
+async def test_build_database_engine_converges_wal_sidecar_modes(tmp_path) -> None:
+    settings = _settings_for(tmp_path)
+    engine = build_database_engine(settings)
+    try:
+        async with engine.connect() as conn:
+            await conn.exec_driver_sql("CREATE TABLE sample (value INTEGER)")
+            await conn.exec_driver_sql("INSERT INTO sample VALUES (1)")
+    finally:
+        await engine.dispose()
+
+    database_path = tmp_path / "runtime.db"
+    for suffix in ("", "-wal", "-shm"):
+        sidecar = Path(f"{database_path}{suffix}")
+        if sidecar.exists():
+            assert stat.S_IMODE(sidecar.stat().st_mode) == 0o600
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX file permission semantics")
+@pytest.mark.asyncio
+async def test_build_database_engine_rejects_symlink_wal_sidecar(tmp_path) -> None:
+    settings = _settings_for(tmp_path)
+    engine = build_database_engine(settings)
+    try:
+        async with engine.connect() as conn:
+            await conn.exec_driver_sql("CREATE TABLE sample (value INTEGER)")
+            await conn.exec_driver_sql("INSERT INTO sample VALUES (1)")
+    finally:
+        await engine.dispose()
+
+    target = tmp_path / "target-wal.db"
+    target.write_bytes(b"")
+    wal_sidecar = Path(f"{tmp_path / 'runtime.db'}-wal")
+    if wal_sidecar.exists():
+        wal_sidecar.unlink()
+    wal_sidecar.symlink_to(target)
+
+    with pytest.raises(RuntimeError, match="sidecar"):
+        build_database_engine(_settings_for(tmp_path))


### PR DESCRIPTION
Closes #345
Relates to #331

## 背景

#331 安全审计拆解项：SQLite 持久化缺少文件权限/ownership/symlink 加固。当前 `main` 上 `build_database_engine` 仅配置 PRAGMA 与创建父目录，无文件级防护。实现与 opencode-a2a 同源对齐（https://github.com/Intelligent-Internet/opencode-a2a/pull/507 ）。

## 相关 commits

- `326ab79` chore: harden SQLite persistence file permissions and symlink checks (#345)
- `2e370eb` fix: reject foreign-owned SQLite sidecar files and add recheck coverage (#345)

## 验收标准对照

- [x] 启动时校验 DB 文件为普通文件（拒绝 symlink）、owner 为运行用户
- [x] 文件权限收紧（0600）并在文档说明
- [x] 提供 DB 目录私有化部署要求文档（`docs/guide.md` "SQLite Persistence Hardening"）
- [x] 新增针对 symlink/权限的启动校验测试（`tests/server/test_database.py`，13 项）

## 改动

- 启动加固（`src/codex_a2a/server/database.py`）：
  - 拒绝 symlink/特殊文件作为 DB 路径（基于未 resolve 路径的 `lstat` 校验，避免 `Path.resolve()` 跟随最终组件掩盖 symlink）；
  - 校验 DB 文件 owner 为运行用户（POSIX `st_uid == os.geteuid()`），失败即 fail-closed；
  - 文件强制 `0600`，父目录创建时 `0700`；既有 `-wal`/`-shm`/`-journal` sidecar 做类型与 owner 双重校验并收敛为 `0600`（防止预置异主 sidecar 文件窃取明文 WAL 数据）；
  - 首次启动文件不存在时以 `O_CREAT|O_EXCL|O_NOFOLLOW` 私有创建；
  - 每次新连接复检（connect hook），运行中被替换为 symlink/异主文件也会 fail-closed。
- 测试：symlink 拒绝（含相对路径回归）、owner 不匹配、目录路径、0600/0700 收敛、WAL sidecar 权限与 symlink/异主 sidecar 拒绝、运行期替换后新连接复检、`:memory:`/内存 `file:` URI 豁免、PRAGMA 回归。
- 文档：`docs/guide.md` 新增 "SQLite Persistence Hardening" 小节（私有化部署要求、迁移处置步骤）。

## 范围边界

- 仅对普通文件路径 DB 生效；`:memory:` 与 `file:` URI 风格组件豁免（文档已注明，建议生产使用普通绝对路径）。
- Windows 无 POSIX owner/symlink 语义，依赖宿主目录 ACL，文档已说明。
- `docs/inspection/` 决策记录待 #331 收尾时统一补齐。

## 验证

- `bash ./scripts/validate_baseline.sh` 通过：pre-commit、dead-code、mypy、650 tests（覆盖率 85.84%）、diff-cover 91.8%（≥90%）、pip-audit 无已知漏洞、wheel 构建与 CLI smoke 通过。
