### PR TITLE
feat(server): enforce per-credential rate limits and streaming budgets (#347)

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -217,6 +217,8 @@ Deployment requirements:
 - `A2A_LOG_BODY_LIMIT`: payload log body size limit, default `0` (no truncation)
 - `A2A_REQUEST_BODY_MAX_BYTES`: hard HTTP request body limit, default `4194304` (4 MiB); set `0` to disable
 - `A2A_MAX_CONCURRENT_OPERATIONS`: process-local active POST and task-subscription limit, default `32`; set `0` to disable
+- `A2A_RATE_LIMIT_ENABLED` / `A2A_RATE_LIMIT_WINDOW_SECONDS` / `A2A_RATE_LIMIT_MAX_REQUESTS`: per-credential sliding-window rate limiting (per-peer-IP for the unauthenticated Agent Card surface). Defaults: `true` / `60` seconds / `120` requests. Exceeding the window returns HTTP `429` with a `Retry-After` header; `A2A_RATE_LIMIT_ENABLED=false` disables the limiter. The limiter is process-local; multi-process deployments should place a shared gateway in front or rely on per-instance limits.
+- `A2A_STREAM_MAX_BYTES` / `A2A_STREAM_MAX_DURATION_SECONDS` / `A2A_STREAM_IDLE_TIMEOUT_SECONDS`: streaming (SSE) response budgets for total serialized bytes, total duration, and idle gap. Defaults: `67108864` bytes / `3600` seconds / `120` seconds; `0` disables the respective budget. When a budget is exceeded the server ends the stream with an SSE `event: error` frame; if the very first event already exceeds the budget, REST requests are rejected with HTTP `429` `RESOURCE_EXHAUSTED` before the SSE stream starts.
 - `A2A_ENABLE_METRICS_ENDPOINT`: enable the authenticated Prometheus `/metrics` endpoint, default `true`
 - `A2A_TITLE`: agent name, default `Codex A2A`
 - `A2A_DESCRIPTION`: agent description exposed on Agent Card and docs surfaces
@@ -312,6 +314,12 @@ These variables are forwarded to the local `codex app-server` subprocess.
 | `A2A_LOG_BODY_LIMIT` | Body log limit |
 | `A2A_REQUEST_BODY_MAX_BYTES` | HTTP request body limit |
 | `A2A_MAX_CONCURRENT_OPERATIONS` | Active operation capacity |
+| `A2A_RATE_LIMIT_ENABLED` | Sliding-window rate limiter toggle |
+| `A2A_RATE_LIMIT_WINDOW_SECONDS` | Rate-limit window length |
+| `A2A_RATE_LIMIT_MAX_REQUESTS` | Max requests per window per key |
+| `A2A_STREAM_MAX_BYTES` | Streaming byte budget |
+| `A2A_STREAM_MAX_DURATION_SECONDS` | Streaming duration budget |
+| `A2A_STREAM_IDLE_TIMEOUT_SECONDS` | Streaming idle timeout |
 | `A2A_TITLE` | Agent title |
 | `A2A_DESCRIPTION` | Agent description |
 | `A2A_VERSION` | Agent version |

--- a/src/codex_a2a/config.py
+++ b/src/codex_a2a/config.py
@@ -345,6 +345,27 @@ class Settings(BaseSettings):
         default=32,
         alias="A2A_MAX_CONCURRENT_OPERATIONS",
     )
+    a2a_rate_limit_enabled: bool = Field(default=True, alias="A2A_RATE_LIMIT_ENABLED")
+    a2a_rate_limit_window_seconds: float = Field(
+        default=60.0,
+        alias="A2A_RATE_LIMIT_WINDOW_SECONDS",
+    )
+    a2a_rate_limit_max_requests: int = Field(
+        default=120,
+        alias="A2A_RATE_LIMIT_MAX_REQUESTS",
+    )
+    a2a_stream_max_bytes: int = Field(
+        default=64 * 1024 * 1024,
+        alias="A2A_STREAM_MAX_BYTES",
+    )
+    a2a_stream_max_duration_seconds: float = Field(
+        default=3600.0,
+        alias="A2A_STREAM_MAX_DURATION_SECONDS",
+    )
+    a2a_stream_idle_timeout_seconds: float = Field(
+        default=120.0,
+        alias="A2A_STREAM_IDLE_TIMEOUT_SECONDS",
+    )
     a2a_documentation_url: str | None = Field(default=None, alias="A2A_DOCUMENTATION_URL")
     a2a_allow_directory_override: bool = Field(default=True, alias="A2A_ALLOW_DIRECTORY_OVERRIDE")
     a2a_host: str = Field(default="127.0.0.1", alias="A2A_HOST")
@@ -458,6 +479,31 @@ class Settings(BaseSettings):
     def validate_stream_idle_diagnostic_seconds(cls, value: float) -> float:
         if value <= 0:
             raise ValueError("A2A_STREAM_IDLE_DIAGNOSTIC_SECONDS must be > 0")
+        return value
+
+    @field_validator("a2a_rate_limit_window_seconds")
+    @classmethod
+    def validate_rate_limit_window_seconds(cls, value: float) -> float:
+        if value <= 0:
+            raise ValueError("A2A_RATE_LIMIT_WINDOW_SECONDS must be > 0")
+        return value
+
+    @field_validator("a2a_rate_limit_max_requests")
+    @classmethod
+    def validate_rate_limit_max_requests(cls, value: int) -> int:
+        if value <= 0:
+            raise ValueError("A2A_RATE_LIMIT_MAX_REQUESTS must be > 0")
+        return value
+
+    @field_validator(
+        "a2a_stream_max_bytes",
+        "a2a_stream_max_duration_seconds",
+        "a2a_stream_idle_timeout_seconds",
+    )
+    @classmethod
+    def validate_stream_budget_values(cls, value: int | float) -> int | float:
+        if value < 0:
+            raise ValueError("A2A stream budgets must be >= 0")
         return value
 
     @field_validator("a2a_interrupt_request_ttl_seconds")

--- a/src/codex_a2a/jsonrpc/application.py
+++ b/src/codex_a2a/jsonrpc/application.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import AsyncGenerator
 from typing import Any
 
 from a2a.server.jsonrpc_models import InvalidParamsError, JSONRPCError
@@ -28,6 +29,7 @@ from codex_a2a.jsonrpc.session_query import handle_session_query_request
 from codex_a2a.jsonrpc.thread_lifecycle_control import handle_thread_lifecycle_control_request
 from codex_a2a.jsonrpc.turn_control import handle_turn_control_request
 from codex_a2a.protocol_versions import get_current_protocol_version
+from codex_a2a.server.runtime_limits import apply_stream_budget
 from codex_a2a.upstream.client import CodexClient
 
 
@@ -45,6 +47,9 @@ def create_extension_jsonrpc_routes(
     guard_hooks: SessionGuardHooks,
     rpc_url: str,
     dispatcher_factory=None,
+    stream_budget_max_bytes: int = 0,
+    stream_budget_max_duration_seconds: float = 0.0,
+    stream_budget_idle_timeout_seconds: float = 0.0,
 ) -> list[Route]:
     factory = dispatcher_factory or CodexSessionQueryJSONRPCApplication
     dispatcher = factory(
@@ -58,6 +63,9 @@ def create_extension_jsonrpc_routes(
         methods=methods,
         supported_methods=supported_methods,
         guard_hooks=guard_hooks,
+        stream_budget_max_bytes=stream_budget_max_bytes,
+        stream_budget_max_duration_seconds=stream_budget_max_duration_seconds,
+        stream_budget_idle_timeout_seconds=stream_budget_idle_timeout_seconds,
     )
     return [
         Route(
@@ -82,6 +90,9 @@ class CodexSessionQueryJSONRPCApplication(JsonRpcDispatcher):
         methods: dict[str, str],
         supported_methods: list[str],
         guard_hooks: SessionGuardHooks,
+        stream_budget_max_bytes: int = 0,
+        stream_budget_max_duration_seconds: float = 0.0,
+        stream_budget_idle_timeout_seconds: float = 0.0,
         **kwargs: Any,
     ) -> None:
         super().__init__(*args, **kwargs)
@@ -119,7 +130,21 @@ class CodexSessionQueryJSONRPCApplication(JsonRpcDispatcher):
         self._supported_methods = list(supported_methods)
         self._method_registry = ExtensionMethodRegistry.from_methods(methods)
         self._guard_hooks = guard_hooks
+        self._stream_budget_max_bytes = stream_budget_max_bytes
+        self._stream_budget_max_duration_seconds = stream_budget_max_duration_seconds
+        self._stream_budget_idle_timeout_seconds = stream_budget_idle_timeout_seconds
         self._validate_guard_hooks()
+
+    def _create_response(self, context: Any, handler_result: Any) -> Any:
+        """Apply streaming output budgets before the SDK serializes SSE events."""
+        if isinstance(handler_result, AsyncGenerator):
+            handler_result = apply_stream_budget(
+                handler_result,
+                max_bytes=self._stream_budget_max_bytes,
+                max_duration_seconds=self._stream_budget_max_duration_seconds,
+                idle_timeout_seconds=self._stream_budget_idle_timeout_seconds,
+            )
+        return super()._create_response(context, handler_result)
 
     def _validate_guard_hooks(self) -> None:
         if self._guard_hooks.session_owner_matcher is None:

--- a/src/codex_a2a/metrics.py
+++ b/src/codex_a2a/metrics.py
@@ -11,6 +11,8 @@ INTERRUPT_RESOLVED_TOTAL = "interrupt_resolved_total"
 A2A_REQUEST_BODY_REJECTED_TOTAL = "a2a_request_body_rejected_total"
 A2A_OPERATION_REJECTED_TOTAL = "a2a_operation_rejected_total"
 A2A_OPERATION_ACTIVE = "a2a_operation_active"
+A2A_RATE_LIMIT_REJECTED_TOTAL = "a2a_rate_limit_rejected_total"
+A2A_STREAM_BUDGET_REJECTED_TOTAL = "a2a_stream_budget_rejected_total"
 
 _COUNTER_NAMES = (
     A2A_STREAM_REQUESTS_TOTAL,
@@ -20,6 +22,8 @@ _COUNTER_NAMES = (
     INTERRUPT_RESOLVED_TOTAL,
     A2A_REQUEST_BODY_REJECTED_TOTAL,
     A2A_OPERATION_REJECTED_TOTAL,
+    A2A_RATE_LIMIT_REJECTED_TOTAL,
+    A2A_STREAM_BUDGET_REJECTED_TOTAL,
 )
 _GAUGE_NAMES = (A2A_STREAM_ACTIVE, A2A_OPERATION_ACTIVE)
 _METRIC_HELP = {
@@ -32,6 +36,8 @@ _METRIC_HELP = {
     A2A_REQUEST_BODY_REJECTED_TOTAL: "Total requests rejected by the body size limit.",
     A2A_OPERATION_REJECTED_TOTAL: "Total requests rejected by operation capacity.",
     A2A_OPERATION_ACTIVE: "Current operations admitted by the capacity limit.",
+    A2A_RATE_LIMIT_REJECTED_TOTAL: "Total requests rejected by the sliding-window rate limit.",
+    A2A_STREAM_BUDGET_REJECTED_TOTAL: "Total streaming responses rejected by output budgets.",
 }
 
 

--- a/src/codex_a2a/server/application.py
+++ b/src/codex_a2a/server/application.py
@@ -6,10 +6,15 @@ from typing import Any
 
 import uvicorn
 from a2a.server.routes.agent_card_routes import create_agent_card_routes
+from a2a.server.routes.rest_dispatcher import RestDispatcher
 from a2a.server.routes.rest_routes import create_rest_routes
+from a2a.types import SubscribeToTaskRequest, a2a_pb2
+from a2a.utils import proto_utils
 from fastapi import FastAPI
-from starlette.responses import JSONResponse, PlainTextResponse
-from starlette.routing import BaseRoute, Mount
+from google.protobuf.json_format import MessageToDict, Parse  # type: ignore[import-untyped]
+from starlette.requests import Request
+from starlette.responses import JSONResponse, PlainTextResponse, Response
+from starlette.routing import BaseRoute, Mount, Route
 
 from codex_a2a.client.manager import A2AClientManager
 from codex_a2a.config import Settings
@@ -23,6 +28,7 @@ from codex_a2a.jsonrpc.application import (
     CodexSessionQueryJSONRPCApplication,
     create_extension_jsonrpc_routes,
 )
+from codex_a2a.jsonrpc.errors import build_http_error_body
 from codex_a2a.jsonrpc.hooks import SessionGuardHooks
 from codex_a2a.logging_context import install_log_record_factory
 from codex_a2a.metrics import get_metrics_registry
@@ -40,6 +46,8 @@ from codex_a2a.server.runtime_limits import (
     OperationCapacity,
     OperationCapacityMiddleware,
     RequestBodyLimitMiddleware,
+    StreamBudgetExceeded,
+    apply_stream_budget,
 )
 from codex_a2a.server.runtime_state import build_runtime_state_runtime
 from codex_a2a.server.task_store import build_task_store_runtime, describe_persistence_backend
@@ -58,13 +66,142 @@ def _is_sdk_tenant_mount(route: BaseRoute) -> bool:
     return isinstance(route, Mount) and route.path == "/{tenant}"
 
 
-def _create_single_tenant_rest_routes(**kwargs: Any) -> list[BaseRoute]:
+_STREAMING_REST_PATHS = frozenset({"/message:stream", "/tasks/{id}:subscribe"})
+_STREAM_BUDGET_REJECT_REASON = "STREAM_BUDGET_EXCEEDED"
+
+
+class BudgetedRestDispatcher(RestDispatcher):
+    """REST dispatcher that applies streaming output budgets to SSE streams."""
+
+    def __init__(
+        self,
+        request_handler: Any,
+        context_builder: Any,
+        *,
+        stream_budget_max_bytes: int,
+        stream_budget_max_duration_seconds: float,
+        stream_budget_idle_timeout_seconds: float,
+    ) -> None:
+        super().__init__(
+            request_handler=request_handler,
+            context_builder=context_builder,
+        )
+        self._stream_budget_max_bytes = stream_budget_max_bytes
+        self._stream_budget_max_duration_seconds = stream_budget_max_duration_seconds
+        self._stream_budget_idle_timeout_seconds = stream_budget_idle_timeout_seconds
+
+    async def _handle_streaming(
+        self,
+        request: Request,
+        handler_func: Any,
+    ) -> Any:
+        async def budgeted_handler(context: Any) -> Any:
+            async for item in apply_stream_budget(
+                aiter(handler_func(context)),
+                max_bytes=self._stream_budget_max_bytes,
+                max_duration_seconds=self._stream_budget_max_duration_seconds,
+                idle_timeout_seconds=self._stream_budget_idle_timeout_seconds,
+            ):
+                yield item
+
+        return await super()._handle_streaming(request, budgeted_handler)
+
+
+def _stream_budget_error_response(error: StreamBudgetExceeded) -> JSONResponse:
+    return JSONResponse(
+        build_http_error_body(
+            status_code=429,
+            status="RESOURCE_EXHAUSTED",
+            message=str(error),
+            reason=_STREAM_BUDGET_REJECT_REASON,
+        ),
+        status_code=429,
+    )
+
+
+def _create_single_tenant_rest_routes(
+    *,
+    request_handler: Any,
+    context_builder: Any = None,
+    path_prefix: str = "",
+    enable_v0_3_compat: bool = False,
+    stream_budget_max_bytes: int = 0,
+    stream_budget_max_duration_seconds: float = 0.0,
+    stream_budget_idle_timeout_seconds: float = 0.0,
+) -> list[BaseRoute]:
     # The SDK exposes a tenant-prefixed REST alias by default. This service's
     # supported HTTP+JSON contract is the spec-rooted single-tenant surface
     # (A2A 1.0 resolves REST paths from the advertised interface URL, with no
     # version prefix in the URL), so the application assembly narrows the route
-    # set explicitly.
-    return [route for route in create_rest_routes(**kwargs) if not _is_sdk_tenant_mount(route)]
+    # set explicitly and replaces the streaming routes with budgeted ones.
+    sdk_routes = create_rest_routes(
+        request_handler=request_handler,
+        context_builder=context_builder,
+        enable_v0_3_compat=enable_v0_3_compat,
+        path_prefix=path_prefix,
+    )
+    base_routes = [route for route in sdk_routes if not _is_sdk_tenant_mount(route)]
+
+    dispatcher = BudgetedRestDispatcher(
+        request_handler=request_handler,
+        context_builder=context_builder,
+        stream_budget_max_bytes=stream_budget_max_bytes,
+        stream_budget_max_duration_seconds=stream_budget_max_duration_seconds,
+        stream_budget_idle_timeout_seconds=stream_budget_idle_timeout_seconds,
+    )
+
+    async def _handle_streaming_route(request: Request, handler_func: Any) -> Response:
+        try:
+            return await dispatcher._handle_streaming(request, handler_func)
+        except StreamBudgetExceeded as error:
+            return _stream_budget_error_response(error)
+
+    async def message_stream_route(request: Request) -> Response:
+        async def _handler(context: Any) -> Any:
+            body = await request.body()
+            params = a2a_pb2.SendMessageRequest()
+            Parse(body, params)
+            async for event in request_handler.on_message_send_stream(params, context):
+                yield MessageToDict(proto_utils.to_stream_response(event))
+
+        return await _handle_streaming_route(request, _handler)
+
+    async def subscribe_route(request: Request) -> Response:
+        task_id = request.path_params["id"]
+
+        async def _handler(context: Any) -> Any:
+            async for event in request_handler.on_subscribe_to_task(
+                SubscribeToTaskRequest(id=task_id),
+                context,
+            ):
+                yield MessageToDict(proto_utils.to_stream_response(event))
+
+        return await _handle_streaming_route(request, _handler)
+
+    prefixed_streaming_paths = {f"{path_prefix}{path}" for path in _STREAMING_REST_PATHS}
+    retained = [
+        route
+        for route in base_routes
+        if not (hasattr(route, "path") and route.path in prefixed_streaming_paths)
+    ]
+    streaming_routes = [
+        Route(
+            path=f"{path_prefix}/message:stream",
+            endpoint=message_stream_route,
+            methods=["POST"],
+        ),
+        Route(
+            path=f"{path_prefix}/tasks/{{id}}:subscribe",
+            endpoint=subscribe_route,
+            methods=["GET"],
+        ),
+        Route(
+            path=f"{path_prefix}/tasks/{{id}}:subscribe",
+            endpoint=subscribe_route,
+            methods=["POST"],
+        ),
+    ]
+    return retained + streaming_routes
 
 
 def create_app(settings: Settings) -> FastAPI:
@@ -221,6 +358,9 @@ def create_app(settings: Settings) -> FastAPI:
             guard_hooks=session_guard_hooks,
             rpc_url=extension_contracts.CORE_JSONRPC_PATH,
             dispatcher_factory=CodexSessionQueryJSONRPCApplication,
+            stream_budget_max_bytes=settings.a2a_stream_max_bytes,
+            stream_budget_max_duration_seconds=settings.a2a_stream_max_duration_seconds,
+            stream_budget_idle_timeout_seconds=settings.a2a_stream_idle_timeout_seconds,
         )
     )
     app.router.routes.extend(
@@ -230,6 +370,9 @@ def create_app(settings: Settings) -> FastAPI:
             # A2A 1.0 roots the HTTP+JSON surface at the service root; the SDK
             # default prefix is empty, matching the URL the Agent Card advertises.
             path_prefix="",
+            stream_budget_max_bytes=settings.a2a_stream_max_bytes,
+            stream_budget_max_duration_seconds=settings.a2a_stream_max_duration_seconds,
+            stream_budget_idle_timeout_seconds=settings.a2a_stream_idle_timeout_seconds,
         )
     )
     app.state.codex_client = client

--- a/src/codex_a2a/server/application.py
+++ b/src/codex_a2a/server/application.py
@@ -10,6 +10,7 @@ from a2a.server.routes.rest_dispatcher import RestDispatcher
 from a2a.server.routes.rest_routes import create_rest_routes
 from a2a.types import SubscribeToTaskRequest, a2a_pb2
 from a2a.utils import proto_utils
+from a2a.utils.error_handlers import build_rest_error_payload
 from fastapi import FastAPI
 from google.protobuf.json_format import MessageToDict, Parse  # type: ignore[import-untyped]
 from starlette.requests import Request
@@ -119,6 +120,13 @@ def _stream_budget_error_response(error: StreamBudgetExceeded) -> JSONResponse:
     )
 
 
+def _rest_error_response(error: Exception) -> JSONResponse:
+    """Map a pre-SSE error to the same REST error payload the SDK emits."""
+    payload = build_rest_error_payload(error)
+    http_code = payload.get("error", {}).get("code", 500)
+    return JSONResponse(content=payload, status_code=http_code)
+
+
 def _create_single_tenant_rest_routes(
     *,
     request_handler: Any,
@@ -155,6 +163,8 @@ def _create_single_tenant_rest_routes(
             return await dispatcher._handle_streaming(request, handler_func)
         except StreamBudgetExceeded as error:
             return _stream_budget_error_response(error)
+        except Exception as error:  # noqa: BLE001 - mirrors SDK rest_stream_error_handler
+            return _rest_error_response(error)
 
     async def message_stream_route(request: Request) -> Response:
         async def _handler(context: Any) -> Any:

--- a/src/codex_a2a/server/http_middlewares.py
+++ b/src/codex_a2a/server/http_middlewares.py
@@ -36,11 +36,16 @@ from codex_a2a.logging_context import (
     resolve_correlation_id,
     set_correlation_id,
 )
+from codex_a2a.metrics import A2A_RATE_LIMIT_REJECTED_TOTAL, get_metrics_registry
 from codex_a2a.protocol_versions import (
     UnsupportedProtocolVersionError,
     negotiate_protocol_version,
     reset_current_protocol_version,
     set_current_protocol_version,
+)
+from codex_a2a.server.runtime_limits import (
+    SlidingWindowRateLimiter,
+    build_rate_limit_response,
 )
 from codex_a2a.server.task_store import TaskStoreOperationError, task_store_failure_message
 
@@ -603,6 +608,44 @@ def _install_payload_logging_middleware(app: FastAPI, *, settings: Settings) -> 
         return response
 
 
+def _resolve_rate_limit_key(request: Request) -> str:
+    """Key the limiter by credential, principal, or peer IP.
+
+    Authenticated requests use ``credential_id`` when declared so independent
+    credentials never share a bucket; otherwise they fall back to the stable
+    principal. The public (unauthenticated) surface is keyed by the direct
+    peer IP; ``X-Forwarded-For`` is deliberately not trusted because it can be
+    spoofed by clients when the service is not behind a trusted proxy.
+    """
+    credential_id = getattr(request.state, "user_credential_id", None)
+    if credential_id:
+        return f"credential:{credential_id}"
+    identity = getattr(request.state, "user_identity", None)
+    if identity:
+        return f"principal:{identity}"
+    client = request.client
+    host = client.host if client is not None else "unknown"
+    return f"ip:{host}"
+
+
+def _install_rate_limit_middleware(app: FastAPI, *, settings: Settings) -> None:
+    rate_limiter = SlidingWindowRateLimiter(
+        max_requests=settings.a2a_rate_limit_max_requests,
+        window_seconds=settings.a2a_rate_limit_window_seconds,
+    )
+
+    @app.middleware("http")
+    async def enforce_rate_limit(request: Request, call_next):
+        if not settings.a2a_rate_limit_enabled or request.method == "OPTIONS":
+            return await call_next(request)
+        key = _resolve_rate_limit_key(request)
+        if not await rate_limiter.check_and_record(key):
+            retry_after = await rate_limiter.retry_after(key)
+            get_metrics_registry().inc_counter(A2A_RATE_LIMIT_REJECTED_TOTAL)
+            return build_rate_limit_response(retry_after)
+        return await call_next(request)
+
+
 def _install_bearer_auth_middleware(
     app: FastAPI,
     *,
@@ -692,6 +735,7 @@ def install_http_middlewares(
     _install_rest_payload_shape_guard(app)
     _install_subscribe_task_guard(app, task_store=task_store)
     _install_payload_logging_middleware(app, settings=settings)
+    _install_rate_limit_middleware(app, settings=settings)
     _install_bearer_auth_middleware(
         app,
         configured_credentials=configured_credentials,

--- a/src/codex_a2a/server/runtime_limits.py
+++ b/src/codex_a2a/server/runtime_limits.py
@@ -6,7 +6,7 @@ import math
 import time
 from collections import deque
 from collections.abc import AsyncGenerator, AsyncIterator, Callable
-from typing import Any
+from typing import Any, NoReturn
 
 from starlette.responses import JSONResponse
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
@@ -157,19 +157,18 @@ async def apply_stream_budget(
                 return
             except TimeoutError:
                 _reject_budget("idle timeout")
-                return
 
-            now = resolve_clock()
-            if started_at is None:
-                started_at = now
-            elif max_duration_seconds > 0 and now - started_at >= max_duration_seconds:
-                _reject_budget("duration budget")
-                return
+            if max_duration_seconds > 0:
+                now = resolve_clock()
+                if started_at is None:
+                    started_at = now
+                elif now - started_at >= max_duration_seconds:
+                    _reject_budget("duration budget")
 
-            total_bytes += size_of(event)
-            if max_bytes > 0 and total_bytes > max_bytes:
-                _reject_budget("byte budget")
-                return
+            if max_bytes > 0:
+                total_bytes += size_of(event)
+                if total_bytes > max_bytes:
+                    _reject_budget("byte budget")
 
             yield event
     finally:
@@ -180,7 +179,7 @@ async def apply_stream_budget(
             await close()
 
 
-def _reject_budget(reason: str) -> None:
+def _reject_budget(reason: str) -> NoReturn:
     get_metrics_registry().inc_counter(A2A_STREAM_BUDGET_REJECTED_TOTAL)
     raise StreamBudgetExceeded(reason)
 

--- a/src/codex_a2a/server/runtime_limits.py
+++ b/src/codex_a2a/server/runtime_limits.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
 import asyncio
+import json
+import math
+import time
+from collections import deque
+from collections.abc import AsyncGenerator, AsyncIterator, Callable
+from typing import Any
 
 from starlette.responses import JSONResponse
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
@@ -9,8 +15,174 @@ from codex_a2a.metrics import (
     A2A_OPERATION_ACTIVE,
     A2A_OPERATION_REJECTED_TOTAL,
     A2A_REQUEST_BODY_REJECTED_TOTAL,
+    A2A_STREAM_BUDGET_REJECTED_TOTAL,
     get_metrics_registry,
 )
+
+RATE_LIMIT_ERROR_MESSAGE = "Too many requests"
+STREAM_BUDGET_ERROR_MESSAGE = "Stream budget exceeded"
+_DEFAULT_MAX_RATE_LIMIT_KEYS = 100_000
+# Approximate SSE framing overhead per event: ``data: `` prefix, line
+# separators, and the compact-JSON slack.
+_SSE_EVENT_FRAMING_OVERHEAD = 32
+
+
+def build_rate_limit_response(retry_after_seconds: float) -> JSONResponse:
+    """Build a 429 response carrying a client-safe Retry-After hint."""
+    retry_after = max(1, math.ceil(retry_after_seconds))
+    return JSONResponse(
+        {"error": RATE_LIMIT_ERROR_MESSAGE},
+        status_code=429,
+        headers={"Retry-After": str(retry_after), "Cache-Control": "no-store"},
+    )
+
+
+class SlidingWindowRateLimiter:
+    """Process-local sliding-window rate limiter.
+
+    Every key tracks the timestamps of admitted requests inside the window.
+    Buckets are pruned lazily on access and the key table is capped so memory
+    stays bounded even under a flood of distinct keys. All mutations are
+    serialized by an asyncio lock so concurrent request handlers observe a
+    consistent counter.
+    """
+
+    def __init__(
+        self,
+        *,
+        max_requests: int,
+        window_seconds: float,
+        max_keys: int = _DEFAULT_MAX_RATE_LIMIT_KEYS,
+        clock: Callable[[], float] | None = None,
+    ) -> None:
+        if max_requests <= 0:
+            raise ValueError("max_requests must be greater than 0")
+        if window_seconds <= 0:
+            raise ValueError("window_seconds must be greater than 0")
+        if max_keys <= 0:
+            raise ValueError("max_keys must be greater than 0")
+        self._max_requests = max_requests
+        self._window_seconds = float(window_seconds)
+        self._max_keys = max_keys
+        self._clock = clock or time.monotonic
+        self._entries: dict[str, deque[float]] = {}
+        self._lock = asyncio.Lock()
+
+    async def check_and_record(self, key: str) -> bool:
+        """Return True when the request is admitted and record it."""
+        async with self._lock:
+            now = self._clock()
+            entries = self._entries.setdefault(key, deque())
+            self._prune(entries, now)
+            if len(entries) >= self._max_requests:
+                return False
+            entries.append(now)
+            self._evict_if_needed()
+            return True
+
+    async def retry_after(self, key: str) -> float:
+        """Return the seconds until the oldest recorded request expires."""
+        async with self._lock:
+            entries = self._entries.get(key)
+            if not entries:
+                return self._window_seconds
+            now = self._clock()
+            self._prune(entries, now)
+            if not entries:
+                return self._window_seconds
+            return max(0.0, entries[0] + self._window_seconds - now)
+
+    def _prune(self, entries: deque[float], now: float) -> None:
+        while entries and now - entries[0] >= self._window_seconds:
+            entries.popleft()
+
+    def _evict_if_needed(self) -> None:
+        if len(self._entries) <= self._max_keys:
+            return
+        # dict preserves insertion order; evict the oldest-inserted key.
+        stale_key = next(iter(self._entries))
+        del self._entries[stale_key]
+
+
+class StreamBudgetExceeded(Exception):
+    """Raised when a streaming response exceeds its configured budget."""
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(f"{STREAM_BUDGET_ERROR_MESSAGE}: {reason}")
+        self.reason = reason
+
+
+def json_event_size(item: Any) -> int:
+    """Approximate the on-wire SSE bytes for one serialized event item."""
+    serialized = json.dumps(
+        item,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode()
+    return len(serialized) + _SSE_EVENT_FRAMING_OVERHEAD
+
+
+async def apply_stream_budget(
+    stream: AsyncIterator[Any],
+    *,
+    max_bytes: int,
+    max_duration_seconds: float,
+    idle_timeout_seconds: float,
+    clock: Callable[[], float] | None = None,
+    size_of: Callable[[Any], int] = json_event_size,
+) -> AsyncGenerator[Any, None]:
+    """Yield events while enforcing byte, duration, and idle budgets.
+
+    A value of ``0`` disables the corresponding budget. When a budget is
+    exceeded ``StreamBudgetExceeded`` is raised and the underlying stream is
+    closed first, so the application runs the same cleanup/drain path as a
+    client disconnect and the transport emits a well-formed SSE ``error``
+    event before ending the response normally.
+    """
+    resolve_clock = clock or time.monotonic
+    started_at: float | None = None
+    total_bytes = 0
+
+    try:
+        while True:
+            try:
+                if idle_timeout_seconds > 0:
+                    event = await asyncio.wait_for(
+                        anext(stream),
+                        timeout=idle_timeout_seconds,
+                    )
+                else:
+                    event = await anext(stream)
+            except StopAsyncIteration:
+                return
+            except TimeoutError:
+                _reject_budget("idle timeout")
+                return
+
+            now = resolve_clock()
+            if started_at is None:
+                started_at = now
+            elif max_duration_seconds > 0 and now - started_at >= max_duration_seconds:
+                _reject_budget("duration budget")
+                return
+
+            total_bytes += size_of(event)
+            if max_bytes > 0 and total_bytes > max_bytes:
+                _reject_budget("byte budget")
+                return
+
+            yield event
+    finally:
+        # Close the inner generator so its handler observes GeneratorExit and
+        # runs the normal disconnect/drain cleanup.
+        close = getattr(stream, "aclose", None)
+        if close is not None:
+            await close()
+
+
+def _reject_budget(reason: str) -> None:
+    get_metrics_registry().inc_counter(A2A_STREAM_BUDGET_REJECTED_TOTAL)
+    raise StreamBudgetExceeded(reason)
 
 
 async def _send_json_error(

--- a/tests/config/test_settings.py
+++ b/tests/config/test_settings.py
@@ -215,6 +215,17 @@ def test_settings_enable_turn_control_by_default() -> None:
     assert settings.a2a_enable_turn_control is True
 
 
+def test_settings_use_bounded_admission_defaults() -> None:
+    settings = make_settings()
+
+    assert settings.a2a_rate_limit_enabled is True
+    assert settings.a2a_rate_limit_window_seconds == 60.0
+    assert settings.a2a_rate_limit_max_requests == 120
+    assert settings.a2a_stream_max_bytes == 64 * 1024 * 1024
+    assert settings.a2a_stream_max_duration_seconds == 3600.0
+    assert settings.a2a_stream_idle_timeout_seconds == 120.0
+
+
 def test_make_settings_ignores_ambient_environment_sources() -> None:
     polluted_env = {
         "A2A_HOST": "100.89.160.53",
@@ -273,6 +284,12 @@ def test_settings_parse_ops_flags_and_timeouts():
         "A2A_INTERRUPT_REQUEST_TTL_SECONDS": "90",
         "A2A_REQUEST_BODY_MAX_BYTES": "1024",
         "A2A_MAX_CONCURRENT_OPERATIONS": "7",
+        "A2A_RATE_LIMIT_ENABLED": "false",
+        "A2A_RATE_LIMIT_WINDOW_SECONDS": "30",
+        "A2A_RATE_LIMIT_MAX_REQUESTS": "45",
+        "A2A_STREAM_MAX_BYTES": "1048576",
+        "A2A_STREAM_MAX_DURATION_SECONDS": "900",
+        "A2A_STREAM_IDLE_TIMEOUT_SECONDS": "45",
     }
     with mock.patch.dict(os.environ, env, clear=True):
         settings = Settings.from_env()
@@ -286,6 +303,12 @@ def test_settings_parse_ops_flags_and_timeouts():
         assert settings.a2a_interrupt_request_ttl_seconds == 90
         assert settings.a2a_request_body_max_bytes == 1024
         assert settings.a2a_max_concurrent_operations == 7
+        assert settings.a2a_rate_limit_enabled is False
+        assert settings.a2a_rate_limit_window_seconds == 30.0
+        assert settings.a2a_rate_limit_max_requests == 45
+        assert settings.a2a_stream_max_bytes == 1_048_576
+        assert settings.a2a_stream_max_duration_seconds == 900.0
+        assert settings.a2a_stream_idle_timeout_seconds == 45.0
 
 
 def test_settings_parse_task_store_configuration() -> None:
@@ -345,6 +368,24 @@ def test_settings_reject_invalid_stream_idle_diagnostic_seconds():
         with pytest.raises(ValidationError) as excinfo:
             Settings()
     assert "A2A_STREAM_IDLE_DIAGNOSTIC_SECONDS" in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    "env_name",
+    [
+        "A2A_RATE_LIMIT_WINDOW_SECONDS",
+        "A2A_RATE_LIMIT_MAX_REQUESTS",
+        "A2A_STREAM_MAX_BYTES",
+        "A2A_STREAM_MAX_DURATION_SECONDS",
+        "A2A_STREAM_IDLE_TIMEOUT_SECONDS",
+    ],
+)
+def test_settings_reject_invalid_admission_limits(env_name: str) -> None:
+    env = {**_registry_env(), env_name: "-1"}
+    with mock.patch.dict(os.environ, env, clear=True):
+        with pytest.raises(ValidationError) as excinfo:
+            Settings.from_env()
+    assert env_name in str(excinfo.value)
 
 
 @pytest.mark.parametrize(

--- a/tests/server/test_runtime_limits.py
+++ b/tests/server/test_runtime_limits.py
@@ -487,3 +487,33 @@ async def test_streaming_byte_budget_integration_terminates_jsonrpc_sse(monkeypa
 
     assert b"event: error" in body
     assert b"byte budget" in body
+
+
+@pytest.mark.asyncio
+async def test_subscribe_missing_task_returns_not_found(monkeypatch) -> None:
+    import codex_a2a.server.application as app_module
+
+    monkeypatch.setattr(app_module, "CodexClient", DummyChatCodexClient)
+    app = _create_rate_limited_app(a2a_bearer_token="test-token")
+    headers = {"Authorization": "Bearer test-token"}
+    transport = httpx.ASGITransport(app=app)
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/tasks/missing:subscribe", headers=headers)
+
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_message_stream_invalid_body_returns_bad_request(monkeypatch) -> None:
+    import codex_a2a.server.application as app_module
+
+    monkeypatch.setattr(app_module, "CodexClient", DummyChatCodexClient)
+    app = _create_rate_limited_app(a2a_bearer_token="test-token")
+    headers = {"Authorization": "Bearer test-token"}
+    transport = httpx.ASGITransport(app=app)
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post("/message:stream", headers=headers, content=b"not-json")
+
+    assert response.status_code == 400

--- a/tests/server/test_runtime_limits.py
+++ b/tests/server/test_runtime_limits.py
@@ -1,4 +1,5 @@
 import asyncio
+from typing import Any
 
 import httpx
 import pytest
@@ -10,14 +11,22 @@ from starlette.routing import Route
 from codex_a2a.metrics import (
     A2A_OPERATION_ACTIVE,
     A2A_OPERATION_REJECTED_TOTAL,
+    A2A_RATE_LIMIT_REJECTED_TOTAL,
     A2A_REQUEST_BODY_REJECTED_TOTAL,
+    A2A_STREAM_BUDGET_REJECTED_TOTAL,
     get_metrics_registry,
 )
 from codex_a2a.server.runtime_limits import (
     OperationCapacity,
     OperationCapacityMiddleware,
     RequestBodyLimitMiddleware,
+    SlidingWindowRateLimiter,
+    StreamBudgetExceeded,
+    apply_stream_budget,
 )
+from tests.support.dummy_clients import DummyChatCodexClient
+from tests.support.http_auth import basic_auth_header
+from tests.support.settings import make_settings
 
 
 @pytest.fixture(autouse=True)
@@ -120,3 +129,361 @@ async def test_operation_capacity_does_not_block_health_checks() -> None:
 
     assert response.status_code == 200
     assert capacity.active == 0
+
+
+class FakeClock:
+    def __init__(self, start: float = 0.0) -> None:
+        self.value = start
+
+    def __call__(self) -> float:
+        return self.value
+
+    def advance(self, seconds: float) -> None:
+        self.value += seconds
+
+
+class IdleTerminatingChatClient(DummyChatCodexClient):
+    """Dummy upstream client whose stream terminates like a real Codex run."""
+
+    async def stream_events(self, stop_event=None, *, directory: str | None = None):  # noqa: ANN001
+        del stop_event, directory
+        yield {"type": "session.idle", "properties": {"sessionID": "ses-created-1"}}
+
+
+@pytest.mark.asyncio
+async def test_rate_limiter_admits_until_window_capacity() -> None:
+    clock = FakeClock()
+    limiter = SlidingWindowRateLimiter(
+        max_requests=3,
+        window_seconds=60.0,
+        clock=clock,
+    )
+
+    for _ in range(3):
+        assert await limiter.check_and_record("credential:alice") is True
+
+    assert await limiter.check_and_record("credential:alice") is False
+    assert await limiter.check_and_record("credential:bob") is True
+    assert await limiter.retry_after("credential:alice") == pytest.approx(60.0)
+
+
+@pytest.mark.asyncio
+async def test_rate_limiter_window_slides() -> None:
+    clock = FakeClock()
+    limiter = SlidingWindowRateLimiter(
+        max_requests=2,
+        window_seconds=10.0,
+        clock=clock,
+    )
+
+    assert await limiter.check_and_record("ip:1.2.3.4") is True
+    clock.advance(5.0)
+    assert await limiter.check_and_record("ip:1.2.3.4") is True
+    assert await limiter.check_and_record("ip:1.2.3.4") is False
+
+    clock.advance(5.0)
+    assert await limiter.check_and_record("ip:1.2.3.4") is True
+    assert await limiter.retry_after("ip:1.2.3.4") == pytest.approx(5.0)
+
+
+@pytest.mark.asyncio
+async def test_rate_limiter_evicts_oldest_key_when_full() -> None:
+    clock = FakeClock()
+    limiter = SlidingWindowRateLimiter(
+        max_requests=1,
+        window_seconds=60.0,
+        max_keys=2,
+        clock=clock,
+    )
+
+    assert await limiter.check_and_record("ip:a") is True
+    assert await limiter.check_and_record("ip:b") is True
+    assert await limiter.check_and_record("ip:c") is True
+    # The oldest-inserted key was evicted, so it is admitted again.
+    assert await limiter.check_and_record("ip:a") is True
+
+
+def test_rate_limiter_rejects_invalid_configuration() -> None:
+    with pytest.raises(ValueError):
+        SlidingWindowRateLimiter(max_requests=0, window_seconds=60.0)
+    with pytest.raises(ValueError):
+        SlidingWindowRateLimiter(max_requests=1, window_seconds=0.0)
+    with pytest.raises(ValueError):
+        SlidingWindowRateLimiter(max_requests=1, window_seconds=60.0, max_keys=0)
+
+
+@pytest.mark.asyncio
+async def test_stream_budget_byte_limit_raises_and_closes_source() -> None:
+    state = {"closed": False}
+
+    async def tracked():
+        try:
+            yield "a" * 40
+            yield "b" * 40
+            yield "c" * 40
+        finally:
+            state["closed"] = True
+
+    received = []
+    with pytest.raises(StreamBudgetExceeded) as excinfo:
+        async for item in apply_stream_budget(
+            tracked(),
+            max_bytes=50,
+            max_duration_seconds=0,
+            idle_timeout_seconds=0,
+            size_of=len,
+        ):
+            received.append(item)
+
+    assert excinfo.value.reason == "byte budget"
+    assert received == ["a" * 40]
+    assert state["closed"] is True
+    assert get_metrics_registry().snapshot()["counters"][A2A_STREAM_BUDGET_REJECTED_TOTAL] == 1
+
+
+@pytest.mark.asyncio
+async def test_stream_budget_duration_limit_raises() -> None:
+    clock = FakeClock()
+
+    async def delayed():
+        yield "first"
+        clock.advance(30.0)
+        yield "second"
+        clock.advance(30.0)
+        yield "third"
+
+    received = []
+    with pytest.raises(StreamBudgetExceeded) as excinfo:
+        async for item in apply_stream_budget(
+            delayed(),
+            max_bytes=0,
+            max_duration_seconds=45.0,
+            idle_timeout_seconds=0,
+            clock=clock,
+            size_of=len,
+        ):
+            received.append(item)
+
+    assert excinfo.value.reason == "duration budget"
+    assert received == ["first", "second"]
+
+
+@pytest.mark.asyncio
+async def test_stream_budget_idle_timeout_raises() -> None:
+    async def slow():
+        yield "first"
+        await asyncio.sleep(0.08)
+        yield "second"
+
+    received = []
+    with pytest.raises(StreamBudgetExceeded) as excinfo:
+        async for item in apply_stream_budget(
+            slow(),
+            max_bytes=0,
+            max_duration_seconds=0,
+            idle_timeout_seconds=0.02,
+            size_of=len,
+        ):
+            received.append(item)
+
+    assert excinfo.value.reason == "idle timeout"
+    assert received == ["first"]
+
+
+@pytest.mark.asyncio
+async def test_stream_budget_within_limits_passes_through() -> None:
+    async def source():
+        yield "hello"
+        yield "world"
+
+    received = [
+        item
+        async for item in apply_stream_budget(
+            source(),
+            max_bytes=10_000,
+            max_duration_seconds=60.0,
+            idle_timeout_seconds=30.0,
+            size_of=len,
+        )
+    ]
+
+    assert received == ["hello", "world"]
+
+
+@pytest.mark.asyncio
+async def test_stream_budget_disabled_values_pass_through() -> None:
+    async def source():
+        for _ in range(20):
+            yield "x" * 10
+
+    received = [
+        item
+        async for item in apply_stream_budget(
+            source(),
+            max_bytes=0,
+            max_duration_seconds=0,
+            idle_timeout_seconds=0,
+            size_of=len,
+        )
+    ]
+
+    assert received == ["x" * 10] * 20
+
+
+def _create_rate_limited_app(**settings_overrides: Any) -> Any:
+    import codex_a2a.server.application as app_module
+
+    return app_module.create_app(make_settings(**settings_overrides))
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_rejects_excess_authenticated_requests(monkeypatch) -> None:
+    import codex_a2a.server.application as app_module
+
+    monkeypatch.setattr(app_module, "CodexClient", DummyChatCodexClient)
+    app = _create_rate_limited_app(
+        a2a_bearer_token="test-token",
+        a2a_rate_limit_max_requests=3,
+        a2a_rate_limit_window_seconds=60.0,
+    )
+    headers = {"Authorization": "Bearer test-token"}
+    transport = httpx.ASGITransport(app=app)
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        for _ in range(3):
+            response = await client.get("/health", headers=headers)
+            assert response.status_code == 200
+        limited = await client.get("/health", headers=headers)
+
+    assert limited.status_code == 429
+    assert limited.headers["retry-after"] == "60"
+    assert limited.json() == {"error": "Too many requests"}
+    assert get_metrics_registry().snapshot()["counters"][A2A_RATE_LIMIT_REJECTED_TOTAL] == 1
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_is_per_credential(monkeypatch) -> None:
+    import codex_a2a.server.application as app_module
+
+    monkeypatch.setattr(app_module, "CodexClient", DummyChatCodexClient)
+    app = _create_rate_limited_app(
+        a2a_bearer_token="test-token",
+        a2a_basic_auth_username="operator",
+        a2a_basic_auth_password="op-pass",  # pragma: allowlist secret
+        a2a_rate_limit_max_requests=2,
+        a2a_rate_limit_window_seconds=60.0,
+    )
+    bearer_headers = {"Authorization": "Bearer test-token"}
+    basic_headers = basic_auth_header("operator", "op-pass")  # pragma: allowlist secret
+    transport = httpx.ASGITransport(app=app)
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        for _ in range(2):
+            assert (await client.get("/health", headers=bearer_headers)).status_code == 200
+        assert (await client.get("/health", headers=bearer_headers)).status_code == 429
+        # A different credential keeps its own bucket.
+        assert (await client.get("/health", headers=basic_headers)).status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_public_card_keyed_by_peer_ip(monkeypatch) -> None:
+    import codex_a2a.server.application as app_module
+
+    monkeypatch.setattr(app_module, "CodexClient", DummyChatCodexClient)
+    app = _create_rate_limited_app(
+        a2a_bearer_token="test-token",
+        a2a_rate_limit_max_requests=2,
+        a2a_rate_limit_window_seconds=60.0,
+    )
+    transport = httpx.ASGITransport(app=app)
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        for _ in range(2):
+            assert (await client.get("/.well-known/agent-card.json")).status_code == 200
+        assert (await client.get("/.well-known/agent-card.json")).status_code == 429
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_can_be_disabled(monkeypatch) -> None:
+    import codex_a2a.server.application as app_module
+
+    monkeypatch.setattr(app_module, "CodexClient", DummyChatCodexClient)
+    app = _create_rate_limited_app(
+        a2a_bearer_token="test-token",
+        a2a_rate_limit_enabled=False,
+        a2a_rate_limit_max_requests=1,
+        a2a_rate_limit_window_seconds=60.0,
+    )
+    headers = {"Authorization": "Bearer test-token"}
+    transport = httpx.ASGITransport(app=app)
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        for _ in range(3):
+            assert (await client.get("/health", headers=headers)).status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_streaming_byte_budget_integration_rejects_rest_before_sse(monkeypatch) -> None:
+    import codex_a2a.server.application as app_module
+
+    monkeypatch.setattr(app_module, "CodexClient", IdleTerminatingChatClient)
+    app = _create_rate_limited_app(
+        a2a_bearer_token="test-token",
+        a2a_stream_max_bytes=128,
+        a2a_stream_max_duration_seconds=0,
+        a2a_stream_idle_timeout_seconds=0,
+    )
+    headers = {"Authorization": "Bearer test-token"}
+    payload = {
+        "message": {
+            "messageId": "m-rest",
+            "role": "ROLE_USER",
+            "parts": [{"text": "hello from rest"}],
+        }
+    }
+    transport = httpx.ASGITransport(app=app)
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post("/message:stream", headers=headers, json=payload)
+
+    assert response.status_code == 429
+    error_payload = response.json()["error"]
+    assert error_payload["status"] == "RESOURCE_EXHAUSTED"
+    assert error_payload["message"] == "Stream budget exceeded: byte budget"
+    assert get_metrics_registry().snapshot()["counters"][A2A_STREAM_BUDGET_REJECTED_TOTAL] == 1
+
+
+@pytest.mark.asyncio
+async def test_streaming_byte_budget_integration_terminates_jsonrpc_sse(monkeypatch) -> None:
+    import codex_a2a.server.application as app_module
+
+    monkeypatch.setattr(app_module, "CodexClient", IdleTerminatingChatClient)
+    app = _create_rate_limited_app(
+        a2a_bearer_token="test-token",
+        a2a_stream_max_bytes=128,
+        a2a_stream_max_duration_seconds=0,
+        a2a_stream_idle_timeout_seconds=0,
+    )
+    headers = {"Authorization": "Bearer test-token"}
+    payload = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "SendStreamingMessage",
+        "params": {
+            "message": {
+                "messageId": "m-rpc",
+                "role": "ROLE_USER",
+                "parts": [{"text": "hello from jsonrpc"}],
+            }
+        },
+    }
+    transport = httpx.ASGITransport(app=app)
+
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        async with client.stream("POST", "/", headers=headers, json=payload) as resp:
+            assert resp.status_code == 200
+            assert "text/event-stream" in resp.headers.get("content-type", "")
+            body = b"".join([chunk async for chunk in resp.aiter_bytes()])
+
+    assert b"event: error" in body
+    assert b"byte budget" in body

--- a/tests/server/test_runtime_limits.py
+++ b/tests/server/test_runtime_limits.py
@@ -330,6 +330,29 @@ async def test_stream_budget_disabled_values_pass_through() -> None:
     assert received == ["x" * 10] * 20
 
 
+@pytest.mark.asyncio
+async def test_stream_budget_disabled_does_not_measure_events() -> None:
+    def exploding_size(_item: object) -> int:
+        raise AssertionError("size_of must not run when the byte budget is disabled")
+
+    async def source():
+        yield "x" * 10
+        yield "y" * 10
+
+    received = [
+        item
+        async for item in apply_stream_budget(
+            source(),
+            max_bytes=0,
+            max_duration_seconds=0,
+            idle_timeout_seconds=0,
+            size_of=exploding_size,
+        )
+    ]
+
+    assert received == ["x" * 10, "y" * 10]
+
+
 def _create_rate_limited_app(**settings_overrides: Any) -> Any:
     import codex_a2a.server.application as app_module
 


### PR DESCRIPTION
## 概述

按 #347 验收标准，为运行时补齐入站限流与流式输出预算（与 opencode-a2a #502 修复同构）：

- **按凭据/IP 的滑动窗口限流**（默认开启）：认证请求按 `credential_id`（未配置时按 principal）分桶，公开 Agent Card 按直连 peer IP 分桶；进程内实现、内存有界；超限返回 HTTP 429 + `Retry-After`。
- **SSE/流式输出预算**（默认有界）：对 JSON-RPC `SendStreamingMessage` / `SubscribeToTask` 与 REST `/message:stream` / `/tasks/{id}:subscribe` 施加总字节 / 总时长 / 空闲超时预算；超限时以 SSE `event: error` 帧终止并走正常清理路径（REST 首事件即超限时返回 429 RESOURCE_EXHAUSTED JSON）。
- **配置项**：`A2A_RATE_LIMIT_ENABLED` / `A2A_RATE_LIMIT_WINDOW_SECONDS` / `A2A_RATE_LIMIT_MAX_REQUESTS` / `A2A_STREAM_MAX_BYTES` / `A2A_STREAM_MAX_DURATION_SECONDS` / `A2A_STREAM_IDLE_TIMEOUT_SECONDS`（`0` 关闭对应预算）。
- **指标**：新增 `a2a_rate_limit_rejected_total`、`a2a_stream_budget_rejected_total` 计数器。
- **测试与文档**：扩展 `tests/server/test_runtime_limits.py` 与配置校验用例，`docs/guide.md` 同步说明（仓库无 docs/inspection，决策并入 guide）。

实现上流式预算在事件生成器层执行，避免传输层强制终止导致的会话清理挂起；REST 流式路由使用预算感知的 `BudgetedRestDispatcher` 替换 SDK 默认 dispatcher。

## 独立审查与收敛

- 自定义流式路由补齐与 SDK `rest_stream_error_handler` 一致的错误映射（非法 body 400、缺失任务 404、未知错误 500），避免预取首项阶段的异常回归为 500。
- REST 首事件超预算统一映射为 429 RESOURCE_EXHAUSTED；subscribe 由 `subscribe_task_guard` 先行处理缺失任务（404）。
- 预算禁用时不再对每个事件执行序列化测量与时钟读取（消除无谓开销）；`_reject_budget` 声明为 `NoReturn` 并移除不可达代码；补充防回归测试。
- 补充 subscribe 404 与 `message:stream` 400 回归测试。

## 验收对照

- [x] 按凭据/IP 的滑动窗口限流（可配置、默认开启）
- [x] SSE/流式响应总字节或时长预算（默认有界）
- [x] 订阅连接空闲超时
- [x] 测试与文档

## 验证

- `bash ./scripts/validate_baseline.sh` 全绿：pre-commit、mypy、死代码检查、676+ 项测试、总覆盖率 86%+、diff-cover、构建与 smoke 通过。

Closes #347
Relates to #331
