### PR TITLE
chore(security): redact absolute paths in error responses and publish SHA256SUMS

### DIFF
--- a/docs/inspection/README.md
+++ b/docs/inspection/README.md
@@ -1,0 +1,17 @@
+# Inspection Deliverables
+
+This directory records security-audit decisions and deliverables produced by
+the tracked sub-items of the system security audit ([#331]).
+
+Current contents:
+
+- [Error redaction policy](./error_redaction_policy.md) — client-facing error
+  text masking of absolute local paths (#346).
+- [Release integrity policy](./release_integrity_policy.md) — SHA256 checksum
+  manifest for published GitHub release assets (#346).
+
+Remaining audit deliverables (full security report, network surface map,
+capability graph, test plan, and architecture invariants) will be added as the
+remaining sub-items are merged.
+
+[#331]: https://github.com/liujuanjuan1984/codex-a2a/issues/331

--- a/docs/inspection/error_redaction_policy.md
+++ b/docs/inspection/error_redaction_policy.md
@@ -17,6 +17,12 @@ Masked output uses the fixed placeholder `<redacted-path>`.
 - Raw exception fallback in
   `codex_a2a.jsonrpc.application._generate_error_response`.
 - Streaming task error messages — `codex_a2a.execution.executor._emit_error`.
+- Interactive exec session failure messages and metadata —
+  `codex_a2a.execution.exec_runtime._run_exec_session`.
+- A2A tool-call error results —
+  `codex_a2a.execution.executor._handle_a2a_call_tool`; the error text is
+  embedded in follow-up turns within the same upstream session, which session
+  queries can later expose.
 
 ## Masking rules
 
@@ -25,6 +31,9 @@ Masked:
 - POSIX absolute paths (`/a/b/c`).
 - Windows drive paths (`C:\a\b`, `C:/a/b`) and UNC paths (`\\server\share`).
 - `file://` URIs that embed a local path (`file:///tmp/x`, `file://C:/tmp/x`).
+- Any other slash-prefixed token (for example API route strings such as
+  `/tasks/123`) — masking is deliberately conservative; a slash-prefixed
+  token is treated as a potential path rather than risk leaking a real one.
 
 Preserved:
 

--- a/docs/inspection/error_redaction_policy.md
+++ b/docs/inspection/error_redaction_policy.md
@@ -1,0 +1,47 @@
+# Error Redaction Policy
+
+## Decision
+
+Client-visible error text must never expose absolute local filesystem paths.
+All error responses that can leave the process are passed through a single
+deterministic masker (`codex_a2a.redact.redact_absolute_paths`) before
+serialization.
+
+Masked output uses the fixed placeholder `<redacted-path>`.
+
+## Boundaries covered
+
+- JSON-RPC error responses — `codex_a2a.jsonrpc.errors.adapt_jsonrpc_error`
+  (message and error metadata, including nested values).
+- REST/HTTP error bodies — `codex_a2a.jsonrpc.errors.build_http_error_body`.
+- Raw exception fallback in
+  `codex_a2a.jsonrpc.application._generate_error_response`.
+- Streaming task error messages — `codex_a2a.execution.executor._emit_error`.
+
+## Masking rules
+
+Masked:
+
+- POSIX absolute paths (`/a/b/c`).
+- Windows drive paths (`C:\a\b`, `C:/a/b`) and UNC paths (`\\server\share`).
+- `file://` URIs that embed a local path (`file:///tmp/x`, `file://C:/tmp/x`).
+
+Preserved:
+
+- Remote URLs (`https://host/path`).
+- Relative paths (`a/b`, `./x`, `../y`).
+- Ordinary prose without absolute paths.
+
+## Logging policy
+
+Server-side logs intentionally retain full exception context (including
+absolute paths) for diagnosability. Logs are produced on the host that owns
+the filesystem and are not sent to clients. Any pipeline that ships logs off
+the host must apply the same redaction or restrict access before export.
+
+## Verification
+
+Unit coverage lives in `tests/test_redact.py`, with boundary tests in
+`tests/execution/test_error_redaction.py` and
+`tests/jsonrpc/test_error_redaction.py`. The masker is deterministic and
+idempotent.

--- a/docs/inspection/release_integrity_policy.md
+++ b/docs/inspection/release_integrity_policy.md
@@ -1,0 +1,33 @@
+# Release Integrity Policy
+
+## Decision
+
+Every GitHub Release must ship a `SHA256SUMS` checksum manifest alongside the
+wheel and sdist artifacts so consumers can verify artifact integrity
+independently of the registry.
+
+## Generation
+
+`scripts/publish_github_release.sh` regenerates `dist/SHA256SUMS` from the
+release assets at publish time, before upload:
+
+- One line per asset in `sha256sum` format: `<sha256-hex>  <basename>`.
+- Lines are sorted by basename so the manifest is deterministic.
+- The manifest itself is uploaded as a release asset and is skipped
+  idempotently when it is already present on the release.
+
+## Verification
+
+Consumers verify a downloaded release with:
+
+```bash
+sha256sum -c SHA256SUMS
+```
+
+## Scope notes
+
+Supply-chain dependency auditing is already covered separately by Dependabot
+and `pip-audit` (part of the baseline validation); this policy covers only the
+published artifact integrity gap from [#346].
+
+[#346]: https://github.com/liujuanjuan1984/codex-a2a/issues/346

--- a/scripts/publish_github_release.sh
+++ b/scripts/publish_github_release.sh
@@ -43,6 +43,29 @@ if [[ "${#release_assets[@]}" -eq 0 ]]; then
   exit 1
 fi
 
+checksum_manifest_name="SHA256SUMS"
+checksum_path="${dist_dir}/${checksum_manifest_name}"
+
+# Regenerate the checksum manifest for the current release assets so every
+# published artifact can be verified against the release (sha256sum -c).
+"${python_bin}" - "${checksum_path}" "${release_assets[@]}" <<'PY'
+from __future__ import annotations
+
+import hashlib
+import sys
+from pathlib import Path
+
+manifest_path = Path(sys.argv[1])
+assets = [Path(arg) for arg in sys.argv[2:]]
+lines = []
+for asset in sorted(assets, key=lambda item: item.name):
+    digest = hashlib.sha256(asset.read_bytes()).hexdigest()
+    lines.append(f"{digest}  {asset.name}")
+manifest_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+PY
+
+release_assets+=("${checksum_path}")
+
 retry() {
   local attempt=1
   local exit_code=0

--- a/src/codex_a2a/execution/exec_runtime.py
+++ b/src/codex_a2a/execution/exec_runtime.py
@@ -25,6 +25,7 @@ from codex_a2a.contracts.runtime_output import (
 )
 from codex_a2a.execution.output_mapping import enqueue_artifact_update
 from codex_a2a.execution.stream_state import BlockType
+from codex_a2a.redact import redact_absolute_paths
 from codex_a2a.upstream.request_mapping import format_exec_result_text
 
 logger = logging.getLogger(__name__)
@@ -263,7 +264,7 @@ class CodexExecRuntime:
                         message=self._build_status_message(
                             task_id=handle.task_id,
                             context_id=handle.context_id,
-                            text=f"Interactive exec failed: {exc}",
+                            text=(f"Interactive exec failed: {redact_absolute_paths(str(exc))}"),
                             message_id=f"{handle.task_id}:status:failed",
                         ),
                     ),
@@ -271,7 +272,7 @@ class CodexExecRuntime:
                         process_id=handle.process_id,
                         command_text=handle.command_text,
                         phase="failed",
-                        error=str(exc),
+                        error=redact_absolute_paths(str(exc)),
                     ),
                 )
             )

--- a/src/codex_a2a/execution/executor.py
+++ b/src/codex_a2a/execution/executor.py
@@ -44,6 +44,7 @@ from codex_a2a.input_mapping import (
     map_a2a_message_parts_to_normalized_items,
     summarize_normalized_items,
 )
+from codex_a2a.redact import redact_absolute_paths
 from codex_a2a.upstream.client import CodexClient
 
 from .output_mapping import extract_token_usage, merge_token_usage
@@ -610,6 +611,7 @@ class CodexAgentExecutor(AgentExecutor):
         *,
         streaming_request: bool,
     ) -> None:
+        message = redact_absolute_paths(message)
         error_message = Message(
             message_id=str(uuid.uuid4()),
             role=Role.ROLE_AGENT,

--- a/src/codex_a2a/execution/executor.py
+++ b/src/codex_a2a/execution/executor.py
@@ -484,7 +484,7 @@ class CodexAgentExecutor(AgentExecutor):
             }
         except Exception as exc:
             logger.exception("A2A tool call failed")
-            return {"call_id": call_id, "tool": tool_name, "error": str(exc)}
+            return {"call_id": call_id, "tool": tool_name, "error": redact_absolute_paths(str(exc))}
 
     @staticmethod
     def _build_tool_followup_prompt(tool_results: list[dict[str, Any]]) -> str:

--- a/src/codex_a2a/jsonrpc/application.py
+++ b/src/codex_a2a/jsonrpc/application.py
@@ -5,7 +5,7 @@ from typing import Any
 
 from a2a.server.jsonrpc_models import InvalidParamsError, JSONRPCError
 from a2a.server.routes.jsonrpc_dispatcher import JsonRpcDispatcher
-from a2a.utils.errors import A2AError, ContentTypeNotSupportedError
+from a2a.utils.errors import A2AError, ContentTypeNotSupportedError, InternalError
 from fastapi.responses import JSONResponse
 from starlette.requests import Request
 from starlette.responses import Response
@@ -29,6 +29,7 @@ from codex_a2a.jsonrpc.session_query import handle_session_query_request
 from codex_a2a.jsonrpc.thread_lifecycle_control import handle_thread_lifecycle_control_request
 from codex_a2a.jsonrpc.turn_control import handle_turn_control_request
 from codex_a2a.protocol_versions import get_current_protocol_version
+from codex_a2a.redact import redact_absolute_paths
 from codex_a2a.server.runtime_limits import apply_stream_budget
 from codex_a2a.upstream.client import CodexClient
 
@@ -276,7 +277,7 @@ class CodexSessionQueryJSONRPCApplication(JsonRpcDispatcher):
         if isinstance(error, JSONRPCError | A2AError):
             adapted_error: Exception | JSONRPCError | A2AError = adapt_jsonrpc_error(error)
         else:
-            adapted_error = error
+            adapted_error = InternalError(message=redact_absolute_paths(str(error)))
         return super()._generate_error_response(
             request_id,
             adapted_error,

--- a/src/codex_a2a/jsonrpc/errors.py
+++ b/src/codex_a2a/jsonrpc/errors.py
@@ -9,6 +9,7 @@ from a2a.utils.errors import A2AError
 from starlette.responses import Response
 
 from codex_a2a.jsonrpc.params_common import JsonRpcParamsValidationError
+from codex_a2a.redact import redact_absolute_paths, redact_paths_in_value
 
 if TYPE_CHECKING:
     from codex_a2a.jsonrpc.application import CodexSessionQueryJSONRPCApplication
@@ -70,10 +71,12 @@ def _to_upper_snake_case(name: str) -> str:
 
 def _stringify_metadata_value(value: Any) -> str:
     if isinstance(value, str):
-        return value
+        return redact_absolute_paths(value)
     if isinstance(value, bool | int | float):
         return str(value)
-    return json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+    return redact_absolute_paths(
+        json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+    )
 
 
 def _build_error_info_detail(
@@ -98,7 +101,7 @@ def _build_error_info_detail(
 def _build_context_detail(type_name: str, payload: Mapping[str, Any]) -> dict[str, Any]:
     return {
         "@type": f"type.googleapis.com/codex_a2a.{type_name}",
-        **dict(payload),
+        **{str(key): redact_paths_in_value(value) for key, value in payload.items()},
     }
 
 
@@ -149,6 +152,7 @@ def adapt_jsonrpc_error(error: JSONRPCError | A2AError) -> JSONRPCError | A2AErr
     message = getattr(root_error, "message", None) or str(root_error)
     if message is None:
         message = STANDARD_JSONRPC_ERROR_MESSAGES.get(root_code or -32603, "Internal error")
+    message = redact_absolute_paths(message)
 
     if root_code is None:
         root_code = _SDK_ERROR_CODE_BY_TYPE.get(type(root_error).__name__, -32603)
@@ -177,7 +181,7 @@ def build_http_error_body(
     error_payload: dict[str, Any] = {
         "code": status_code,
         "status": status,
-        "message": message,
+        "message": redact_absolute_paths(message),
     }
     if details:
         error_payload["details"] = details

--- a/src/codex_a2a/jsonrpc/errors.py
+++ b/src/codex_a2a/jsonrpc/errors.py
@@ -132,9 +132,13 @@ def adapt_jsonrpc_error(error: JSONRPCError | A2AError) -> JSONRPCError | A2AErr
     if root_code in STANDARD_JSONRPC_ERROR_CODES:
         adapted_data = None
         if isinstance(root_data, Mapping):
-            adapted_data = {str(key): value for key, value in root_data.items() if key != "type"}
+            adapted_data = {
+                str(key): redact_paths_in_value(value)
+                for key, value in root_data.items()
+                if key != "type"
+            }
         elif root_data is not None:
-            adapted_data = root_data
+            adapted_data = redact_paths_in_value(root_data)
         return JSONRPCError(
             code=root_code,
             message=STANDARD_JSONRPC_ERROR_MESSAGES[root_code],

--- a/src/codex_a2a/redact.py
+++ b/src/codex_a2a/redact.py
@@ -72,6 +72,8 @@ def redact_paths_in_value(value: Any) -> Any:
         return redact_absolute_paths(value)
     if isinstance(value, list):
         return [redact_paths_in_value(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(redact_paths_in_value(item) for item in value)
     if isinstance(value, dict):
         return {str(key): redact_paths_in_value(item) for key, item in value.items()}
     return value

--- a/src/codex_a2a/redact.py
+++ b/src/codex_a2a/redact.py
@@ -1,0 +1,77 @@
+"""Deterministic masking of absolute filesystem paths in error-facing text.
+
+Client-visible error messages (JSON-RPC/REST error bodies and streaming task
+messages) can embed exception text that includes host-local absolute paths,
+for example::
+
+    FileNotFoundError: [Errno 2] No such file or directory: '/home/ubuntu/x'
+
+This module replaces such paths with a fixed placeholder before the text
+leaves the process, while leaving URLs, relative paths, and ordinary prose
+untouched. The replacement is deterministic and idempotent.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+REDACTED_PATH_PLACEHOLDER = "<redacted-path>"
+
+# A path segment: word characters plus common path-safe punctuation
+# (``- _ + @ %``), with dots allowed only between word characters so trailing
+# sentence punctuation (``.``/``,``/``;``) is not swallowed by the match.
+_SEGMENT = r"[\w@+%-]+(?:\.[\w@+%-]+)*"
+
+# POSIX absolute paths: ``/a/b`` with at least one segment. The leading slash
+# must not be preceded by a word character (which would make it a relative
+# ``a/b`` fragment) or another slash or dot (which would make it part of a URL
+# authority such as ``https://host/path``, a ``//host/path`` reference, or a
+# ``../path`` traversal fragment).
+_POSIX_ABSOLUTE_PATH = re.compile(rf"(?<![\\/\w.])(?:/{_SEGMENT})+")
+
+# Windows drive paths (``C:\\a\\b`` / ``C:/a/b``) and UNC paths
+# (``\\\\server\\share\\path``). A drive letter must be followed by a
+# separator and at least one segment.
+_WINDOWS_ABSOLUTE_PATH = re.compile(
+    rf"(?<![\\/\w])(?:[A-Za-z]:[\\/]|\\\\[\w@+%-]+[\\/]){_SEGMENT}(?:[\\/]{_SEGMENT})*"
+)
+
+# ``file://`` URIs embed an absolute local path (``file:///tmp/x`` or
+# ``file://C:/tmp/x``) and are therefore treated as path leaks, unlike remote
+# ``scheme://host/path`` URLs which are preserved.
+_FILE_URL_PATH = re.compile(
+    r"(?i)file://"
+    r"(?:[A-Za-z]:[\\/]|[\w@+%-]+(?:[.:][\w@+%-]+)*/|/)"
+    rf"(?:{_SEGMENT})(?:/{_SEGMENT})*"
+)
+
+
+def redact_absolute_paths(text: str) -> str:
+    """Return ``text`` with absolute filesystem paths replaced by a placeholder.
+
+    Both POSIX (``/a/b``) and Windows (``C:\\a\\b``, ``\\\\server\\share``)
+    absolute paths are replaced. URLs (``scheme://host/path``), relative paths
+    (``a/b``), and prose without absolute paths are left unchanged. ``file://``
+    URIs and Windows paths are processed before POSIX paths so a
+    drive-qualified local path is replaced as one unit rather than leaving the
+    ``file://C:`` or ``C:`` prefix behind.
+    """
+    redacted = _FILE_URL_PATH.sub(REDACTED_PATH_PLACEHOLDER, text)
+    redacted = _WINDOWS_ABSOLUTE_PATH.sub(REDACTED_PATH_PLACEHOLDER, redacted)
+    return _POSIX_ABSOLUTE_PATH.sub(REDACTED_PATH_PLACEHOLDER, redacted)
+
+
+def redact_paths_in_value(value: Any) -> Any:
+    """Recursively redact absolute paths in every string leaf of ``value``.
+
+    ``value`` is expected to be JSON-compatible (dict/list/str/scalar). Keys
+    are kept as-is so error metadata remains machine-readable.
+    """
+    if isinstance(value, str):
+        return redact_absolute_paths(value)
+    if isinstance(value, list):
+        return [redact_paths_in_value(item) for item in value]
+    if isinstance(value, dict):
+        return {str(key): redact_paths_in_value(item) for key, item in value.items()}
+    return value

--- a/tests/execution/test_error_redaction.py
+++ b/tests/execution/test_error_redaction.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from a2a.server.events.event_queue import EventQueue
+from a2a.types import TaskState
 
+from codex_a2a.execution.exec_runtime import CodexExecRuntime, ExecSessionHandle
 from codex_a2a.execution.executor import CodexAgentExecutor
 from codex_a2a.redact import REDACTED_PATH_PLACEHOLDER
 
@@ -47,3 +50,74 @@ async def test_emit_error_redacts_paths_in_streaming_task() -> None:
     text = task.status.message.parts[0].text
     assert REDACTED_PATH_PLACEHOLDER in text
     assert "/var/log/codex/app.log" not in text
+
+
+@pytest.mark.asyncio
+async def test_exec_session_failure_redacts_paths() -> None:
+    client = MagicMock()
+
+    async def empty_stream(*args, **kwargs):
+        if False:
+            yield {}
+
+    client.stream_events.side_effect = lambda **kwargs: empty_stream()
+    client.exec_start = AsyncMock(
+        side_effect=FileNotFoundError(2, "No such file or directory", "/home/ubuntu/secret.txt")
+    )
+
+    runtime = CodexExecRuntime(client=client, request_handler=MagicMock())
+    event_queue = AsyncMock(spec=EventQueue)
+    handle = ExecSessionHandle(
+        process_id="p-1",
+        task_id="task-1",
+        context_id="context-1",
+        stop_event=asyncio.Event(),
+        command_text="cat /home/ubuntu/secret.txt",
+        owner_identity="alice",
+    )
+
+    await runtime._run_exec_session(
+        handle=handle,
+        request={"process_id": "p-1"},
+        directory=None,
+        event_queue=event_queue,
+    )
+
+    event = event_queue.enqueue_event.call_args[0][0]
+    assert event.status.state == TaskState.TASK_STATE_FAILED
+    text = event.status.message.parts[0].text
+    assert REDACTED_PATH_PLACEHOLDER in text
+    assert "/home/ubuntu/secret.txt" not in text
+    error_metadata = event.metadata["codex"]["exec"]["error"]
+    assert REDACTED_PATH_PLACEHOLDER in error_metadata
+    assert "/home/ubuntu/secret.txt" not in error_metadata
+
+
+@pytest.mark.asyncio
+async def test_tool_call_error_redacts_paths() -> None:
+    client = MagicMock()
+    manager = MagicMock()
+    manager.get_client = AsyncMock(
+        side_effect=FileNotFoundError(2, "No such file or directory", "/home/ubuntu/tool.txt")
+    )
+    executor = CodexAgentExecutor(
+        client,
+        streaming_enabled=False,
+        a2a_client_manager=manager,
+    )
+
+    result = await executor._handle_a2a_call_tool(
+        {
+            "callID": "call-1",
+            "tool": "a2a_call",
+            "state": {
+                "input": {
+                    "url": "https://example.com/agent",
+                    "message": "hello",
+                }
+            },
+        }
+    )
+
+    assert REDACTED_PATH_PLACEHOLDER in result["error"]
+    assert "/home/ubuntu/tool.txt" not in result["error"]

--- a/tests/execution/test_error_redaction.py
+++ b/tests/execution/test_error_redaction.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from a2a.server.events.event_queue import EventQueue
+
+from codex_a2a.execution.executor import CodexAgentExecutor
+from codex_a2a.redact import REDACTED_PATH_PLACEHOLDER
+
+
+@pytest.mark.asyncio
+async def test_emit_error_redacts_absolute_paths() -> None:
+    client = MagicMock()
+    executor = CodexAgentExecutor(client, streaming_enabled=False)
+    event_queue = AsyncMock(spec=EventQueue)
+
+    await executor._emit_error(
+        event_queue,
+        task_id="task-1",
+        context_id="context-1",
+        message="Cannot open session file '/home/ubuntu/sessions/session-1.json': No such file",
+        streaming_request=False,
+    )
+
+    task = event_queue.enqueue_event.call_args[0][0]
+    text = task.status.message.parts[0].text
+    assert REDACTED_PATH_PLACEHOLDER in text
+    assert "/home/ubuntu/sessions/session-1.json" not in text
+
+
+@pytest.mark.asyncio
+async def test_emit_error_redacts_paths_in_streaming_task() -> None:
+    client = MagicMock()
+    executor = CodexAgentExecutor(client, streaming_enabled=True)
+    event_queue = AsyncMock(spec=EventQueue)
+
+    await executor._emit_error(
+        event_queue,
+        task_id="task-2",
+        context_id="context-2",
+        message="Timeout writing output to /var/log/codex/app.log",
+        streaming_request=True,
+    )
+
+    task = event_queue.enqueue_event.call_args[0][0]
+    text = task.status.message.parts[0].text
+    assert REDACTED_PATH_PLACEHOLDER in text
+    assert "/var/log/codex/app.log" not in text

--- a/tests/jsonrpc/test_error_redaction.py
+++ b/tests/jsonrpc/test_error_redaction.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import json
+from typing import cast
+from unittest.mock import AsyncMock, MagicMock
+
+from a2a.server.jsonrpc_models import JSONRPCError
+
+from codex_a2a.contracts.extensions import (
+    DISCOVERY_METHODS,
+    EXEC_CONTROL_METHODS,
+    INTERRUPT_CALLBACK_METHODS,
+    INTERRUPT_RECOVERY_METHODS,
+    REVIEW_CONTROL_METHODS,
+    SESSION_QUERY_METHODS,
+    THREAD_LIFECYCLE_METHODS,
+    TURN_CONTROL_METHODS,
+    build_capability_snapshot,
+)
+from codex_a2a.jsonrpc.application import CodexSessionQueryJSONRPCApplication
+from codex_a2a.jsonrpc.errors import adapt_jsonrpc_error, build_http_error_body
+from codex_a2a.jsonrpc.hooks import SessionGuardHooks
+from codex_a2a.profile.runtime import build_runtime_profile
+from codex_a2a.redact import REDACTED_PATH_PLACEHOLDER
+from codex_a2a.upstream.client import CodexClient
+from tests.support.dummy_clients import DummySessionQueryCodexClient as DummyCodexClient
+from tests.support.settings import make_settings
+
+
+def test_adapt_jsonrpc_error_redacts_message_and_metadata() -> None:
+    error = JSONRPCError(
+        code=-32001,
+        message="Session file '/home/ubuntu/sessions/s1.json' missing",
+        data={
+            "type": "SESSION_NOT_FOUND",
+            "path": "/home/ubuntu/sessions/s1.json",
+            "nested": {"location": r"C:\Users\alice\x"},
+        },
+    )
+
+    adapted = adapt_jsonrpc_error(error)
+
+    assert adapted.code == -32001
+    assert REDACTED_PATH_PLACEHOLDER in adapted.message
+    assert "/home/ubuntu/sessions/s1.json" not in adapted.message
+    dumped = json.dumps(adapted.data)
+    assert REDACTED_PATH_PLACEHOLDER in dumped
+    assert "/home/ubuntu/sessions/s1.json" not in dumped
+    assert r"C:\Users\alice\x" not in dumped
+
+
+def test_build_http_error_body_redacts_message_and_metadata() -> None:
+    body = build_http_error_body(
+        status_code=500,
+        status="INTERNAL",
+        message="Unhandled path /opt/codex/bin/tool",
+        metadata={"directory": "/opt/codex/bin"},
+    )
+
+    payload = body["error"]
+    assert payload["message"] == f"Unhandled path {REDACTED_PATH_PLACEHOLDER}"
+    dumped = json.dumps(payload["details"])
+    assert REDACTED_PATH_PLACEHOLDER in dumped
+    assert "/opt/codex/bin" not in dumped
+
+
+def _build_app() -> CodexSessionQueryJSONRPCApplication:
+    settings = make_settings(a2a_bearer_token="t-1", a2a_log_payloads=False, codex_timeout=1.0)
+    methods = {
+        **SESSION_QUERY_METHODS,
+        **DISCOVERY_METHODS,
+        "thread_fork": THREAD_LIFECYCLE_METHODS["fork"],
+        "thread_archive": THREAD_LIFECYCLE_METHODS["archive"],
+        "thread_unarchive": THREAD_LIFECYCLE_METHODS["unarchive"],
+        "thread_metadata_update": THREAD_LIFECYCLE_METHODS["metadata_update"],
+        "thread_watch": THREAD_LIFECYCLE_METHODS["watch"],
+        "thread_watch_release": THREAD_LIFECYCLE_METHODS["watch_release"],
+        "interrupts_list": INTERRUPT_RECOVERY_METHODS["list"],
+        "turn_steer": TURN_CONTROL_METHODS["steer"],
+        "review_start": REVIEW_CONTROL_METHODS["start"],
+        "review_watch": REVIEW_CONTROL_METHODS["watch"],
+        **EXEC_CONTROL_METHODS,
+        **INTERRUPT_CALLBACK_METHODS,
+    }
+    return CodexSessionQueryJSONRPCApplication(
+        request_handler=MagicMock(),
+        codex_client=cast(CodexClient, DummyCodexClient(settings)),
+        exec_runtime=MagicMock(),
+        discovery_runtime=MagicMock(),
+        review_runtime=MagicMock(),
+        thread_lifecycle_runtime=MagicMock(),
+        methods=methods,
+        supported_methods=list(
+            build_capability_snapshot(
+                runtime_profile=build_runtime_profile(settings)
+            ).supported_jsonrpc_methods
+        ),
+        guard_hooks=cast(
+            SessionGuardHooks,
+            SessionGuardHooks(session_owner_matcher=AsyncMock(return_value=True)),
+        ),
+    )
+
+
+def test_generate_error_response_redacts_raw_exception_text() -> None:
+    app = _build_app()
+
+    response = app._generate_error_response("1", ValueError("broken at /home/ubuntu/x"))
+
+    body = response.body.decode("utf-8")
+    assert REDACTED_PATH_PLACEHOLDER in body
+    assert "/home/ubuntu/x" not in body

--- a/tests/jsonrpc/test_error_redaction.py
+++ b/tests/jsonrpc/test_error_redaction.py
@@ -4,7 +4,7 @@ import json
 from typing import cast
 from unittest.mock import AsyncMock, MagicMock
 
-from a2a.server.jsonrpc_models import JSONRPCError
+from a2a.server.jsonrpc_models import InvalidParamsError, JSONRPCError
 
 from codex_a2a.contracts.extensions import (
     DISCOVERY_METHODS,
@@ -47,6 +47,20 @@ def test_adapt_jsonrpc_error_redacts_message_and_metadata() -> None:
     assert REDACTED_PATH_PLACEHOLDER in dumped
     assert "/home/ubuntu/sessions/s1.json" not in dumped
     assert r"C:\Users\alice\x" not in dumped
+
+
+def test_adapt_jsonrpc_error_redacts_data_for_standard_codes() -> None:
+    error = InvalidParamsError(
+        message="Invalid params",
+        data={"field": "directory", "value": "/home/ubuntu/project"},
+    )
+
+    adapted = adapt_jsonrpc_error(error)
+
+    assert adapted.code == -32602
+    dumped = json.dumps(adapted.data)
+    assert REDACTED_PATH_PLACEHOLDER in dumped
+    assert "/home/ubuntu/project" not in dumped
 
 
 def test_build_http_error_body_redacts_message_and_metadata() -> None:

--- a/tests/package/test_publish_github_release_script.py
+++ b/tests/package/test_publish_github_release_script.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import stat
@@ -131,6 +132,7 @@ def test_publish_release_script_creates_missing_release_before_upload(tmp_path: 
     assert set(state["assets"]) == {
         "codex_a2a-0.5.1.tar.gz",
         "codex_a2a-0.5.1-py3-none-any.whl",
+        "SHA256SUMS",
     }
     log_lines = log_path.read_text(encoding="utf-8").splitlines()
     assert "release create v0.5.1 --generate-notes --verify-tag" in log_lines
@@ -138,6 +140,16 @@ def test_publish_release_script_creates_missing_release_before_upload(tmp_path: 
     assert (
         "release upload v0.5.1 " + str(dist_dir / "codex_a2a-0.5.1-py3-none-any.whl") in log_lines
     )
+    assert "release upload v0.5.1 " + str(dist_dir / "SHA256SUMS") in log_lines
+
+    manifest = (dist_dir / "SHA256SUMS").read_text(encoding="utf-8")
+    wheel = dist_dir / "codex_a2a-0.5.1-py3-none-any.whl"
+    sdist = dist_dir / "codex_a2a-0.5.1.tar.gz"
+    expected_lines = [
+        f"{hashlib.sha256(wheel.read_bytes()).hexdigest()}  {wheel.name}",
+        f"{hashlib.sha256(sdist.read_bytes()).hexdigest()}  {sdist.name}",
+    ]
+    assert manifest.splitlines() == expected_lines
 
 
 def test_publish_release_script_fails_when_asset_upload_keeps_failing(tmp_path: Path) -> None:

--- a/tests/test_redact.py
+++ b/tests/test_redact.py
@@ -77,3 +77,8 @@ def test_redact_paths_in_value_recurses() -> None:
     assert result["nested"][1]["url"] == "https://example.com/a"
     assert result["count"] == 3
     assert result["flag"] is True
+
+
+def test_redact_paths_in_value_handles_tuples() -> None:
+    result = redact_paths_in_value(("ok", "/tmp/x", ["/var/log/y"]))
+    assert result == ("ok", REDACTED_PATH_PLACEHOLDER, [REDACTED_PATH_PLACEHOLDER])

--- a/tests/test_redact.py
+++ b/tests/test_redact.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from codex_a2a.redact import (
+    REDACTED_PATH_PLACEHOLDER,
+    redact_absolute_paths,
+    redact_paths_in_value,
+)
+
+
+def test_masks_posix_absolute_paths() -> None:
+    text = "FileNotFoundError: [Errno 2] No such file or directory: '/home/ubuntu/secret/data.txt'"
+    assert redact_absolute_paths(text) == (
+        f"FileNotFoundError: [Errno 2] No such file or directory: '{REDACTED_PATH_PLACEHOLDER}'"
+    )
+
+
+def test_masks_multiple_paths() -> None:
+    text = "paths /tmp/a and /var/log/codex/app.log"
+    assert redact_absolute_paths(text) == (
+        f"paths {REDACTED_PATH_PLACEHOLDER} and {REDACTED_PATH_PLACEHOLDER}"
+    )
+
+
+def test_masks_windows_drive_paths() -> None:
+    assert redact_absolute_paths(r"C:\Users\alice\secret.txt") == REDACTED_PATH_PLACEHOLDER
+    assert redact_absolute_paths("C:/Users/alice/secret.txt") == REDACTED_PATH_PLACEHOLDER
+
+
+def test_masks_unc_paths() -> None:
+    assert redact_absolute_paths(r"\\server\share\data\file.txt") == REDACTED_PATH_PLACEHOLDER
+
+
+def test_masks_file_url_paths() -> None:
+    assert redact_absolute_paths("file:///tmp/secret/config.json") == REDACTED_PATH_PLACEHOLDER
+    assert redact_absolute_paths("file://C:/tmp/secret.txt") == REDACTED_PATH_PLACEHOLDER
+
+
+def test_preserves_remote_urls() -> None:
+    text = "upstream https://example.com/path/to/file failed; local http://localhost:8000/a2a"
+    assert redact_absolute_paths(text) == text
+
+
+def test_preserves_relative_paths() -> None:
+    text = "module src/codex_a2a/redact.py and ./local and ../parent/file"
+    assert redact_absolute_paths(text) == text
+
+
+def test_preserves_trailing_punctuation() -> None:
+    assert redact_absolute_paths("/tmp/x.") == f"{REDACTED_PATH_PLACEHOLDER}."
+    assert redact_absolute_paths("/tmp/x,") == f"{REDACTED_PATH_PLACEHOLDER},"
+
+
+def test_redaction_is_idempotent() -> None:
+    text = "error /home/u/x with https://example.com/a/b and C:\\Users\\a\\y"
+    once = redact_absolute_paths(text)
+    assert redact_absolute_paths(once) == once
+
+
+def test_plain_text_unchanged() -> None:
+    text = "hello world; method=send_message; code=-32001"
+    assert redact_absolute_paths(text) == text
+
+
+def test_redact_paths_in_value_recurses() -> None:
+    value = {
+        "directory": "/home/ubuntu/project",
+        "nested": [
+            {"path": r"C:\Users\alice\x"},
+            {"url": "https://example.com/a"},
+        ],
+        "count": 3,
+        "flag": True,
+    }
+    result = redact_paths_in_value(value)
+    assert result["directory"] == REDACTED_PATH_PLACEHOLDER
+    assert result["nested"][0]["path"] == REDACTED_PATH_PLACEHOLDER
+    assert result["nested"][1]["url"] == "https://example.com/a"
+    assert result["count"] == 3
+    assert result["flag"] is True


### PR DESCRIPTION
## 背景

#331 安全审计拆解出的低优先残余项（#346）：错误响应文本未统一做本机绝对路径脱敏；发布物无完整性校验清单。当前 main 上两个证据点仍然成立（`executor._emit_error` 与 `jsonrpc/errors.py` 直接透出异常文本；`publish_github_release.sh` 无校验清单），`docs/inspection/` 尚不存在。

## 变更内容

- 新增 `codex_a2a.redact` 确定性脱敏工具：POSIX/Windows/UNC 绝对路径与 `file://` 本地 URI 统一替换为 `<redacted-path>` 占位符；远程 URL、相对路径与普通文本保持不变；幂等；`redact_paths_in_value` 递归覆盖 dict/list/tuple/str。
- 错误出口统一接入（覆盖客户端可见的路径泄露面）：
  - `executor._emit_error`（SSE 与 task 错误消息）
  - `jsonrpc.errors.adapt_jsonrpc_error`（message 与嵌套 metadata，含标准 JSON-RPC 错误码分支的 data）
  - `jsonrpc.errors.build_http_error_body`（REST 错误体）
  - `jsonrpc.application._generate_error_response`（裸异常兜底分支）
  - `execution.exec_runtime._run_exec_session`（交互 exec 失败消息与 metadata）
  - `execution.executor._handle_a2a_call_tool`（a2a_call 工具错误，避免路径进入同会话后续轮次与可查询的会话历史）
- 发布脚本 `publish_github_release.sh` 在上传前生成 `dist/SHA256SUMS`（sha256sum 格式、按文件名排序、确定性），并作为 release asset 上传；已存在时幂等跳过。
- `docs/inspection/` 新增日志脱敏与发布完整性策略文档（同时部分推进 #331 的 docs 交付项）。
- 测试：新增脱敏单元测试、executor/jsonrpc/exec-runtime 边界测试，并扩展发布脚本 fake-gh 测试断言 SHA256SUMS 内容与上传。

## 验证

- `bash ./scripts/validate_baseline.sh` 全部通过（pre-commit、dead-code、mypy、全量 pytest、diff-cover ≥90%、pip-audit、构建与 wheel CLI smoke）。
- `bash -n scripts/publish_github_release.sh` 通过。

## 相关提交

- `4436215` chore(security): redact absolute paths in error responses and publish SHA256SUMS (#346)
- `9d96ab4` fix(security): redact paths in exec/tool error surfaces and standard error data (#346)

## 验收标准对照

- [x] 错误文本统一脱敏（绝对路径替换为占位符）
- [x] 发布物附 SHA256SUMS
- [x] `docs/inspection/` 记录日志与发布策略决策

## 关联 issue

- Closes #346
- Relates to #331（父级安全审计；`docs/inspection/` 交付物随本 PR 部分补齐）
- 相关已完成子项：#342、#343、#344、#345、#347（均已合入 main）
