### PR TITLE
fix(client): propagate outbound headers through SDK transports

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -396,7 +396,7 @@ For more details on each variable, see the internal configuration schema in `src
 
 Configuration note:
 - The service configuration layer only accepts `CODEX_*` names for Codex-facing settings.
-- Outbound auth prefers `A2A_CLIENT_BEARER_TOKEN` when both bearer and basic credentials are configured; otherwise it uses `A2A_CLIENT_BASIC_AUTH`.
+- Outbound auth prefers `A2A_CLIENT_BEARER_TOKEN` when both bearer and basic credentials are configured; otherwise it uses `A2A_CLIENT_BASIC_AUTH`. Agent Card discovery and subsequent peer operations such as `SendMessage`, `GetTask`, and `CancelTask` send the selected credential together with the fixed `A2A-Version` header.
 
 YOLO-equivalent execution note:
 - `codex-a2a` does not expose a separate `--yolo` flag or `YOLO` environment variable.

--- a/src/codex_a2a/client/client.py
+++ b/src/codex_a2a/client/client.py
@@ -96,7 +96,6 @@ class A2AClient:
                 if config.request_timeout_seconds is None
                 else httpx.Timeout(config.request_timeout_seconds)
             ),
-            headers=config.default_headers,
         )
         self._owns_http_client = httpx_client is None
         self._closed = False
@@ -239,7 +238,11 @@ class A2AClient:
         try:
             task = await sdk_client.get_task(
                 task_request,
-                context=build_call_context(extra_headers, requested_extensions),
+                context=build_call_context(
+                    extra_headers,
+                    requested_extensions,
+                    default_headers=self._config.default_headers,
+                ),
             )
             return filter_negotiated_extensions_from_task(task, requested_extensions)
         except Exception as exc:
@@ -271,7 +274,11 @@ class A2AClient:
             cancel_request = self._with_request_metadata(cancel_request, request_metadata)
             task = await sdk_client.cancel_task(
                 cancel_request,
-                context=build_call_context(extra_headers, requested_extensions),
+                context=build_call_context(
+                    extra_headers,
+                    requested_extensions,
+                    default_headers=self._config.default_headers,
+                ),
             )
             return filter_negotiated_extensions_from_task(task, requested_extensions)
         except Exception as exc:
@@ -354,7 +361,11 @@ class A2AClient:
         try:
             async for item in sdk_client.send_message(
                 normalized_request,
-                context=build_call_context(extra_headers, requested_extensions),
+                context=build_call_context(
+                    extra_headers,
+                    requested_extensions,
+                    default_headers=self._config.default_headers,
+                ),
             ):
                 yield filter_negotiated_extensions_from_stream_response(
                     item,

--- a/src/codex_a2a/client/config.py
+++ b/src/codex_a2a/client/config.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 
 from pydantic import BaseModel, Field, field_validator
+
+from .request_context import build_default_headers
 
 
 class A2AClientConfig(BaseModel):
@@ -15,7 +17,7 @@ class A2AClientConfig(BaseModel):
     use_client_preference: bool = False
     request_timeout_seconds: float | None = None
     close_http_client: bool = True
-    default_headers: dict[str, str] = Field(default_factory=dict)
+    default_headers: dict[str, str] = Field(default_factory=lambda: build_default_headers(None))
     auth_credentials: dict[str, str] = Field(default_factory=dict)
     accepted_output_modes: list[str] = Field(default_factory=list)
     extensions: list[str] = Field(default_factory=list)
@@ -26,6 +28,15 @@ class A2AClientConfig(BaseModel):
         if value <= 0:
             raise ValueError("card_fetch_timeout_seconds must be > 0")
         return value
+
+    @field_validator("default_headers", mode="before")
+    @classmethod
+    def include_protocol_version_header(cls, value: object) -> object:
+        if not isinstance(value, Mapping):
+            return value
+        headers = build_default_headers(None)
+        headers.update({str(key): str(item) for key, item in value.items()})
+        return headers
 
     @field_validator("extensions", mode="before")
     @classmethod

--- a/src/codex_a2a/client/config.py
+++ b/src/codex_a2a/client/config.py
@@ -4,6 +4,8 @@ from collections.abc import Mapping, Sequence
 
 from pydantic import BaseModel, Field, field_validator
 
+from codex_a2a.protocol_versions import ADVERTISED_PROTOCOL_VERSION
+
 from .request_context import build_default_headers
 
 
@@ -34,8 +36,17 @@ class A2AClientConfig(BaseModel):
     def include_protocol_version_header(cls, value: object) -> object:
         if not isinstance(value, Mapping):
             return value
-        headers = build_default_headers(None)
-        headers.update({str(key): str(item) for key, item in value.items()})
+        headers: dict[object, object] = {}
+        headers.update(build_default_headers(None))
+        for key, item in value.items():
+            if isinstance(key, str) and key.lower() == "a2a-version":
+                if item != ADVERTISED_PROTOCOL_VERSION:
+                    raise ValueError(
+                        "A2A-Version is fixed to "
+                        f"{ADVERTISED_PROTOCOL_VERSION} and must not be overridden"
+                    )
+                continue
+            headers[key] = item
         return headers
 
     @field_validator("extensions", mode="before")

--- a/src/codex_a2a/client/manager.py
+++ b/src/codex_a2a/client/manager.py
@@ -39,7 +39,7 @@ class A2AClientManager:
             allowed_hosts=self._settings.a2a_client_allowed_hosts,
             allow_private_hosts=self._settings.a2a_client_allow_private_hosts,
         )
-        default_headers = build_default_headers(None)
+        default_headers: dict[str, str] = {}
         if policy.credentials_allowed:
             default_headers = build_default_headers(
                 self._settings.a2a_client_bearer_token,

--- a/src/codex_a2a/client/manager.py
+++ b/src/codex_a2a/client/manager.py
@@ -39,7 +39,7 @@ class A2AClientManager:
             allowed_hosts=self._settings.a2a_client_allowed_hosts,
             allow_private_hosts=self._settings.a2a_client_allow_private_hosts,
         )
-        default_headers: dict[str, str] = {}
+        default_headers = build_default_headers(None)
         if policy.credentials_allowed:
             default_headers = build_default_headers(
                 self._settings.a2a_client_bearer_token,

--- a/src/codex_a2a/client/request_context.py
+++ b/src/codex_a2a/client/request_context.py
@@ -32,12 +32,14 @@ def split_request_metadata(
     for key, value in dict(metadata or {}).items():
         if isinstance(key, str) and key.lower() == "authorization":
             if value is not None:
-                extra_headers["Authorization"] = str(value)
+                if not isinstance(value, str):
+                    raise ValueError("Authorization metadata header must be a string")
+                extra_headers["Authorization"] = value
             continue
         if isinstance(key, str) and key.lower() == "a2a-version":
-            if value is not None:
-                extra_headers["A2A-Version"] = str(value)
-            continue
+            raise ValueError(
+                f"A2A-Version is fixed to {ADVERTISED_PROTOCOL_VERSION} and must not be overridden"
+            )
         if isinstance(key, str) and key.lower() == "a2a-extensions":
             if isinstance(value, str):
                 requested_extensions.append(value)

--- a/src/codex_a2a/client/request_context.py
+++ b/src/codex_a2a/client/request_context.py
@@ -5,6 +5,8 @@ from typing import Any
 
 from a2a.client import ClientCallContext
 
+from codex_a2a.protocol_versions import ADVERTISED_PROTOCOL_VERSION
+
 from .auth import encode_basic_auth
 from .extension_negotiation import merge_extension_service_parameters, parse_requested_extensions
 
@@ -13,11 +15,12 @@ def build_default_headers(
     bearer_token: str | None,
     basic_auth: str | None = None,
 ) -> dict[str, str]:
+    headers = {"A2A-Version": ADVERTISED_PROTOCOL_VERSION}
     if bearer_token:
-        return {"Authorization": f"Bearer {bearer_token}"}
-    if basic_auth:
-        return {"Authorization": f"Basic {encode_basic_auth(basic_auth)}"}
-    return {}
+        headers["Authorization"] = f"Bearer {bearer_token}"
+    elif basic_auth:
+        headers["Authorization"] = f"Basic {encode_basic_auth(basic_auth)}"
+    return headers
 
 
 def split_request_metadata(
@@ -54,8 +57,13 @@ def split_request_metadata(
 def build_call_context(
     extra_headers: Mapping[str, str] | None,
     extensions: tuple[str, ...] | None = None,
+    *,
+    default_headers: Mapping[str, str] | None = None,
 ) -> ClientCallContext | None:
-    service_parameters = merge_extension_service_parameters(extra_headers, extensions)
+    merged_headers = dict(default_headers or {})
+    if extra_headers:
+        merged_headers.update(extra_headers)
+    service_parameters = merge_extension_service_parameters(merged_headers, extensions)
     if not service_parameters:
         return None
     return ClientCallContext(service_parameters=service_parameters)

--- a/tests/client/test_agent_card.py
+++ b/tests/client/test_agent_card.py
@@ -41,7 +41,10 @@ def test_build_agent_card_request_kwargs_includes_timeout_and_headers() -> None:
     assert timeout is not None
     assert isinstance(timeout, httpx.Timeout)
     assert timeout.connect == 7.5
-    assert http_kwargs["headers"] == {"Authorization": "Bearer peer-token"}
+    assert http_kwargs["headers"] == {
+        "A2A-Version": "1.0",
+        "Authorization": "Bearer peer-token",
+    }
 
 
 def test_build_agent_card_request_kwargs_supports_basic_auth_header() -> None:
@@ -52,4 +55,7 @@ def test_build_agent_card_request_kwargs_supports_basic_auth_header() -> None:
 
     http_kwargs = build_agent_card_request_kwargs(config)
 
-    assert http_kwargs["headers"] == {"Authorization": "Basic dXNlcjpwYXNz"}
+    assert http_kwargs["headers"] == {
+        "A2A-Version": "1.0",
+        "Authorization": "Basic dXNlcjpwYXNz",
+    }

--- a/tests/client/test_client_flow.py
+++ b/tests/client/test_client_flow.py
@@ -156,7 +156,10 @@ async def test_send_get_task_and_cancel_use_sdk_methods() -> None:
     assert send_result.task.id == "task-1"
     send_call = sdk_client.send_calls[0]
     assert proto_to_python(send_call["request"].metadata) == {"trace_id": "trace-1"}
-    assert send_call["context"].service_parameters == {"Authorization": "Bearer token"}
+    assert send_call["context"].service_parameters == {
+        "A2A-Version": "1.0",
+        "Authorization": "Bearer token",
+    }
     assert send_call["request"].configuration.accepted_output_modes == ["text/plain"]
     assert send_call["request"].configuration.history_length == 3
     assert send_call["request"].configuration.return_immediately is True
@@ -173,7 +176,10 @@ async def test_send_get_task_and_cancel_use_sdk_methods() -> None:
         "id": "task-1",
         "history_length": 2,
     }
-    assert sdk_client.get_task_contexts[0].service_parameters == {"Authorization": "Bearer token"}
+    assert sdk_client.get_task_contexts[0].service_parameters == {
+        "A2A-Version": "1.0",
+        "Authorization": "Bearer token",
+    }
 
     cancel_result = await client.cancel(
         CancelTaskRequest(
@@ -186,7 +192,10 @@ async def test_send_get_task_and_cancel_use_sdk_methods() -> None:
         "id": "task-1",
         "metadata": {"trace_id": "trace-3"},
     }
-    assert sdk_client.cancel_contexts[0].service_parameters == {"Authorization": "Bearer token"}
+    assert sdk_client.cancel_contexts[0].service_parameters == {
+        "A2A-Version": "1.0",
+        "Authorization": "Bearer token",
+    }
 
 
 @pytest.mark.asyncio
@@ -218,6 +227,7 @@ async def test_send_negotiates_extensions_from_config_and_metadata() -> None:
 
     send_call = sdk_client.send_calls[0]
     assert send_call["context"].service_parameters == {
+        "A2A-Version": "1.0",
         "Authorization": "Bearer token",
         "A2A-Extensions": SESSION_BINDING_EXTENSION_URI,
     }

--- a/tests/client/test_client_http_headers.py
+++ b/tests/client/test_client_http_headers.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import json
+from base64 import b64encode
+
+import httpx
+import pytest
+from a2a.types import (
+    AgentCapabilities,
+    AgentCard,
+    AgentInterface,
+    CancelTaskRequest,
+    GetTaskRequest,
+    Message,
+    Part,
+    Role,
+    SendMessageRequest,
+    SendMessageResponse,
+    Task,
+    TaskState,
+    TaskStatus,
+)
+from google.protobuf.json_format import MessageToDict
+
+from codex_a2a.client import A2AClient, A2AClientConfig
+
+_PEER_URL = "https://peer.example.com"
+_EXTENSION_URI = "https://example.com/extensions/test"
+
+
+def _agent_card() -> AgentCard:
+    return AgentCard(
+        name="HTTP stub peer",
+        description="Exercises the real SDK JSON-RPC transport.",
+        version="1.0",
+        supported_interfaces=[
+            AgentInterface(
+                url=f"{_PEER_URL}/",
+                protocol_binding="JSONRPC",
+                protocol_version="1.0",
+            )
+        ],
+        capabilities=AgentCapabilities(streaming=False),
+        default_input_modes=["text/plain"],
+        default_output_modes=["text/plain"],
+        skills=[],
+    )
+
+
+def _http_stub(requests: dict[str, httpx.Request]) -> httpx.MockTransport:
+    card = _agent_card()
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET":
+            requests["GetAgentCard"] = request
+            return httpx.Response(200, json=MessageToDict(card))
+
+        payload = json.loads(request.content)
+        method = payload["method"]
+        requests[method] = request
+        if method == "SendMessage":
+            result = MessageToDict(
+                SendMessageResponse(
+                    message=Message(
+                        message_id="reply-1",
+                        role=Role.ROLE_AGENT,
+                        parts=[Part(text="ok")],
+                    )
+                )
+            )
+        elif method in {"GetTask", "CancelTask"}:
+            state = (
+                TaskState.TASK_STATE_COMPLETED
+                if method == "GetTask"
+                else TaskState.TASK_STATE_CANCELED
+            )
+            result = MessageToDict(
+                Task(
+                    id="task-1",
+                    context_id="context-1",
+                    status=TaskStatus(state=state),
+                )
+            )
+        else:  # pragma: no cover - keeps unexpected SDK calls visible
+            raise AssertionError(f"Unexpected JSON-RPC method: {method}")
+        return httpx.Response(
+            200,
+            json={"jsonrpc": "2.0", "id": payload["id"], "result": result},
+        )
+
+    return httpx.MockTransport(handle)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("authorization", "expected_authorization"),
+    [
+        ("Bearer peer-token", "Bearer peer-token"),
+        (f"Basic {b64encode(b'user:pass').decode()}", "Basic dXNlcjpwYXNz"),
+    ],
+    ids=("bearer", "basic"),
+)
+async def test_sdk_jsonrpc_requests_send_configured_headers(
+    authorization: str,
+    expected_authorization: str,
+) -> None:
+    requests: dict[str, httpx.Request] = {}
+    config = A2AClientConfig(
+        agent_url=_PEER_URL,
+        default_headers={"Authorization": authorization},
+        extensions=[_EXTENSION_URI],
+    )
+    async with httpx.AsyncClient(transport=_http_stub(requests)) as http_client:
+        client = A2AClient(config, httpx_client=http_client)
+
+        await client.send(
+            SendMessageRequest(
+                message=Message(
+                    message_id="message-1",
+                    role=Role.ROLE_USER,
+                    parts=[Part(text="hello")],
+                )
+            )
+        )
+        await client.get_task(GetTaskRequest(id="task-1"))
+        await client.cancel(CancelTaskRequest(id="task-1"))
+
+    for method in ("GetAgentCard", "SendMessage", "GetTask", "CancelTask"):
+        assert requests[method].headers["Authorization"] == expected_authorization
+        assert requests[method].headers["A2A-Version"] == "1.0"
+    for method in ("SendMessage", "GetTask", "CancelTask"):
+        assert requests[method].headers["A2A-Extensions"] == _EXTENSION_URI
+
+
+@pytest.mark.asyncio
+async def test_sdk_jsonrpc_request_preserves_explicit_authorization_override() -> None:
+    requests: dict[str, httpx.Request] = {}
+    config = A2AClientConfig(
+        agent_url=_PEER_URL,
+        default_headers={"Authorization": "Bearer default-token"},
+    )
+    async with httpx.AsyncClient(transport=_http_stub(requests)) as http_client:
+        client = A2AClient(config, httpx_client=http_client)
+
+        await client.send(
+            SendMessageRequest(
+                message=Message(
+                    message_id="message-1",
+                    role=Role.ROLE_USER,
+                    parts=[Part(text="hello")],
+                ),
+                metadata={"authorization": "Bearer explicit-token"},
+            )
+        )
+
+    assert requests["GetAgentCard"].headers["Authorization"] == "Bearer default-token"
+    assert requests["SendMessage"].headers["Authorization"] == "Bearer explicit-token"

--- a/tests/client/test_client_manager.py
+++ b/tests/client/test_client_manager.py
@@ -56,7 +56,10 @@ async def test_manager_normalizes_config_and_transports(monkeypatch: pytest.Monk
     assert client.config.request_timeout_seconds == 41.0
     assert client.config.card_fetch_timeout_seconds == 7.0
     assert client.config.use_client_preference is True
-    assert client.config.default_headers == {"Authorization": "Bearer peer-token"}
+    assert client.config.default_headers == {
+        "A2A-Version": "1.0",
+        "Authorization": "Bearer peer-token",
+    }
     assert client.config.supported_transports == ["HTTP+JSON", "JSONRPC"]
     assert client.config.extensions == [
         SESSION_BINDING_EXTENSION_URI,
@@ -77,7 +80,10 @@ async def test_manager_uses_basic_auth_when_bearer_is_absent(
     manager = A2AClientManager(settings, client_factory=factory)
     client = await manager.get_client("https://peer.example.com/")
 
-    assert client.config.default_headers == {"Authorization": "Basic dXNlcjpwYXNz"}
+    assert client.config.default_headers == {
+        "A2A-Version": "1.0",
+        "Authorization": "Basic dXNlcjpwYXNz",
+    }
 
 
 @pytest.mark.asyncio
@@ -92,7 +98,7 @@ async def test_manager_does_not_send_credentials_without_allowlist(
     manager = A2AClientManager(settings, client_factory=factory)
     client = await manager.get_client("https://peer.example.com/")
 
-    assert client.config.default_headers == {}
+    assert client.config.default_headers == {"A2A-Version": "1.0"}
 
 
 @pytest.mark.asyncio

--- a/tests/client/test_request_context.py
+++ b/tests/client/test_request_context.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import pytest
+from pydantic import ValidationError
 
+from codex_a2a.client.config import A2AClientConfig
 from codex_a2a.client.request_context import (
     build_call_context,
     build_default_headers,
@@ -18,6 +20,16 @@ def test_split_request_metadata_separates_authorization_header() -> None:
     assert request_metadata == {"trace_id": "trace-1"}
     assert extra_headers == {"Authorization": "Bearer explicit-token"}
     assert requested_extensions is None
+
+
+def test_split_request_metadata_rejects_non_string_authorization_header() -> None:
+    with pytest.raises(ValueError, match="Authorization metadata header must be a string"):
+        split_request_metadata({"authorization": 123})
+
+
+def test_split_request_metadata_rejects_protocol_version_override() -> None:
+    with pytest.raises(ValueError, match="A2A-Version is fixed to 1.0"):
+        split_request_metadata({"a2a-version": "1.0"})
 
 
 def test_split_request_metadata_extracts_a2a_extensions_header() -> None:
@@ -47,11 +59,31 @@ def test_split_request_metadata_ignores_empty_input() -> None:
     assert requested_extensions is None
 
 
-def test_build_call_context_returns_header_state() -> None:
+def test_build_call_context_carries_headers_via_service_parameters() -> None:
     context = build_call_context({"Authorization": "Bearer explicit-token"})
 
     assert context is not None
     assert context.service_parameters == {"Authorization": "Bearer explicit-token"}
+
+
+def test_client_config_canonicalizes_fixed_protocol_version_header() -> None:
+    config = A2AClientConfig(
+        agent_url="https://example.org",
+        default_headers={"a2a-version": "1.0", "X-Trace-Id": "trace-1"},
+    )
+
+    assert config.default_headers == {
+        "A2A-Version": "1.0",
+        "X-Trace-Id": "trace-1",
+    }
+
+
+def test_client_config_rejects_protocol_version_override() -> None:
+    with pytest.raises(ValidationError, match="A2A-Version is fixed to 1.0"):
+        A2AClientConfig(
+            agent_url="https://example.org",
+            default_headers={"A2A-Version": "0.3"},
+        )
 
 
 def test_build_call_context_merges_extensions_into_service_parameters() -> None:

--- a/tests/client/test_request_context.py
+++ b/tests/client/test_request_context.py
@@ -67,6 +67,22 @@ def test_build_call_context_merges_extensions_into_service_parameters() -> None:
     }
 
 
+def test_build_call_context_merges_defaults_before_explicit_headers() -> None:
+    context = build_call_context(
+        {"Authorization": "Bearer explicit-token"},
+        default_headers={
+            "A2A-Version": "1.0",
+            "Authorization": "Bearer default-token",
+        },
+    )
+
+    assert context is not None
+    assert context.service_parameters == {
+        "A2A-Version": "1.0",
+        "Authorization": "Bearer explicit-token",
+    }
+
+
 def test_build_call_context_returns_none_without_headers() -> None:
     assert build_call_context(None) is None
 
@@ -82,16 +98,23 @@ def test_build_call_context_returns_extensions_without_headers() -> None:
 
 def test_build_default_headers_prefers_bearer_over_basic_auth() -> None:
     assert build_default_headers("peer-token", "user:pass") == {
-        "Authorization": "Bearer peer-token"
+        "A2A-Version": "1.0",
+        "Authorization": "Bearer peer-token",
     }
 
 
 def test_build_default_headers_encodes_basic_auth() -> None:
-    assert build_default_headers(None, "user:pass") == {"Authorization": "Basic dXNlcjpwYXNz"}
+    assert build_default_headers(None, "user:pass") == {
+        "A2A-Version": "1.0",
+        "Authorization": "Basic dXNlcjpwYXNz",
+    }
 
 
 def test_build_default_headers_accepts_pre_encoded_basic_auth() -> None:
-    assert build_default_headers(None, "dXNlcjpwYXNz") == {"Authorization": "Basic dXNlcjpwYXNz"}
+    assert build_default_headers(None, "dXNlcjpwYXNz") == {
+        "A2A-Version": "1.0",
+        "Authorization": "Basic dXNlcjpwYXNz",
+    }
 
 
 def test_build_default_headers_rejects_invalid_basic_auth() -> None:


### PR DESCRIPTION
## 变更摘要

- 将默认出站请求头与显式 per-call 请求头合并后，通过 `ClientCallContext.service_parameters` 交给 SDK transport，覆盖 `SendMessage`、`GetTask` 与 `CancelTask`。
- Agent Card discovery 继续通过 resolver 的 `http_kwargs` 显式携带相同请求头；移除共享 `httpx.AsyncClient` 的全局 headers，缩小凭据隐式附着面。
- 固定发送仓库声明的 `A2A-Version: 1.0`，禁止配置或 per-call metadata 覆盖版本；大小写不同但值相同的版本头会规范为唯一 canonical header。
- 显式 per-call `Authorization` 继续优先于默认凭据，但非字符串鉴权头现在会 fail-fast；`A2A-Extensions` 合并行为保持不变。
- 新增真实 SDK JSON-RPC HTTP transport 回归测试，覆盖 Bearer、Basic、显式鉴权覆盖、协议版本、扩展头以及 `SendMessage`、`GetTask`、`CancelTask`。
- 更新出站鉴权文档。

## 独立审查结论

当前项目不完全复现 `opencode-a2a` #513：默认凭据原本已通过共享 HTTP client 发送，显式 per-call `Authorization` 也已使用 `service_parameters`，所以常规路径不会直接因同一问题返回 401。不过，原实现仍有两个实际缺口：固定 `A2A-Version` 没有覆盖出站操作，且缺少真实 SDK transport 测试，无法防止后续回归。

对本 PR 代码进行独立复审时又发现并已收敛：

- `default_headers` 与 per-call metadata 原本可以覆盖所谓“固定”的 `A2A-Version`，大小写不同还可能形成重复版本头；现在统一 canonicalize 并拒绝任何版本漂移。
- 非字符串 Authorization 原本会被静默 `str()` 后发送；现在严格要求字符串，避免把无效或意外结构发送到 wire。
- manager 层不再重复注入无凭据版本头，固定版本由 `A2AClientConfig` 单点保证。

SDK `AuthInterceptor` 继续保留：它根据 Agent Card security scheme 动态获取凭据，与已移除的共享 client headers 职责不同，不属于冗余兼容层。trace、客户端缓存和 handler shutdown 属于独立出站/生命周期议题，本 PR 不扩大范围。

## a2a-sdk 升级与 audit

- 上游 GitHub 已发布 `a2a-python v1.1.3`，但 PyPI 尚无可安装的 `a2a-sdk 1.1.3`，GitHub Release 也没有 wheel/sdist 制品。
- 本 PR 不引入 Git source override，避免发行包依赖声明不可由 PyPI 解析，并避免新增供应链、审计和可重复安装风险；正式制品发布后的升级继续由 #338 跟踪。
- runtime 与 dev 依赖审计均未发现已知漏洞；当前 lock 使用 `pyasn1 0.6.4`。
- 参考实现对应的 `opencode-a2a` PR #514 已合并；其最终实现同样只使用 SDK 正式的 `service_parameters` 通道。

## 相关 commits

- `f09001a` `fix(client): send outbound headers through SDK transport (#354)`
- `2c690ee` `fix(client): enforce fixed outbound protocol version (#354)`

## 验证

- `bash ./scripts/dependency_health.sh`
- `bash ./scripts/validate_baseline.sh`
- 727 项测试通过
- 总覆盖率 86.34%，diff coverage 96%
- pre-commit、dead-code、mypy、runtime/dev `pip-audit`、构建与 wheel smoke test 均通过

## 关联

- Closes #354
- Relates to #338
- 参考：https://github.com/Intelligent-Internet/opencode-a2a/issues/513
- 参考：https://github.com/Intelligent-Internet/opencode-a2a/pull/514
