### PR TITLE
fix(server): prevent aiosqlite connection leaks during SQLite hardening

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,12 @@ filterwarnings = [
     "always:.*was deleted before being closed.*:ResourceWarning:aiosqlite.core",
 ]
 
+[tool.coverage.run]
+# SQLAlchemy's async engine runs connect listeners inside greenlets; without
+# this, coverage.py's tracer loses line events there on CPython 3.13 (and
+# diff-cover under-reports the SQLite connection setup paths).
+concurrency = ["greenlet"]
+
 [tool.coverage.report]
 fail_under = 84
 show_missing = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,9 @@ tag_regex = "^v?(?P<version>.+)$"
 addopts = "--cov=src/codex_a2a --cov-branch --cov-report=term-missing:skip-covered --cov-report=xml"
 filterwarnings = [
     "ignore:'HTTP_413_REQUEST_ENTITY_TOO_LARGE' is deprecated. Use 'HTTP_413_CONTENT_TOO_LARGE' instead.:DeprecationWarning:a2a\\.server\\.apps\\.jsonrpc\\.fastapi_app",
+    "error::pytest.PytestUnhandledThreadExceptionWarning",
+    "error::pytest.PytestUnraisableExceptionWarning",
+    "always:.*was deleted before being closed.*:ResourceWarning:aiosqlite.core",
 ]
 
 [tool.coverage.report]

--- a/src/codex_a2a/server/database.py
+++ b/src/codex_a2a/server/database.py
@@ -141,12 +141,16 @@ def _harden_sqlite_before_connect(
     *,
     database_path: Path,
 ) -> None:
-    """Fail-closed hardening before a DBAPI connection is created.
+    """Event-signature adapter for the SQLAlchemy ``do_connect`` hook.
 
-    Registered on the ``do_connect`` event, which fires before SQLAlchemy
-    instantiates the underlying aiosqlite connection. Rejecting a symlink or
-    an untrusted file here never allocates a connection (or its worker
-    thread), so no resource can be leaked.
+    ``do_connect`` listeners receive ``(dialect, connection_record, cargs,
+    cparams)`` and SQLAlchemy binds them by parameter name, so
+    ``_harden_sqlite_file(path)`` cannot be registered directly (a bare
+    ``partial`` fails at runtime with a TypeError). This adapter exists solely
+    to translate that signature while keeping the fail-closed hardening
+    before any physical connection is created: rejecting a symlink or an
+    untrusted file here never allocates a connection (or its worker thread),
+    so no resource can be leaked.
     """
     _harden_sqlite_file(database_path)
 

--- a/src/codex_a2a/server/database.py
+++ b/src/codex_a2a/server/database.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import stat
+from contextlib import suppress
 from functools import partial
 from pathlib import Path
 from typing import Any
@@ -108,15 +109,46 @@ def _configure_sqlite_connection(
     *,
     database_path: Path | None = None,
 ) -> None:
-    if database_path is not None:
-        _harden_sqlite_file(database_path)
-    cursor = dbapi_connection.cursor()
     try:
-        cursor.execute(f"PRAGMA journal_mode={_SQLITE_JOURNAL_MODE}")
-        cursor.execute(f"PRAGMA busy_timeout={_SQLITE_BUSY_TIMEOUT_MS}")
-        cursor.execute(f"PRAGMA synchronous={_SQLITE_SYNCHRONOUS_MODE}")
-    finally:
-        cursor.close()
+        if database_path is not None:
+            # Keep the post-connect re-check as defense in depth: the file
+            # may have been swapped between the do_connect pre-check and the
+            # physical connection.
+            _harden_sqlite_file(database_path)
+        cursor = dbapi_connection.cursor()
+        try:
+            cursor.execute(f"PRAGMA journal_mode={_SQLITE_JOURNAL_MODE}")
+            cursor.execute(f"PRAGMA busy_timeout={_SQLITE_BUSY_TIMEOUT_MS}")
+            cursor.execute(f"PRAGMA synchronous={_SQLITE_SYNCHRONOUS_MODE}")
+        finally:
+            cursor.close()
+    except BaseException:
+        # The DBAPI connection was already created by the time the ``connect``
+        # event fires; close it explicitly so a failed configuration cannot
+        # leak an aiosqlite connection (and its worker thread). The close
+        # itself may raise (e.g. loop teardown), so absorb it and keep the
+        # original exception.
+        with suppress(Exception):
+            dbapi_connection.close()
+        raise
+
+
+def _harden_sqlite_before_connect(
+    _dialect: Any,
+    _connection_record: Any,
+    _connection_args: tuple[Any, ...],
+    _connection_params: dict[str, Any],
+    *,
+    database_path: Path,
+) -> None:
+    """Fail-closed hardening before a DBAPI connection is created.
+
+    Registered on the ``do_connect`` event, which fires before SQLAlchemy
+    instantiates the underlying aiosqlite connection. Rejecting a symlink or
+    an untrusted file here never allocates a connection (or its worker
+    thread), so no resource can be leaked.
+    """
+    _harden_sqlite_file(database_path)
 
 
 def build_database_engine(settings: Settings) -> AsyncEngine:
@@ -136,6 +168,12 @@ def build_database_engine(settings: Settings) -> AsyncEngine:
         pool_pre_ping=not url.drivername.startswith("sqlite"),
     )
     if url.drivername.startswith("sqlite"):
+        if sqlite_path is not None:
+            event.listen(
+                engine.sync_engine,
+                "do_connect",
+                partial(_harden_sqlite_before_connect, database_path=sqlite_path),
+            )
         event.listen(
             engine.sync_engine,
             "connect",

--- a/tests/execution/test_session_persistence.py
+++ b/tests/execution/test_session_persistence.py
@@ -252,13 +252,17 @@ async def test_runtime_state_runtime_does_not_dispose_shared_engine(
         a2a_database_url=f"sqlite+aiosqlite:///{(tmp_path / 'shared-runtime.db').resolve()}",
     )
     engine = build_database_engine(settings)
+    original_dispose = engine.dispose
     dispose_spy = AsyncMock()
     monkeypatch.setattr(type(engine), "dispose", dispose_spy)
 
-    runtime_state = build_runtime_state_runtime(settings, engine=engine)
-    await runtime_state.shutdown()
+    try:
+        runtime_state = build_runtime_state_runtime(settings, engine=engine)
+        await runtime_state.shutdown()
 
-    dispose_spy.assert_not_awaited()
+        dispose_spy.assert_not_awaited()
+    finally:
+        await original_dispose()
 
 
 async def _return_session(session_id: str) -> str:

--- a/tests/server/test_database.py
+++ b/tests/server/test_database.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 import os
 import stat
 from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
 
+import aiosqlite
 import pytest
 
 from codex_a2a.server import database as database_module
@@ -202,7 +205,19 @@ def test_apply_private_sqlite_modes_rejects_foreign_owned_sidecar(tmp_path, monk
 
 @pytest.mark.skipif(os.name != "posix", reason="POSIX file permission semantics")
 @pytest.mark.asyncio
-async def test_build_database_engine_rechecks_hardening_on_new_connection(tmp_path) -> None:
+async def test_build_database_engine_rechecks_hardening_on_new_connection(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    created_connections: list[aiosqlite.Connection] = []
+    original_connect = aiosqlite.connect
+
+    def tracking_connect(*args: Any, **kwargs: Any) -> aiosqlite.Connection:
+        connection = original_connect(*args, **kwargs)
+        created_connections.append(connection)
+        return connection
+
+    monkeypatch.setattr(aiosqlite, "connect", tracking_connect)
     settings = _settings_for(tmp_path)
     engine = build_database_engine(settings)
     try:
@@ -221,3 +236,40 @@ async def test_build_database_engine_rechecks_hardening_on_new_connection(tmp_pa
                 await conn.exec_driver_sql("SELECT 1")
     finally:
         await engine.dispose()
+
+    # The pre-connect hardening rejects the symlink before any new DBAPI
+    # connection is created, so the failed attempt must not leak a second
+    # aiosqlite connection.
+    assert len(created_connections) == 1
+
+
+def test_configure_sqlite_connection_closes_connection_on_failure() -> None:
+    dbapi_connection = MagicMock()
+    cursor = dbapi_connection.cursor.return_value
+    cursor.execute.side_effect = RuntimeError("PRAGMA failed")
+    dbapi_connection.close.side_effect = OSError("close failed")
+
+    with pytest.raises(RuntimeError, match="PRAGMA failed"):
+        database_module._configure_sqlite_connection(dbapi_connection, MagicMock())
+
+    cursor.close.assert_called_once_with()
+    dbapi_connection.close.assert_called_once_with()
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX file permission semantics")
+def test_configure_sqlite_connection_closes_connection_on_hardening_failure(tmp_path) -> None:
+    victim = tmp_path / "victim.db"
+    victim.write_bytes(b"")
+    database_path = tmp_path / "runtime.db"
+    database_path.symlink_to(victim)
+    dbapi_connection = MagicMock()
+
+    with pytest.raises(RuntimeError, match="symlink"):
+        database_module._configure_sqlite_connection(
+            dbapi_connection,
+            MagicMock(),
+            database_path=database_path,
+        )
+
+    dbapi_connection.cursor.assert_not_called()
+    dbapi_connection.close.assert_called_once_with()

--- a/tests/server/test_push_config_store.py
+++ b/tests/server/test_push_config_store.py
@@ -51,10 +51,14 @@ async def test_push_config_store_runtime_does_not_dispose_shared_engine(
         a2a_database_url=database_url,
     )
     engine = build_database_engine(settings)
+    original_dispose = engine.dispose
     dispose_spy = AsyncMock()
     monkeypatch.setattr(type(engine), "dispose", dispose_spy)
 
-    runtime = build_push_config_store_runtime(settings, engine=engine)
-    await runtime.shutdown()
+    try:
+        runtime = build_push_config_store_runtime(settings, engine=engine)
+        await runtime.shutdown()
 
-    dispose_spy.assert_not_awaited()
+        dispose_spy.assert_not_awaited()
+    finally:
+        await original_dispose()

--- a/tests/server/test_task_store.py
+++ b/tests/server/test_task_store.py
@@ -133,13 +133,17 @@ async def test_task_store_runtime_does_not_dispose_shared_engine(
         a2a_database_url=database_url,
     )
     engine = build_database_engine(settings)
+    original_dispose = engine.dispose
     dispose_spy = AsyncMock()
     monkeypatch.setattr(type(engine), "dispose", dispose_spy)
 
-    runtime = build_task_store_runtime(settings, engine=engine)
-    await runtime.shutdown()
+    try:
+        runtime = build_task_store_runtime(settings, engine=engine)
+        await runtime.shutdown()
 
-    dispose_spy.assert_not_awaited()
+        dispose_spy.assert_not_awaited()
+    finally:
+        await original_dispose()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 背景

审查确认本仓库存在与 [opencode-a2a #516](https://github.com/Intelligent-Internet/opencode-a2a/issues/516) 同源的连接泄漏：`src/codex_a2a/server/database.py` 的 SQLite 加固检查在 SQLAlchemy `connect` listener 中执行，而该事件在 aiosqlite 物理连接与 worker thread **已创建之后**才触发；若运行期间数据库文件被换成 symlink（或属主 / WAL sidecar 异常），加固检查抛错后 SQLAlchemy 不会关闭这个尚未接管的 DBAPI 连接，导致连接泄漏。GC 回收时 worker thread 尝试向已关闭的 event loop 投递结果，表现为 Python 3.14 下偶发的 `PytestUnhandledThreadExceptionWarning` / `ResourceWarning`。

Closes #356

## 变更

- 加固预检前置到 SQLAlchemy `do_connect` 事件：物理连接创建前拒绝 symlink / 属主 / sidecar 异常，失败时**不创建任何 aiosqlite 资源**；
- `connect` listener 保留连接后复检（纵深防御：文件可能在预检与物理连接之间被替换）；复检或 PRAGMA 配置失败时显式关闭 DBAPI 连接并保留原始异常（`suppress` 吸收关闭自身异常）；
- 三个共享 engine ownership 测试加固：monkeypatch 前保存真实 `dispose`，在 `finally` 中调用完成清理；
- 回归测试：
  - 运行期文件换 symlink 的复检失败**不创建第二个 aiosqlite 连接**（连接计数断言）；
  - PRAGMA 失败路径显式关闭连接且不覆盖原始异常（含 close 自身抛错场景）；
  - 加固失败路径（symlink）在创建游标前拒绝并关闭连接；
- pytest 配置：未处理线程 / 析构异常升级为 error；`ResourceWarning`（aiosqlite 未关闭连接）强制展示但不升级为 error（避免中断 aiosqlite 析构器 worker `stop()`）；
- coverage 配置：声明 `concurrency = ["greenlet"]`，修复 CPython 3.13 下 coverage.py 7.15.4（最新版）在 SQLAlchemy greenlet 上下文丢失行事件、导致 diff-cover 低估改动行覆盖率（88% < 90% 门槛）而使 CI Validation Baseline 失败的问题。

## 与上游的一致性

本实现与上游 [opencode-a2a PR #517](https://github.com/Intelligent-Internet/opencode-a2a/pull/517)（`fix: prevent SQLite connection leaks during setup`，已于 2026-08-24 合并，commit `f9647d1`）逐行对齐：

- `do_connect` 预检 + `connect` 后复检 + `suppress` 兜底关闭，函数命名（`_harden_sqlite_before_connect`）与事件注册方式一致；
- 回归测试（连接计数断言、PRAGMA / 加固失败关闭路径）与 pytest warning 策略一致；
- 差异仅为 codex-a2a 既有结构（`build_database_engine` 支持非 sqlite URL 与 `pool_pre_ping` 分支）及更详细的注释 / docstring（明确 `do_connect` 适配器按参数名绑定的必要性）。

## 验证

- 修复前复现（Python 3.14.6 / aiosqlite 0.22.1 / SQLAlchemy 2.0.52）：`tests/server/test_database.py` 在 warning 提升下触发 `ResourceWarning: aiosqlite.Connection was deleted before being closed` + `PytestUnraisableExceptionWarning`；独立连接追踪确认抛错后连接 `closed=False worker_alive=True`。
- 修复后：泄漏警告消失；`test_database.py` 及相关定向测试通过。
- 全量测试（CPython 3.13 与 3.14）：**729 passed**，覆盖率 86.35%（门槛 84%），diff-cover **100%**（门槛 90%）。
- `bash ./scripts/validate_baseline.sh`：通过（pre-commit、mypy、check_dead_code、diff-cover、pip-audit、构建与 wheel smoke test）。

## 风险

- 正常 SQLite 连接路径仅增加一次物理连接前的文件安全预检；PRAGMA 与连接成功语义不变。
- 显式关闭仅在连接初始化异常路径触发。
- 未添加任何 warning ignore，未修改用户可见配置或协议；coverage 的 `concurrency=greenlet` 仅影响测试工具链（覆盖率统计），不影响运行时代码。

## 关联

- Closes #356
- 参考上游：[Intelligent-Internet/opencode-a2a#516](https://github.com/Intelligent-Internet/opencode-a2a/issues/516)（问题）、[Intelligent-Internet/opencode-a2a#517](https://github.com/Intelligent-Internet/opencode-a2a/pull/517)（已合并的同方向实现）
